### PR TITLE
 Correcting Tiger source texts

### DIFF
--- a/de_gsd-ud-dev.conllu
+++ b/de_gsd-ud-dev.conllu
@@ -8384,47 +8384,48 @@
 33	.	.	PUNCT	$.	_	6	punct	_	_
 
 # sent_id = dev-s502
-# text = Spöri, SPD-Wirtschaftsminister in Teufels großer Koalition Baden-Württembergs, findet, daß die SPD aus den Folgen des radikalen wirtschaftlichen Wandels, der Globalisierung von Arbeitsmarkt und Produktion noch nicht die entscheidenden Folgerungen gezogen hat.
-1	Spöri	Spöri	PROPN	NE	Case=Nom|Gender=Masc|Number=Sing	14	nsubj	_	SpaceAfter=No
-2	,	,	PUNCT	$,	_	14	punct	_	_
-3	SPD	SPD	PROPN	NN	Case=Nom|Gender=Masc|Number=Sing	5	compound	_	SpaceAfter=No
-4	-	-	PUNCT	$(	_	3	punct	_	SpaceAfter=No
-5	Wirtschaftsminister	Wirtschaftsminister	NOUN	NN	Case=Nom|Gender=Masc|Number=Sing	1	appos	_	_
-6	in	in	ADP	APPR	_	9	case	_	_
-7	Teufels	Teufel	PROPN	NE	Case=Gen|Number=Sing	9	nmod	_	_
-8	großer	groß	ADJ	ADJA	Case=Dat|Gender=Fem|Number=Sing	9	amod	_	_
-9	Koalition	Koalition	NOUN	NN	Case=Dat|Gender=Fem|Number=Sing	3	nmod	_	_
-10	Baden	Baden	PROPN	NE	Case=Gen|Gender=Neut|Number=Sing	9	nmod	_	SpaceAfter=No
-11	-	-	PUNCT	$(	_	10	punct	_	SpaceAfter=No
-12	Württembergs	Württemberg	PROPN	NE	Case=Gen|Gender=Neut|Number=Sing	10	flat	_	SpaceAfter=No
-13	,	,	PUNCT	$,	_	14	punct	_	_
-14	findet	finden	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	0	root	_	SpaceAfter=No
-15	,	,	PUNCT	$,	_	14	punct	_	_
-16	daß	daß	CCONJ	KOUS	_	38	cc	_	_
-17	die	der	DET	ART	Case=Nom|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	18	det	_	_
-18	SPD	SPD	PROPN	NE	Case=Nom|Gender=Fem|Number=Sing	38	nsubj	_	_
-19	aus	aus	ADP	APPR	_	21	case	_	_
-20	den	der	DET	ART	Case=Dat|Definite=Def|Gender=Fem|Number=Plur|PronType=Art	21	det	_	_
-21	Folgen	Folge	NOUN	NN	Case=Dat|Gender=Fem|Number=Plur	38	obl	_	_
-22	des	der	DET	ART	Case=Gen|Definite=Def|Gender=Masc|Number=Sing|PronType=Art	25	det	_	_
-23	radikalen	radikal	ADJ	ADJA	Case=Gen|Gender=Masc|Number=Sing	25	amod	_	_
-24	wirtschaftlichen	wirtschaftlich	ADJ	ADJA	Case=Gen|Gender=Masc|Number=Sing	25	amod	_	_
-25	Wandels	Wandel	NOUN	NN	Case=Gen|Gender=Masc|Number=Sing	21	nmod	_	SpaceAfter=No
-26	,	,	PUNCT	$,	_	28	punct	_	_
-27	der	der	DET	ART	Case=Gen|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	28	det	_	_
-28	Globalisierung	Globalisierung	NOUN	NN	Case=Gen|Gender=Fem|Number=Sing	25	conj	_	_
-29	von	von	ADP	APPR	_	30	case	_	_
-30	Arbeitsmarkt	Arbeitsmarkt	NOUN	NN	Case=Dat|Gender=Masc|Number=Sing	28	nmod	_	_
-31	und	und	CCONJ	KON	_	32	cc	_	_
-32	Produktion	Produktion	NOUN	NN	Case=Dat|Gender=Fem|Number=Sing	30	conj	_	_
-33	noch	noch	ADV	ADV	_	34	advmod	_	_
-34	nicht	nicht	PART	PTKNEG	Polarity=Neg	38	advmod	_	_
-35	die	der	DET	ART	Case=Acc|Definite=Def|Gender=Fem|Number=Plur|PronType=Art	37	det	_	_
-36	entscheidenden	entscheidend	ADJ	ADJA	Case=Acc|Gender=Fem|Number=Plur	37	amod	_	_
-37	Folgerungen	Folgerung	NOUN	NN	Case=Acc|Gender=Fem|Number=Plur	38	obj	_	_
-38	gezogen	ziehen	VERB	VVPP	VerbForm=Part	14	ccomp	_	_
-39	hat	haben	AUX	VAFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	38	aux	_	SpaceAfter=No
-40	.	.	PUNCT	$.	_	14	punct	_	_
+# text = Dieter Spöri, SPD-Wirtschaftsminister in Teufels großer Koalition Baden-Württembergs, findet, daß die SPD aus den Folgen des radikalen wirtschaftlichen Wandels, der Globalisierung von Arbeitsmarkt und Produktion noch nicht die entscheidenden Folgerungen gezogen hat.
+1	Dieter	Dieter	PROPN	NE	Case=Nom|Gender=Masc|Number=Sing	2	dep	_	FixTigerDep=Yes
+2	Spöri	Spöri	PROPN	NE	Case=Nom|Gender=Masc|Number=Sing	15	nsubj	_	SpaceAfter=No
+3	,	,	PUNCT	$,	_	15	punct	_	_
+4	SPD	SPD	PROPN	NN	Case=Nom|Gender=Masc|Number=Sing	6	compound	_	SpaceAfter=No
+5	-	-	PUNCT	$(	_	4	punct	_	SpaceAfter=No
+6	Wirtschaftsminister	Wirtschaftsminister	NOUN	NN	Case=Nom|Gender=Masc|Number=Sing	2	appos	_	_
+7	in	in	ADP	APPR	_	10	case	_	_
+8	Teufels	Teufel	PROPN	NE	Case=Gen|Number=Sing	10	nmod	_	_
+9	großer	groß	ADJ	ADJA	Case=Dat|Gender=Fem|Number=Sing	10	amod	_	_
+10	Koalition	Koalition	NOUN	NN	Case=Dat|Gender=Fem|Number=Sing	4	nmod	_	_
+11	Baden	Baden	PROPN	NE	Case=Gen|Gender=Neut|Number=Sing	10	nmod	_	SpaceAfter=No
+12	-	-	PUNCT	$(	_	11	punct	_	SpaceAfter=No
+13	Württembergs	Württemberg	PROPN	NE	Case=Gen|Gender=Neut|Number=Sing	11	flat	_	SpaceAfter=No
+14	,	,	PUNCT	$,	_	15	punct	_	_
+15	findet	finden	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	0	root	_	SpaceAfter=No
+16	,	,	PUNCT	$,	_	15	punct	_	_
+17	daß	daß	CCONJ	KOUS	_	39	cc	_	_
+18	die	der	DET	ART	Case=Nom|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	19	det	_	_
+19	SPD	SPD	PROPN	NE	Case=Nom|Gender=Fem|Number=Sing	39	nsubj	_	_
+20	aus	aus	ADP	APPR	_	22	case	_	_
+21	den	der	DET	ART	Case=Dat|Definite=Def|Gender=Fem|Number=Plur|PronType=Art	22	det	_	_
+22	Folgen	Folge	NOUN	NN	Case=Dat|Gender=Fem|Number=Plur	39	obl	_	_
+23	des	der	DET	ART	Case=Gen|Definite=Def|Gender=Masc|Number=Sing|PronType=Art	26	det	_	_
+24	radikalen	radikal	ADJ	ADJA	Case=Gen|Gender=Masc|Number=Sing	26	amod	_	_
+25	wirtschaftlichen	wirtschaftlich	ADJ	ADJA	Case=Gen|Gender=Masc|Number=Sing	26	amod	_	_
+26	Wandels	Wandel	NOUN	NN	Case=Gen|Gender=Masc|Number=Sing	22	nmod	_	SpaceAfter=No
+27	,	,	PUNCT	$,	_	29	punct	_	_
+28	der	der	DET	ART	Case=Gen|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	29	det	_	_
+29	Globalisierung	Globalisierung	NOUN	NN	Case=Gen|Gender=Fem|Number=Sing	26	conj	_	_
+30	von	von	ADP	APPR	_	31	case	_	_
+31	Arbeitsmarkt	Arbeitsmarkt	NOUN	NN	Case=Dat|Gender=Masc|Number=Sing	29	nmod	_	_
+32	und	und	CCONJ	KON	_	33	cc	_	_
+33	Produktion	Produktion	NOUN	NN	Case=Dat|Gender=Fem|Number=Sing	31	conj	_	_
+34	noch	noch	ADV	ADV	_	35	advmod	_	_
+35	nicht	nicht	PART	PTKNEG	Polarity=Neg	39	advmod	_	_
+36	die	der	DET	ART	Case=Acc|Definite=Def|Gender=Fem|Number=Plur|PronType=Art	38	det	_	_
+37	entscheidenden	entscheidend	ADJ	ADJA	Case=Acc|Gender=Fem|Number=Plur	38	amod	_	_
+38	Folgerungen	Folgerung	NOUN	NN	Case=Acc|Gender=Fem|Number=Plur	39	obj	_	_
+39	gezogen	ziehen	VERB	VVPP	VerbForm=Part	15	ccomp	_	_
+40	hat	haben	AUX	VAFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	39	aux	_	SpaceAfter=No
+41	.	.	PUNCT	$.	_	15	punct	_	_
 
 # sent_id = dev-s503
 # text = Die Großbauern streichen viel ein, die kleinen bekommen wenig.
@@ -8460,84 +8461,87 @@
 16	.	.	PUNCT	$.	_	2	punct	_	_
 
 # sent_id = dev-s505
-# text = Weber sucht noch Helfer für die kommenden Stunden, doch die versammelten Zugpflegeleiterinnen müssen eine nach der anderen passen.
-1	Weber	Weber	PROPN	NE	Case=Nom|Gender=Fem|Number=Sing	2	nsubj	_	_
-2	sucht	suchen	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	0	root	_	_
-3	noch	noch	ADV	ADV	_	2	advmod	_	_
-4	Helfer	Helfer	NOUN	NN	Case=Acc|Gender=Masc	2	obj	_	_
-5	für	für	ADP	APPR	_	8	case	_	_
-6	die	der	DET	ART	Case=Acc|Definite=Def|Gender=Fem|Number=Plur|PronType=Art	8	det	_	_
-7	kommenden	kommend	ADJ	ADJA	Case=Acc|Gender=Fem|Number=Plur	8	amod	_	_
-8	Stunden	Stunde	NOUN	NN	Case=Acc|Gender=Fem|Number=Plur	2	obl	_	SpaceAfter=No
-9	,	,	PUNCT	$,	_	2	punct	_	_
-10	doch	doch	SCONJ	KON	_	19	mark	_	_
-11	die	der	DET	ART	Case=Nom|Definite=Def|Gender=Fem|Number=Plur|PronType=Art	13	det	_	_
-12	versammelten	versammelt	ADJ	ADJA	Case=Nom|Gender=Fem|Number=Plur	13	amod	_	_
-13	Zugpflegeleiterinnen	Zugpflegeleiterin	NOUN	NN	Case=Nom|Gender=Fem|Number=Plur	19	nsubj	_	_
-14	müssen	müssen	AUX	VMFIN	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	19	aux	_	_
-15	eine	ein	PRON	PIS	Case=Nom|Definite=Ind|Gender=Fem|Number=Sing|PronType=Ind	13	nmod	_	_
-16	nach	nach	ADP	APPR	_	18	case	_	_
-17	der	der	DET	ART	Case=Dat|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	18	det	_	_
-18	anderen	ander	PRON	PIS	Case=Dat|Definite=Ind|Gender=Fem|Number=Sing|PronType=Ind	15	nmod	_	_
-19	passen	passen	VERB	VVINF	VerbForm=Inf	2	advcl	_	SpaceAfter=No
-20	.	.	PUNCT	$.	_	2	punct	_	_
+# text = Beate Weber sucht noch Helfer für die kommenden Stunden, doch die versammelten Zugpflegeleiterinnen müssen eine nach der anderen passen.
+1	Beate	Beate	PROPN	NE	Case=Nom|Gender=Fem|Number=Sing	2	dep	_	FixTigerDep=Yes
+2	Weber	Weber	PROPN	NE	Case=Nom|Gender=Fem|Number=Sing	3	nsubj	_	_
+3	sucht	suchen	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	0	root	_	_
+4	noch	noch	ADV	ADV	_	3	advmod	_	_
+5	Helfer	Helfer	NOUN	NN	Case=Acc|Gender=Masc	3	obj	_	_
+6	für	für	ADP	APPR	_	9	case	_	_
+7	die	der	DET	ART	Case=Acc|Definite=Def|Gender=Fem|Number=Plur|PronType=Art	9	det	_	_
+8	kommenden	kommend	ADJ	ADJA	Case=Acc|Gender=Fem|Number=Plur	9	amod	_	_
+9	Stunden	Stunde	NOUN	NN	Case=Acc|Gender=Fem|Number=Plur	3	obl	_	SpaceAfter=No
+10	,	,	PUNCT	$,	_	3	punct	_	_
+11	doch	doch	SCONJ	KON	_	20	mark	_	_
+12	die	der	DET	ART	Case=Nom|Definite=Def|Gender=Fem|Number=Plur|PronType=Art	14	det	_	_
+13	versammelten	versammelt	ADJ	ADJA	Case=Nom|Gender=Fem|Number=Plur	14	amod	_	_
+14	Zugpflegeleiterinnen	Zugpflegeleiterin	NOUN	NN	Case=Nom|Gender=Fem|Number=Plur	20	nsubj	_	_
+15	müssen	müssen	AUX	VMFIN	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	20	aux	_	_
+16	eine	ein	PRON	PIS	Case=Nom|Definite=Ind|Gender=Fem|Number=Sing|PronType=Ind	14	nmod	_	_
+17	nach	nach	ADP	APPR	_	19	case	_	_
+18	der	der	DET	ART	Case=Dat|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	19	det	_	_
+19	anderen	ander	PRON	PIS	Case=Dat|Definite=Ind|Gender=Fem|Number=Sing|PronType=Ind	16	nmod	_	_
+20	passen	passen	VERB	VVINF	VerbForm=Inf	3	advcl	_	SpaceAfter=No
+21	.	.	PUNCT	$.	_	3	punct	_	_
 
 # sent_id = dev-s506
-# text = Tritium ist radioaktiv und lagert sich leicht im menschlichen Körper ein.
-1	Tritium	Tritium	PROPN	NN	Case=Nom|Gender=Neut|Number=Sing	3	nsubj	_	_
-2	ist	sein	AUX	VAFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	3	cop	_	_
-3	radioaktiv	radioaktiv	ADJ	ADJD	_	0	root	_	_
-4	und	und	CCONJ	KON	_	5	cc	_	_
-5	lagert	lagern	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	3	conj	_	_
-6	sich	er|es|sie	PRON	PRF	Case=Acc|Number=Sing|Person=3|PronType=Prs|Reflex=Yes	5	obj	_	_
-7	leicht	leicht	ADV	ADJD	_	5	advmod	_	_
-8-9	im	_	_	_	_	_	_	_	_
-8	in	in	ADP	APPR	_	11	case	_	_
-9	dem	der	DET	ART	Case=Dat|Definite=Def|Gender=Masc|Number=Sing|PronType=Art	11	det	_	_
-10	menschlichen	menschlich	ADJ	ADJA	Case=Dat|Gender=Masc|Number=Sing	11	amod	_	_
-11	Körper	Körper	NOUN	NN	Case=Dat|Gender=Masc|Number=Sing	5	obl	_	_
-12	ein	ein	ADV	PTKVZ	_	5	compound:prt	_	SpaceAfter=No
-13	.	.	PUNCT	$.	_	3	punct	_	_
+# text = Das Tritium ist radioaktiv und lagert sich leicht im menschlichen Körper ein.
+1	Das	der	DET	ART	Case=Nom|Definite=Def|Gender=Neut|Number=Sing|PronType=Art	2	dep	_	FixTigerDep=Yes
+2	Tritium	Tritium	PROPN	NN	Case=Nom|Gender=Neut|Number=Sing	4	nsubj	_	_
+3	ist	sein	AUX	VAFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	4	cop	_	_
+4	radioaktiv	radioaktiv	ADJ	ADJD	_	0	root	_	_
+5	und	und	CCONJ	KON	_	6	cc	_	_
+6	lagert	lagern	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	4	conj	_	_
+7	sich	er|es|sie	PRON	PRF	Case=Acc|Number=Sing|Person=3|PronType=Prs|Reflex=Yes	6	obj	_	_
+8	leicht	leicht	ADV	ADJD	_	6	advmod	_	_
+9-10	im	_	_	_	_	_	_	_	_
+9	in	in	ADP	APPR	_	12	case	_	_
+10	dem	der	DET	ART	Case=Dat|Definite=Def|Gender=Masc|Number=Sing|PronType=Art	12	det	_	_
+11	menschlichen	menschlich	ADJ	ADJA	Case=Dat|Gender=Masc|Number=Sing	12	amod	_	_
+12	Körper	Körper	NOUN	NN	Case=Dat|Gender=Masc|Number=Sing	6	obl	_	_
+13	ein	ein	ADV	PTKVZ	_	6	compound:prt	_	SpaceAfter=No
+14	.	.	PUNCT	$.	_	4	punct	_	_
 
 # sent_id = dev-s507
-# text = EU-Staaten, die USA und Polen hatten Nigerias Präsidenten Sani Abacha schon am Donnerstag aufgefordert, das Urteil gegen den Schriftsteller Ken Saro-Wiwa und acht weitere Politiker rückgängig zu machen.
-1	EU	EU	PROPN	NN	Case=Nom|Gender=Masc|Number=Plur	3	compound	_	SpaceAfter=No
-2	-	-	PUNCT	$(	_	1	punct	_	SpaceAfter=No
-3	Staaten	Staat	NOUN	NN	Case=Nom|Gender=Masc|Number=Plur	18	nsubj	_	SpaceAfter=No
-4	,	,	PUNCT	$,	_	6	punct	_	_
-5	die	der	DET	ART	Case=Nom|Definite=Def|Number=Plur|PronType=Art	6	det	_	_
-6	USA	USA	PROPN	NE	Case=Nom|Number=Plur	1	conj	_	_
-7	und	und	CCONJ	KON	_	8	cc	_	_
-8	Polen	Polen	PROPN	NE	Case=Nom|Gender=Neut|Number=Sing	1	conj	_	_
-9	hatten	haben	AUX	VAFIN	Mood=Ind|Number=Plur|Person=3|Tense=Past|VerbForm=Fin	18	aux	_	_
-10	Nigerias	Nigeria	PROPN	NE	Case=Gen|Gender=Neut|Number=Sing	11	nmod	_	_
-11	Präsidenten	Präsident	NOUN	NN	Case=Nom|Gender=Masc|Number=Sing	18	obj	_	_
-12	Sani	Sani	PROPN	NE	Case=Nom|Gender=Masc|Number=Sing	11	appos	_	_
-13	Abacha	Abacha	PROPN	NE	Case=Acc|Gender=Masc|Number=Sing	12	flat	_	_
-14	schon	schon	ADV	ADV	_	17	advmod	_	_
-15-16	am	_	_	_	_	_	_	_	_
-15	an	an	ADP	APPR	_	17	case	_	_
-16	dem	der	DET	ART	Case=Dat|Definite=Def|Gender=Masc|Number=Sing|PronType=Art	17	det	_	_
-17	Donnerstag	Donnerstag	PROPN	NN	Case=Dat|Gender=Masc|Number=Sing	18	obl	_	_
-18	aufgefordert	auffordern	VERB	VVPP	VerbForm=Part	0	root	_	SpaceAfter=No
-19	,	,	PUNCT	$,	_	18	punct	_	_
-20	das	der	DET	ART	Case=Acc|Definite=Def|Gender=Neut|Number=Sing|PronType=Art	21	det	_	_
-21	Urteil	Urteil	NOUN	NN	Case=Acc|Gender=Neut|Number=Sing	35	obj	_	_
-22	gegen	gegen	ADP	APPR	_	24	case	_	_
-23	den	der	DET	ART	Case=Acc|Definite=Def|Gender=Masc|Number=Sing|PronType=Art	24	det	_	_
-24	Schriftsteller	Schriftsteller	NOUN	NN	Case=Acc|Gender=Masc|Number=Sing	35	obl	_	_
-25	Ken	Ken	PROPN	NE	Case=Nom|Gender=Masc|Number=Sing	24	appos	_	_
-26	Saro	Saro	PROPN	NE	Case=Nom|Gender=Masc|Number=Sing	25	flat	_	SpaceAfter=No
-27	-	-	PUNCT	$(	_	26	punct	_	SpaceAfter=No
-28	Wiwa	Wiwa	PROPN	NE	Case=Nom|Gender=Masc|Number=Sing	25	flat	_	_
-29	und	und	CCONJ	KON	_	32	cc	_	_
-30	acht	acht	NUM	CARD	NumType=Card	32	nummod	_	_
-31	weitere	weit	ADJ	ADJA	Case=Acc|Gender=Masc|Number=Plur	32	amod	_	_
-32	Politiker	Politiker	NOUN	NN	Case=Acc|Gender=Masc|Number=Plur	24	conj	_	_
-33	rückgängig	rückgängig	ADJ	ADJD	_	35	xcomp	_	_
-34	zu	zu	PART	PTKZU	_	35	mark	_	_
-35	machen	machen	VERB	VVINF	VerbForm=Inf	18	xcomp	_	SpaceAfter=No
-36	.	.	PUNCT	$.	_	18	punct	_	_
+# text = Die EU-Staaten, die USA und Polen hatten Nigerias Präsidenten Sani Abacha schon am Donnerstag aufgefordert, das Urteil gegen den Schriftsteller Ken Saro-Wiwa und acht weitere Politiker rückgängig zu machen.
+1	Die	der	DET	ART	Case=Nom|Definite=Def|Gender=Masc|Number=Plur|PronType=Art	2	dep	_	FixTigerDep=Yes
+2	EU	EU	PROPN	NN	Case=Nom|Gender=Masc|Number=Plur	4	compound	_	SpaceAfter=No
+3	-	-	PUNCT	$(	_	2	punct	_	SpaceAfter=No
+4	Staaten	Staat	NOUN	NN	Case=Nom|Gender=Masc|Number=Plur	19	nsubj	_	SpaceAfter=No
+5	,	,	PUNCT	$,	_	7	punct	_	_
+6	die	der	DET	ART	Case=Nom|Definite=Def|Number=Plur|PronType=Art	7	det	_	_
+7	USA	USA	PROPN	NE	Case=Nom|Number=Plur	2	conj	_	_
+8	und	und	CCONJ	KON	_	9	cc	_	_
+9	Polen	Polen	PROPN	NE	Case=Nom|Gender=Neut|Number=Sing	2	conj	_	_
+10	hatten	haben	AUX	VAFIN	Mood=Ind|Number=Plur|Person=3|Tense=Past|VerbForm=Fin	19	aux	_	_
+11	Nigerias	Nigeria	PROPN	NE	Case=Gen|Gender=Neut|Number=Sing	12	nmod	_	_
+12	Präsidenten	Präsident	NOUN	NN	Case=Nom|Gender=Masc|Number=Sing	19	obj	_	_
+13	Sani	Sani	PROPN	NE	Case=Nom|Gender=Masc|Number=Sing	12	appos	_	_
+14	Abacha	Abacha	PROPN	NE	Case=Acc|Gender=Masc|Number=Sing	13	flat	_	_
+15	schon	schon	ADV	ADV	_	18	advmod	_	_
+16-17	am	_	_	_	_	_	_	_	_
+16	an	an	ADP	APPR	_	18	case	_	_
+17	dem	der	DET	ART	Case=Dat|Definite=Def|Gender=Masc|Number=Sing|PronType=Art	18	det	_	_
+18	Donnerstag	Donnerstag	PROPN	NN	Case=Dat|Gender=Masc|Number=Sing	19	obl	_	_
+19	aufgefordert	auffordern	VERB	VVPP	VerbForm=Part	0	root	_	SpaceAfter=No
+20	,	,	PUNCT	$,	_	19	punct	_	_
+21	das	der	DET	ART	Case=Acc|Definite=Def|Gender=Neut|Number=Sing|PronType=Art	22	det	_	_
+22	Urteil	Urteil	NOUN	NN	Case=Acc|Gender=Neut|Number=Sing	36	obj	_	_
+23	gegen	gegen	ADP	APPR	_	25	case	_	_
+24	den	der	DET	ART	Case=Acc|Definite=Def|Gender=Masc|Number=Sing|PronType=Art	25	det	_	_
+25	Schriftsteller	Schriftsteller	NOUN	NN	Case=Acc|Gender=Masc|Number=Sing	36	obl	_	_
+26	Ken	Ken	PROPN	NE	Case=Nom|Gender=Masc|Number=Sing	25	appos	_	_
+27	Saro	Saro	PROPN	NE	Case=Nom|Gender=Masc|Number=Sing	26	flat	_	SpaceAfter=No
+28	-	-	PUNCT	$(	_	27	punct	_	SpaceAfter=No
+29	Wiwa	Wiwa	PROPN	NE	Case=Nom|Gender=Masc|Number=Sing	26	flat	_	_
+30	und	und	CCONJ	KON	_	33	cc	_	_
+31	acht	acht	NUM	CARD	NumType=Card	33	nummod	_	_
+32	weitere	weit	ADJ	ADJA	Case=Acc|Gender=Masc|Number=Plur	33	amod	_	_
+33	Politiker	Politiker	NOUN	NN	Case=Acc|Gender=Masc|Number=Plur	25	conj	_	_
+34	rückgängig	rückgängig	ADJ	ADJD	_	36	xcomp	_	_
+35	zu	zu	PART	PTKZU	_	36	mark	_	_
+36	machen	machen	VERB	VVINF	VerbForm=Inf	19	xcomp	_	SpaceAfter=No
+37	.	.	PUNCT	$.	_	19	punct	_	_
 
 # sent_id = dev-s508
 # text = Dank der Geldmarktfonds kam die Gruppe auf einen Mittelzufluß von per saldo 5,2 Milliarden.
@@ -8574,33 +8578,34 @@
 13	.	.	PUNCT	$.	_	5	punct	_	_
 
 # sent_id = dev-s510
-# text = Der Stabilitätspakt für Europa ist ein wichtiger zusätzlicher Impuls für die Glaubwürdigkeit und Stabilität der europäischen Währung auf den internationalen Finanzmärkten'', versicherte Waigel.
-1	Der	der	DET	ART	Case=Nom|Definite=Def|Gender=Masc|Number=Sing|PronType=Art	2	det	_	_
-2	Stabilitätspakt	Stabilitätspakt	NOUN	NN	Case=Nom|Gender=Masc|Number=Sing	9	nsubj	_	_
-3	für	für	ADP	APPR	_	4	case	_	_
-4	Europa	Europa	PROPN	NE	Case=Acc|Gender=Neut|Number=Sing	2	nmod	_	_
-5	ist	sein	AUX	VAFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	9	cop	_	_
-6	ein	ein	DET	ART	Case=Nom|Definite=Ind|Gender=Masc|Number=Sing|PronType=Art	9	det	_	_
-7	wichtiger	wichtig	ADJ	ADJA	Case=Nom|Gender=Masc|Number=Sing	9	amod	_	_
-8	zusätzlicher	zusätzlich	ADJ	ADJA	Case=Nom|Gender=Masc|Number=Sing	9	amod	_	_
-9	Impuls	Impuls	NOUN	NN	Case=Nom|Gender=Masc|Number=Sing	24	ccomp	_	_
-10	für	für	ADP	APPR	_	12	case	_	_
-11	die	der	DET	ART	Case=Acc|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	12	det	_	_
-12	Glaubwürdigkeit	Glaubwürdigkeit	NOUN	NN	Case=Acc|Gender=Fem|Number=Sing	9	nmod	_	_
-13	und	und	CCONJ	KON	_	14	cc	_	_
-14	Stabilität	Stabilität	NOUN	NN	Case=Acc|Gender=Fem|Number=Sing	12	conj	_	_
-15	der	der	DET	ART	Case=Gen|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	17	det	_	_
-16	europäischen	europäisch	ADJ	ADJA	Case=Gen|Gender=Fem|Number=Sing	17	amod	_	_
-17	Währung	Währung	NOUN	NN	Case=Gen|Gender=Fem|Number=Sing	12	nmod	_	_
-18	auf	auf	ADP	APPR	_	21	case	_	_
-19	den	der	DET	ART	Case=Dat|Definite=Def|Gender=Masc|Number=Plur|PronType=Art	21	det	_	_
-20	internationalen	international	ADJ	ADJA	Case=Dat|Gender=Masc|Number=Plur	21	amod	_	_
-21	Finanzmärkten	Finanzmarkt	NOUN	NN	Case=Dat|Gender=Masc|Number=Plur	12	nmod	_	SpaceAfter=No
-22	''	''	PUNCT	$(	_	24	punct	_	SpaceAfter=No
-23	,	,	PUNCT	$,	_	24	punct	_	_
-24	versicherte	versichern	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	0	root	_	_
-25	Waigel	Waigel	NOUN	NE	Case=Nom|Number=Sing	24	nsubj	_	SpaceAfter=No
-26	.	.	PUNCT	$.	_	24	punct	_	_
+# text = ``Der Stabilitätspakt für Europa ist ein wichtiger zusätzlicher Impuls für die Glaubwürdigkeit und Stabilität der europäischen Währung auf den internationalen Finanzmärkten'', versicherte Waigel.
+1	``	``	PUNCT	$(	_	2	punct	_	FixTigerDep=Yes|SpaceAfter=No
+2	Der	der	DET	ART	Case=Nom|Definite=Def|Gender=Masc|Number=Sing|PronType=Art	3	det	_	_
+3	Stabilitätspakt	Stabilitätspakt	NOUN	NN	Case=Nom|Gender=Masc|Number=Sing	10	nsubj	_	_
+4	für	für	ADP	APPR	_	5	case	_	_
+5	Europa	Europa	PROPN	NE	Case=Acc|Gender=Neut|Number=Sing	3	nmod	_	_
+6	ist	sein	AUX	VAFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	10	cop	_	_
+7	ein	ein	DET	ART	Case=Nom|Definite=Ind|Gender=Masc|Number=Sing|PronType=Art	10	det	_	_
+8	wichtiger	wichtig	ADJ	ADJA	Case=Nom|Gender=Masc|Number=Sing	10	amod	_	_
+9	zusätzlicher	zusätzlich	ADJ	ADJA	Case=Nom|Gender=Masc|Number=Sing	10	amod	_	_
+10	Impuls	Impuls	NOUN	NN	Case=Nom|Gender=Masc|Number=Sing	25	ccomp	_	_
+11	für	für	ADP	APPR	_	13	case	_	_
+12	die	der	DET	ART	Case=Acc|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	13	det	_	_
+13	Glaubwürdigkeit	Glaubwürdigkeit	NOUN	NN	Case=Acc|Gender=Fem|Number=Sing	10	nmod	_	_
+14	und	und	CCONJ	KON	_	15	cc	_	_
+15	Stabilität	Stabilität	NOUN	NN	Case=Acc|Gender=Fem|Number=Sing	13	conj	_	_
+16	der	der	DET	ART	Case=Gen|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	18	det	_	_
+17	europäischen	europäisch	ADJ	ADJA	Case=Gen|Gender=Fem|Number=Sing	18	amod	_	_
+18	Währung	Währung	NOUN	NN	Case=Gen|Gender=Fem|Number=Sing	13	nmod	_	_
+19	auf	auf	ADP	APPR	_	22	case	_	_
+20	den	der	DET	ART	Case=Dat|Definite=Def|Gender=Masc|Number=Plur|PronType=Art	22	det	_	_
+21	internationalen	international	ADJ	ADJA	Case=Dat|Gender=Masc|Number=Plur	22	amod	_	_
+22	Finanzmärkten	Finanzmarkt	NOUN	NN	Case=Dat|Gender=Masc|Number=Plur	13	nmod	_	SpaceAfter=No
+23	''	''	PUNCT	$(	_	25	punct	_	SpaceAfter=No
+24	,	,	PUNCT	$,	_	25	punct	_	_
+25	versicherte	versichern	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	0	root	_	_
+26	Waigel	Waigel	NOUN	NE	Case=Nom|Number=Sing	25	nsubj	_	SpaceAfter=No
+27	.	.	PUNCT	$.	_	25	punct	_	_
 
 # sent_id = dev-s511
 # text = Im Dezember soll das Europaparlament über die Verwirklichung der zum 1. Januar 1996 geplanten Zollunion der Türkei mit der EU entscheiden.
@@ -8645,25 +8650,26 @@
 9	.	.	PUNCT	$.	_	3	punct	_	_
 
 # sent_id = dev-s513
-# text = Ansicht des Ministers wird dadurch der ``innere Frieden in Deutschland gefährdet''.
-1	Ansicht	Ansicht	NOUN	NN	Case=Dat|Gender=Fem|Number=Sing	12	dep	_	_
-2	des	der	DET	ART	Case=Gen|Definite=Def|Gender=Masc|Number=Sing|PronType=Art	3	det	_	_
-3	Ministers	Minister	NOUN	NN	Case=Gen|Gender=Masc|Number=Sing	1	nmod	_	_
-4	wird	werden	AUX	VAFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin|Voice=Pass	12	aux:pass	_	_
-5	dadurch	dadurch	ADV	PAV	_	12	advmod	_	_
-6	der	der	DET	ART	Case=Nom|Definite=Def|Gender=Masc|Number=Sing|PronType=Art	9	det	_	_
-7	``	``	PUNCT	$(	_	9	punct	_	SpaceAfter=No
-8	innere	innen	ADJ	ADJA	Case=Nom|Gender=Masc|Number=Sing	9	amod	_	_
-9	Frieden	Frieden	NOUN	NN	Case=Nom|Gender=Masc|Number=Sing	12	nsubj:pass	_	_
-10	in	in	ADP	APPR	_	11	case	_	_
-11	Deutschland	Deutschland	PROPN	NE	Case=Dat|Gender=Neut|Number=Sing	9	nmod	_	_
-12	gefährdet	gefährden	VERB	VVPP	VerbForm=Part	0	root	_	SpaceAfter=No
-13	''	''	PUNCT	$(	_	9	punct	_	SpaceAfter=No
-14	.	.	PUNCT	$.	_	12	punct	_	_
+# text = Nach Ansicht des Ministers wird dadurch der ``innere Frieden in Deutschland gefährdet''.
+1	Nach	nach	ADP	APPR	_	2	dep	_	FixTigerDep=Yes
+2	Ansicht	Ansicht	NOUN	NN	Case=Dat|Gender=Fem|Number=Sing	13	dep	_	_
+3	des	der	DET	ART	Case=Gen|Definite=Def|Gender=Masc|Number=Sing|PronType=Art	4	det	_	_
+4	Ministers	Minister	NOUN	NN	Case=Gen|Gender=Masc|Number=Sing	2	nmod	_	_
+5	wird	werden	AUX	VAFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin|Voice=Pass	13	aux:pass	_	_
+6	dadurch	dadurch	ADV	PAV	_	13	advmod	_	_
+7	der	der	DET	ART	Case=Nom|Definite=Def|Gender=Masc|Number=Sing|PronType=Art	10	det	_	_
+8	``	``	PUNCT	$(	_	10	punct	_	SpaceAfter=No
+9	innere	innen	ADJ	ADJA	Case=Nom|Gender=Masc|Number=Sing	10	amod	_	_
+10	Frieden	Frieden	NOUN	NN	Case=Nom|Gender=Masc|Number=Sing	13	nsubj:pass	_	_
+11	in	in	ADP	APPR	_	12	case	_	_
+12	Deutschland	Deutschland	PROPN	NE	Case=Dat|Gender=Neut|Number=Sing	10	nmod	_	_
+13	gefährdet	gefährden	VERB	VVPP	VerbForm=Part	0	root	_	SpaceAfter=No
+14	''	''	PUNCT	$(	_	10	punct	_	SpaceAfter=No
+15	.	.	PUNCT	$.	_	13	punct	_	_
 
 # sent_id = dev-s514
 # text = Ghali besucht Auschwitz.
-1	Ghali	Ghali	PROPN	NE	Case=Nom|Number=Sing	2	nsubj	_	_
+1	Ghali	Butros-Ghali	PROPN	NE	Case=Nom|Number=Sing	2	nsubj	_	_
 2	besucht	besuchen	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	0	root	_	_
 3	Auschwitz	Auschwitz	PROPN	NE	Case=Acc|Gender=Neut|Number=Sing	2	obj	_	SpaceAfter=No
 4	.	.	PUNCT	$.	_	2	punct	_	_
@@ -8764,14 +8770,15 @@
 12	löschen	löschen	VERB	VVINF	VerbForm=Inf	0	root	_	_
 
 # sent_id = dev-s520
-# text = Gewalt provoziert und ergänzt die andere.
-1	Gewalt	Gewalt	NOUN	NN	Case=Nom|Gender=Fem|Number=Sing	2	nsubj	_	_
-2	provoziert	provozieren	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	0	root	_	_
-3	und	und	CCONJ	KON	_	4	cc	_	_
-4	ergänzt	ergänzen	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	2	conj	_	_
-5	die	der	DET	ART	Case=Acc|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	6	det	_	_
-6	andere	ander	PRON	PIS	Case=Acc|Definite=Ind|Gender=Fem|Number=Sing|PronType=Ind	2	obj	_	SpaceAfter=No
-7	.	.	PUNCT	$.	_	2	punct	_	_
+# text = Eine Gewalt provoziert und ergänzt die andere.
+1	Eine	ein	DET	ART	Case=Nom|Definite=Ind|Gender=Fem|Number=Sing|PronType=Art	2	dep	_	FixTigerDep=Yes
+2	Gewalt	Gewalt	NOUN	NN	Case=Nom|Gender=Fem|Number=Sing	3	nsubj	_	_
+3	provoziert	provozieren	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	0	root	_	_
+4	und	und	CCONJ	KON	_	5	cc	_	_
+5	ergänzt	ergänzen	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	3	conj	_	_
+6	die	der	DET	ART	Case=Acc|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	7	det	_	_
+7	andere	ander	PRON	PIS	Case=Acc|Definite=Ind|Gender=Fem|Number=Sing|PronType=Ind	3	obj	_	SpaceAfter=No
+8	.	.	PUNCT	$.	_	3	punct	_	_
 
 # sent_id = dev-s521
 # text = Der Braunschweiger Biologe beobachtete Deutsche am Steuer.
@@ -8805,14 +8812,15 @@
 15	.	.	PUNCT	$.	_	3	punct	_	_
 
 # sent_id = dev-s523
-# text = Aber wir lassen uns nicht unterkriegen.
-1	Aber	aber	CCONJ	KON	_	3	cc	_	_
-2	wir	wir	PRON	PPER	Case=Nom|Number=Plur|Person=1|PronType=Prs	3	nsubj	_	_
-3	lassen	lassen	VERB	VVFIN	Mood=Ind|Number=Plur|Person=1|Tense=Pres|VerbForm=Fin	0	root	_	_
-4	uns	wir	PRON	PRF	Case=Acc|Number=Plur|Person=1|PronType=Prs|Reflex=Yes	3	obj	_	_
-5	nicht	nicht	PART	PTKNEG	Polarity=Neg	3	advmod	_	_
-6	unterkriegen	unterkriegen	VERB	VVINF	VerbForm=Inf	3	xcomp	_	SpaceAfter=No
-7	.	.	PUNCT	$.	_	3	punct	_	_
+# text = ``Aber wir lassen uns nicht unterkriegen.
+1	``	``	PUNCT	$(	_	2	punct	_	FixTigerDep=Yes|SpaceAfter=No
+2	Aber	aber	CCONJ	KON	_	4	cc	_	_
+3	wir	wir	PRON	PPER	Case=Nom|Number=Plur|Person=1|PronType=Prs	4	nsubj	_	_
+4	lassen	lassen	VERB	VVFIN	Mood=Ind|Number=Plur|Person=1|Tense=Pres|VerbForm=Fin	0	root	_	_
+5	uns	wir	PRON	PRF	Case=Acc|Number=Plur|Person=1|PronType=Prs|Reflex=Yes	4	obj	_	_
+6	nicht	nicht	PART	PTKNEG	Polarity=Neg	4	advmod	_	_
+7	unterkriegen	unterkriegen	VERB	VVINF	VerbForm=Inf	4	xcomp	_	SpaceAfter=No
+8	.	.	PUNCT	$.	_	4	punct	_	_
 
 # sent_id = dev-s524
 # text = Die Chefs der Industrie -- und Unternehmerverbände akzeptieren den KCTU nicht.
@@ -8906,22 +8914,23 @@
 41	.	.	PUNCT	$.	_	17	punct	_	_
 
 # sent_id = dev-s528
-# text = Interessierte Länder und Organisationen werden gebeten, bei der Umsetzung dieses Abkommens zu helfen.
-1	Interessierte	interessiert	ADJ	ADJA	Case=Nom|Number=Plur	2	amod	_	_
-2	Länder	Land	NOUN	NN	Case=Nom|Gender=Neut|Number=Plur	6	nsubj:pass	_	_
-3	und	und	CCONJ	KON	_	4	cc	_	_
-4	Organisationen	Organisation	NOUN	NN	Case=Nom|Gender=Fem|Number=Plur	2	conj	_	_
-5	werden	werden	AUX	VAFIN	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin|Voice=Pass	6	aux:pass	_	_
-6	gebeten	bitten	VERB	VVPP	VerbForm=Part	0	root	_	SpaceAfter=No
-7	,	,	PUNCT	$,	_	6	punct	_	_
-8	bei	bei	ADP	APPR	_	10	case	_	_
-9	der	der	DET	ART	Case=Dat|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	10	det	_	_
-10	Umsetzung	Umsetzung	NOUN	NN	Case=Dat|Gender=Fem|Number=Sing	14	obl	_	_
-11	dieses	dies	PRON	PDAT	Case=Gen|Gender=Neut|Number=Sing|PronType=Dem	12	det	_	_
-12	Abkommens	Abkommen	NOUN	NN	Case=Gen|Gender=Neut|Number=Sing	10	nmod	_	_
-13	zu	zu	PART	PTKZU	_	14	mark	_	_
-14	helfen	helfen	VERB	VVINF	VerbForm=Inf	6	xcomp	_	SpaceAfter=No
-15	.	.	PUNCT	$.	_	6	punct	_	_
+# text = 10. Interessierte Länder und Organisationen werden gebeten, bei der Umsetzung dieses Abkommens zu helfen.
+1	10.	10.	ADV	ADV	_	2	dep	_	FixTigerDep=Yes
+2	Interessierte	interessiert	ADJ	ADJA	Case=Nom|Number=Plur	3	amod	_	_
+3	Länder	Land	NOUN	NN	Case=Nom|Gender=Neut|Number=Plur	7	nsubj:pass	_	_
+4	und	und	CCONJ	KON	_	5	cc	_	_
+5	Organisationen	Organisation	NOUN	NN	Case=Nom|Gender=Fem|Number=Plur	3	conj	_	_
+6	werden	werden	AUX	VAFIN	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin|Voice=Pass	7	aux:pass	_	_
+7	gebeten	bitten	VERB	VVPP	VerbForm=Part	0	root	_	SpaceAfter=No
+8	,	,	PUNCT	$,	_	7	punct	_	_
+9	bei	bei	ADP	APPR	_	11	case	_	_
+10	der	der	DET	ART	Case=Dat|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	11	det	_	_
+11	Umsetzung	Umsetzung	NOUN	NN	Case=Dat|Gender=Fem|Number=Sing	15	obl	_	_
+12	dieses	dies	PRON	PDAT	Case=Gen|Gender=Neut|Number=Sing|PronType=Dem	13	det	_	_
+13	Abkommens	Abkommen	NOUN	NN	Case=Gen|Gender=Neut|Number=Sing	11	nmod	_	_
+14	zu	zu	PART	PTKZU	_	15	mark	_	_
+15	helfen	helfen	VERB	VVINF	VerbForm=Inf	7	xcomp	_	SpaceAfter=No
+16	.	.	PUNCT	$.	_	7	punct	_	_
 
 # sent_id = dev-s529
 # text = Die Verkehrsplaner im islamischen ``Gottesstaat'' halten noch eine andere Überraschung bereit:
@@ -9108,31 +9117,32 @@
 30	.	.	PUNCT	$.	_	16	punct	_	_
 
 # sent_id = dev-s537
-# text = Der beste Zeitpunkt, die Energiebilanz eines Gebäudes zu verbessern, ist immer eine anstehende Sanierung'', sagt Olaf Hildebrandt von ebök.
-1	Der	der	DET	ART	Case=Nom|Definite=Def|Gender=Masc|Number=Sing|PronType=Art	3	det	_	_
-2	beste	gut	ADJ	ADJA	Case=Nom|Gender=Masc|Number=Sing	3	amod	_	_
-3	Zeitpunkt	Zeitpunkt	NOUN	NN	Case=Nom|Gender=Masc|Number=Sing	16	nsubj	_	SpaceAfter=No
-4	,	,	PUNCT	$,	_	19	punct	_	_
-5	die	der	DET	ART	Case=Acc|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	6	det	_	_
-6	Energiebilanz	Energiebilanz	NOUN	NN	Case=Acc|Gender=Fem|Number=Sing	10	obj	_	_
-7	eines	ein	DET	ART	Case=Gen|Definite=Ind|Gender=Neut|Number=Sing|PronType=Art	8	det	_	_
-8	Gebäudes	Gebäude	NOUN	NN	Case=Gen|Gender=Neut|Number=Sing	6	nmod	_	_
-9	zu	zu	PART	PTKZU	_	10	mark	_	_
-10	verbessern	verbessern	VERB	VVINF	VerbForm=Inf	3	advcl	_	SpaceAfter=No
-11	,	,	PUNCT	$,	_	19	punct	_	_
-12	ist	sein	AUX	VAFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	16	cop	_	_
-13	immer	immer	ADV	ADV	_	16	advmod	_	_
-14	eine	ein	DET	ART	Case=Nom|Definite=Ind|Gender=Fem|Number=Sing|PronType=Art	16	det	_	_
-15	anstehende	anstehend	ADJ	ADJA	Case=Nom|Gender=Fem|Number=Sing	16	amod	_	_
-16	Sanierung	Sanierung	NOUN	NN	Case=Nom|Gender=Fem|Number=Sing	19	ccomp	_	SpaceAfter=No
-17	''	''	PUNCT	$(	_	19	punct	_	SpaceAfter=No
-18	,	,	PUNCT	$,	_	19	punct	_	_
-19	sagt	sagen	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	0	root	_	_
-20	Olaf	Olaf	PROPN	NE	Case=Nom|Gender=Masc|Number=Sing	19	nsubj	_	_
-21	Hildebrandt	Hildebrandt	PROPN	NE	Case=Nom|Gender=Masc|Number=Sing	20	flat	_	_
-22	von	von	ADP	APPR	_	23	case	_	_
-23	ebök	ebök	PROPN	NE	Case=Dat|Number=Sing	20	nmod	_	SpaceAfter=No
-24	.	.	PUNCT	$.	_	19	punct	_	_
+# text = ``Der beste Zeitpunkt, die Energiebilanz eines Gebäudes zu verbessern, ist immer eine anstehende Sanierung'', sagt Olaf Hildebrandt von ebök.
+1	``	``	PUNCT	$(	_	2	punct	_	FixTigerDep=Yes|SpaceAfter=No
+2	Der	der	DET	ART	Case=Nom|Definite=Def|Gender=Masc|Number=Sing|PronType=Art	4	det	_	_
+3	beste	gut	ADJ	ADJA	Case=Nom|Gender=Masc|Number=Sing	4	amod	_	_
+4	Zeitpunkt	Zeitpunkt	NOUN	NN	Case=Nom|Gender=Masc|Number=Sing	17	nsubj	_	SpaceAfter=No
+5	,	,	PUNCT	$,	_	20	punct	_	_
+6	die	der	DET	ART	Case=Acc|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	7	det	_	_
+7	Energiebilanz	Energiebilanz	NOUN	NN	Case=Acc|Gender=Fem|Number=Sing	11	obj	_	_
+8	eines	ein	DET	ART	Case=Gen|Definite=Ind|Gender=Neut|Number=Sing|PronType=Art	9	det	_	_
+9	Gebäudes	Gebäude	NOUN	NN	Case=Gen|Gender=Neut|Number=Sing	7	nmod	_	_
+10	zu	zu	PART	PTKZU	_	11	mark	_	_
+11	verbessern	verbessern	VERB	VVINF	VerbForm=Inf	4	advcl	_	SpaceAfter=No
+12	,	,	PUNCT	$,	_	20	punct	_	_
+13	ist	sein	AUX	VAFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	17	cop	_	_
+14	immer	immer	ADV	ADV	_	17	advmod	_	_
+15	eine	ein	DET	ART	Case=Nom|Definite=Ind|Gender=Fem|Number=Sing|PronType=Art	17	det	_	_
+16	anstehende	anstehend	ADJ	ADJA	Case=Nom|Gender=Fem|Number=Sing	17	amod	_	_
+17	Sanierung	Sanierung	NOUN	NN	Case=Nom|Gender=Fem|Number=Sing	20	ccomp	_	SpaceAfter=No
+18	''	''	PUNCT	$(	_	20	punct	_	SpaceAfter=No
+19	,	,	PUNCT	$,	_	20	punct	_	_
+20	sagt	sagen	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	0	root	_	_
+21	Olaf	Olaf	PROPN	NE	Case=Nom|Gender=Masc|Number=Sing	20	nsubj	_	_
+22	Hildebrandt	Hildebrandt	PROPN	NE	Case=Nom|Gender=Masc|Number=Sing	21	flat	_	_
+23	von	von	ADP	APPR	_	24	case	_	_
+24	ebök	ebök	PROPN	NE	Case=Dat|Number=Sing	21	nmod	_	SpaceAfter=No
+25	.	.	PUNCT	$.	_	20	punct	_	_
 
 # sent_id = dev-s538
 # text = Die Festlegung einer Mindestquote für Frauen entsprechend dem Mitgliederanteil widerspricht dem Demokratieprinzip.
@@ -9170,39 +9180,40 @@
 16	.	.	PUNCT	$.	_	15	punct	_	_
 
 # sent_id = dev-s540
-# text = Die Bundesrepublik muß sich entscheiden, ob sie einen Demokratisierungsprozeß aktiv gestalten will oder ein Prinzip der Ungleichheit tolerien will, mit all den gesellschaftlichen Konsequenzen, die daraus resultieren.''
-1	Die	der	DET	ART	Case=Nom|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	2	det	_	_
-2	Bundesrepublik	Bundesrepublik	NOUN	NN	Case=Nom|Gender=Fem|Number=Sing	5	nsubj	_	_
-3	muß	müssen	AUX	VMFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	5	aux	_	_
-4	sich	er|es|sie	PRON	PRF	Case=Acc|Number=Sing|Person=3|PronType=Prs|Reflex=Yes	5	obj	_	_
-5	entscheiden	entscheiden	VERB	VVINF	VerbForm=Inf	0	root	_	SpaceAfter=No
-6	,	,	PUNCT	$,	_	5	punct	_	_
-7	ob	ob	SCONJ	KOUS	_	12	mark	_	_
-8	sie	sie	PRON	PPER	Case=Nom|Gender=Fem|Number=Sing|Person=3|PronType=Prs	12	nsubj	_	_
-9	einen	ein	DET	ART	Case=Acc|Definite=Ind|Gender=Masc|Number=Sing|PronType=Art	10	det	_	_
-10	Demokratisierungsprozeß	Demokratisierungsprozeß	NOUN	NN	Case=Acc|Gender=Masc|Number=Sing	12	obj	_	_
-11	aktiv	aktiv	ADV	ADJD	_	12	advmod	_	_
-12	gestalten	gestalten	VERB	VVINF	VerbForm=Inf	5	advcl	_	_
-13	will	wollen	AUX	VMFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	12	aux	_	_
-14	oder	oder	CCONJ	KON	_	19	cc	_	_
-15	ein	ein	DET	ART	Case=Acc|Definite=Ind|Gender=Neut|Number=Sing|PronType=Art	16	det	_	_
-16	Prinzip	Prinzip	NOUN	NN	Case=Acc|Gender=Neut|Number=Sing	19	nsubj	_	_
-17	der	der	DET	ART	Case=Gen|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	18	det	_	_
-18	Ungleichheit	Ungleichheit	NOUN	NN	Case=Gen|Gender=Fem|Number=Sing	16	nmod	_	_
-19	tolerien	landespolitisch	VERB	VVINF	VerbForm=Inf	12	conj	_	_
-20	will	wollen	AUX	VMFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	19	aux	_	SpaceAfter=No
-21	,	,	PUNCT	$,	_	5	punct	_	_
-22	mit	mit	ADP	APPR	_	26	case	_	_
-23	all	all	PRON	PIAT	Definite=Ind|PronType=Ind	26	det	_	_
-24	den	der	DET	ART	Case=Dat|Definite=Def|Gender=Fem|Number=Plur|PronType=Art	26	det	_	_
-25	gesellschaftlichen	gesellschaftlich	ADJ	ADJA	Case=Dat|Gender=Fem|Number=Plur	26	amod	_	_
-26	Konsequenzen	Konsequenz	NOUN	NN	Case=Dat|Gender=Fem|Number=Plur	19	obl	_	SpaceAfter=No
-27	,	,	PUNCT	$,	_	5	punct	_	_
-28	die	der	PRON	PRELS	Case=Nom|Gender=Fem|Number=Plur|PronType=Rel	30	nsubj	_	_
-29	daraus	daraus	ADV	PAV	_	30	advmod	_	_
-30	resultieren	resultieren	VERB	VVFIN	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	26	acl	_	SpaceAfter=No
-31	.	.	PUNCT	$.	_	5	punct	_	SpaceAfter=No
-32	''	''	PUNCT	$(	_	5	punct	_	_
+# text = ``Die Bundesrepublik muß sich entscheiden, ob sie einen Demokratisierungsprozeß aktiv gestalten will oder ein Prinzip der Ungleichheit tolerien will, mit all den gesellschaftlichen Konsequenzen, die daraus resultieren.''
+1	``	``	PUNCT	$(	_	2	punct	_	FixTigerDep=Yes|SpaceAfter=No
+2	Die	der	DET	ART	Case=Nom|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	3	det	_	_
+3	Bundesrepublik	Bundesrepublik	NOUN	NN	Case=Nom|Gender=Fem|Number=Sing	6	nsubj	_	_
+4	muß	müssen	AUX	VMFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	6	aux	_	_
+5	sich	er|es|sie	PRON	PRF	Case=Acc|Number=Sing|Person=3|PronType=Prs|Reflex=Yes	6	obj	_	_
+6	entscheiden	entscheiden	VERB	VVINF	VerbForm=Inf	0	root	_	SpaceAfter=No
+7	,	,	PUNCT	$,	_	6	punct	_	_
+8	ob	ob	SCONJ	KOUS	_	13	mark	_	_
+9	sie	sie	PRON	PPER	Case=Nom|Gender=Fem|Number=Sing|Person=3|PronType=Prs	13	nsubj	_	_
+10	einen	ein	DET	ART	Case=Acc|Definite=Ind|Gender=Masc|Number=Sing|PronType=Art	11	det	_	_
+11	Demokratisierungsprozeß	Demokratisierungsprozeß	NOUN	NN	Case=Acc|Gender=Masc|Number=Sing	13	obj	_	_
+12	aktiv	aktiv	ADV	ADJD	_	13	advmod	_	_
+13	gestalten	gestalten	VERB	VVINF	VerbForm=Inf	6	advcl	_	_
+14	will	wollen	AUX	VMFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	13	aux	_	_
+15	oder	oder	CCONJ	KON	_	20	cc	_	_
+16	ein	ein	DET	ART	Case=Acc|Definite=Ind|Gender=Neut|Number=Sing|PronType=Art	17	det	_	_
+17	Prinzip	Prinzip	NOUN	NN	Case=Acc|Gender=Neut|Number=Sing	20	nsubj	_	_
+18	der	der	DET	ART	Case=Gen|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	19	det	_	_
+19	Ungleichheit	Ungleichheit	NOUN	NN	Case=Gen|Gender=Fem|Number=Sing	17	nmod	_	_
+20	tolerien	landespolitisch	VERB	VVINF	VerbForm=Inf	13	conj	_	_
+21	will	wollen	AUX	VMFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	20	aux	_	SpaceAfter=No
+22	,	,	PUNCT	$,	_	6	punct	_	_
+23	mit	mit	ADP	APPR	_	27	case	_	_
+24	all	all	PRON	PIAT	Definite=Ind|PronType=Ind	27	det	_	_
+25	den	der	DET	ART	Case=Dat|Definite=Def|Gender=Fem|Number=Plur|PronType=Art	27	det	_	_
+26	gesellschaftlichen	gesellschaftlich	ADJ	ADJA	Case=Dat|Gender=Fem|Number=Plur	27	amod	_	_
+27	Konsequenzen	Konsequenz	NOUN	NN	Case=Dat|Gender=Fem|Number=Plur	20	obl	_	SpaceAfter=No
+28	,	,	PUNCT	$,	_	6	punct	_	_
+29	die	der	PRON	PRELS	Case=Nom|Gender=Fem|Number=Plur|PronType=Rel	31	nsubj	_	_
+30	daraus	daraus	ADV	PAV	_	31	advmod	_	_
+31	resultieren	resultieren	VERB	VVFIN	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	27	acl	_	SpaceAfter=No
+32	.	.	PUNCT	$.	_	6	punct	_	SpaceAfter=No
+33	''	''	PUNCT	$(	_	6	punct	_	_
 
 # sent_id = dev-s541
 # text = Die Mobilfunkbetreiber Telekom (D 1), Mannesmann (D 2) und Thyssen / Veba (E-plus) erhalten mittelfristig wahrscheinlich neue Konkurrenz.
@@ -9319,29 +9330,30 @@
 18	.	.	PUNCT	$.	_	17	punct	_	_
 
 # sent_id = dev-s546
-# text = BASF interessierte sich für diese Aktivitäten, wurde aber gestern von Monsanto darüber informiert, daß sie aus dem Rennen ist.
-1	BASF	BASF	PROPN	NE	Case=Nom|Gender=Fem|Number=Sing	2	nsubj	_	_
-2	interessierte	interessieren	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	0	root	_	_
-3	sich	er|es|sie	PRON	PRF	Case=Acc|Number=Sing|Person=3|PronType=Prs|Reflex=Yes	2	obj	_	_
-4	für	für	ADP	APPR	_	6	case	_	_
-5	diese	dies	PRON	PDAT	Case=Acc|Gender=Fem|Number=Plur|PronType=Dem	6	det	_	_
-6	Aktivitäten	Aktivität	NOUN	NN	Case=Acc|Gender=Fem|Number=Plur	2	obl	_	SpaceAfter=No
-7	,	,	PUNCT	$,	_	14	punct	_	_
-8	wurde	werden	AUX	VAFIN	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin|Voice=Pass	14	aux:pass	_	_
-9	aber	aber	CCONJ	ADV	_	14	cc	_	_
-10	gestern	gestern	ADV	ADV	_	14	advmod	_	_
-11	von	von	ADP	APPR	_	12	case	_	_
-12	Monsanto	Monsanto	PROPN	NE	Case=Dat|Number=Sing	14	obl	_	_
-13	darüber	darüber	ADV	PAV	_	14	advmod	_	_
-14	informiert	informieren	VERB	VVPP	VerbForm=Part	2	conj	_	SpaceAfter=No
-15	,	,	PUNCT	$,	_	2	punct	_	_
-16	daß	daß	SCONJ	KOUS	_	21	mark	_	_
-17	sie	sie	PRON	PPER	Case=Nom|Gender=Fem|Number=Sing|Person=3|PronType=Prs	21	nsubj	_	_
-18	aus	aus	ADP	APPR	_	21	case	_	_
-19	dem	der	DET	ART	Case=Dat|Definite=Def|Gender=Neut|Number=Sing|PronType=Art	20	det	_	_
-20	Rennen	Rennen	NOUN	NN	Case=Dat|Gender=Neut|Number=Sing	18	nsubj	_	_
-21	ist	sein	VERB	VAFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	14	ccomp	_	SpaceAfter=No
-22	.	.	PUNCT	$.	_	2	punct	_	_
+# text = Auch BASF interessierte sich für diese Aktivitäten, wurde aber gestern von Monsanto darüber informiert, daß sie aus dem Rennen ist.
+1	Auch	auch	ADV	ADV	_	2	dep	_	FixTigerDep=Yes
+2	BASF	BASF	PROPN	NE	Case=Nom|Gender=Fem|Number=Sing	3	nsubj	_	_
+3	interessierte	interessieren	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	0	root	_	_
+4	sich	er|es|sie	PRON	PRF	Case=Acc|Number=Sing|Person=3|PronType=Prs|Reflex=Yes	3	obj	_	_
+5	für	für	ADP	APPR	_	7	case	_	_
+6	diese	dies	PRON	PDAT	Case=Acc|Gender=Fem|Number=Plur|PronType=Dem	7	det	_	_
+7	Aktivitäten	Aktivität	NOUN	NN	Case=Acc|Gender=Fem|Number=Plur	3	obl	_	SpaceAfter=No
+8	,	,	PUNCT	$,	_	15	punct	_	_
+9	wurde	werden	AUX	VAFIN	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin|Voice=Pass	15	aux:pass	_	_
+10	aber	aber	CCONJ	ADV	_	15	cc	_	_
+11	gestern	gestern	ADV	ADV	_	15	advmod	_	_
+12	von	von	ADP	APPR	_	13	case	_	_
+13	Monsanto	Monsanto	PROPN	NE	Case=Dat|Number=Sing	15	obl	_	_
+14	darüber	darüber	ADV	PAV	_	15	advmod	_	_
+15	informiert	informieren	VERB	VVPP	VerbForm=Part	3	conj	_	SpaceAfter=No
+16	,	,	PUNCT	$,	_	3	punct	_	_
+17	daß	daß	SCONJ	KOUS	_	22	mark	_	_
+18	sie	sie	PRON	PPER	Case=Nom|Gender=Fem|Number=Sing|Person=3|PronType=Prs	22	nsubj	_	_
+19	aus	aus	ADP	APPR	_	22	case	_	_
+20	dem	der	DET	ART	Case=Dat|Definite=Def|Gender=Neut|Number=Sing|PronType=Art	21	det	_	_
+21	Rennen	Rennen	NOUN	NN	Case=Dat|Gender=Neut|Number=Sing	19	nsubj	_	_
+22	ist	sein	VERB	VAFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	15	ccomp	_	SpaceAfter=No
+23	.	.	PUNCT	$.	_	3	punct	_	_
 
 # sent_id = dev-s547
 # text = Das Urteil soll am Donnerstag verkündet werden.
@@ -9367,27 +9379,29 @@
 7	.	.	PUNCT	$.	_	4	punct	_	_
 
 # sent_id = dev-s549
-# text = Philosophie vertrage sich nicht immer mit der sozialen Marktwirtschaft.
-1	Philosophie	Philosophie	NOUN	NN	Case=Nom|Gender=Fem|Number=Sing	2	nsubj	_	_
-2	vertrage	vertragen	VERB	VVFIN	Mood=Sub|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	0	root	_	_
-3	sich	er|es|sie	PRON	PRF	Case=Acc|Number=Sing|Person=3|PronType=Prs|Reflex=Yes	2	obj	_	_
-4	nicht	nicht	PART	PTKNEG	Polarity=Neg	5	advmod	_	_
-5	immer	immer	ADV	ADV	_	2	advmod	_	_
-6	mit	mit	ADP	APPR	_	9	case	_	_
-7	der	der	DET	ART	Case=Dat|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	9	det	_	_
-8	sozialen	sozial	ADJ	ADJA	Case=Dat|Gender=Fem|Number=Sing	9	amod	_	_
-9	Marktwirtschaft	Marktwirtschaft	NOUN	NN	Case=Dat|Gender=Fem|Number=Sing	2	obl	_	SpaceAfter=No
-10	.	.	PUNCT	$.	_	2	punct	_	_
+# text = Diese Philosophie vertrage sich nicht immer mit der sozialen Marktwirtschaft.
+1	Diese	dies	DET	PDAT	Case=Nom|Gender=Fem|Number=Sing|PronType=Dem	2	dep	_	FixTigerDep=Yes
+2	Philosophie	Philosophie	NOUN	NN	Case=Nom|Gender=Fem|Number=Sing	3	nsubj	_	_
+3	vertrage	vertragen	VERB	VVFIN	Mood=Sub|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	0	root	_	_
+4	sich	er|es|sie	PRON	PRF	Case=Acc|Number=Sing|Person=3|PronType=Prs|Reflex=Yes	3	obj	_	_
+5	nicht	nicht	PART	PTKNEG	Polarity=Neg	6	advmod	_	_
+6	immer	immer	ADV	ADV	_	3	advmod	_	_
+7	mit	mit	ADP	APPR	_	10	case	_	_
+8	der	der	DET	ART	Case=Dat|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	10	det	_	_
+9	sozialen	sozial	ADJ	ADJA	Case=Dat|Gender=Fem|Number=Sing	10	amod	_	_
+10	Marktwirtschaft	Marktwirtschaft	NOUN	NN	Case=Dat|Gender=Fem|Number=Sing	3	obl	_	SpaceAfter=No
+11	.	.	PUNCT	$.	_	3	punct	_	_
 
 # sent_id = dev-s550
-# text = 1987 häufen sich jedoch die Fälle.
-1	1987	1987	NUM	CARD	NumType=Card	2	obl	_	_
-2	häufen	häufen	VERB	VVFIN	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	0	root	_	_
-3	sich	er|es|sie	PRON	PRF	Case=Acc|Number=Plur|Person=3|PronType=Prs|Reflex=Yes	2	obj	_	_
-4	jedoch	jedoch	ADV	ADV	_	2	advmod	_	_
-5	die	der	DET	ART	Case=Nom|Definite=Def|Gender=Masc|Number=Plur|PronType=Art	6	det	_	_
-6	Fälle	Fall	NOUN	NN	Case=Nom|Gender=Masc|Number=Plur	2	nsubj	_	SpaceAfter=No
-7	.	.	PUNCT	$.	_	2	punct	_	_
+# text = Seit 1987 häufen sich jedoch die Fälle.
+1	Seit	seit	ADP	APPR	_	2	dep	_	FixTigerDep=Yes
+2	1987	1987	NUM	CARD	NumType=Card	3	obl	_	_
+3	häufen	häufen	VERB	VVFIN	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	0	root	_	_
+4	sich	er|es|sie	PRON	PRF	Case=Acc|Number=Plur|Person=3|PronType=Prs|Reflex=Yes	3	obj	_	_
+5	jedoch	jedoch	ADV	ADV	_	3	advmod	_	_
+6	die	der	DET	ART	Case=Nom|Definite=Def|Gender=Masc|Number=Plur|PronType=Art	7	det	_	_
+7	Fälle	Fall	NOUN	NN	Case=Nom|Gender=Masc|Number=Plur	3	nsubj	_	SpaceAfter=No
+8	.	.	PUNCT	$.	_	3	punct	_	_
 
 # sent_id = dev-s551
 # text = Es besteht die Gefahr, daß die entsprechenden Vorkehrungen im Vertrag als zu lax definiert werden.
@@ -9412,31 +9426,32 @@
 18	.	.	PUNCT	$.	_	2	punct	_	_
 
 # sent_id = dev-s552
-# text = Anlaß zur Sorge'' besteht weniger für die Konjunktur in überschaubarer Zeit als vielmehr für die mittel- und langfristige Perspektive.
-1	Anlaß	Anlaß	NOUN	NN	Case=Nom|Gender=Masc|Number=Sing	6	nsubj	_	_
-2-3	zur	_	_	_	_	_	_	_	_
-2	zu	zu	ADP	APPR	_	4	case	_	_
-3	der	der	DET	ART	Case=Dat|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	4	det	_	_
-4	Sorge	Sorge	NOUN	NN	Case=Dat|Gender=Fem|Number=Sing	1	nmod	_	SpaceAfter=No
-5	''	''	PUNCT	$(	_	6	punct	_	_
-6	besteht	bestehen	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	0	root	_	_
-7	weniger	weniger	CCONJ	ADV	_	10	cc	_	_
-8	für	für	ADP	APPR	_	10	case	_	_
-9	die	der	DET	ART	Case=Acc|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	10	det	_	_
-10	Konjunktur	Konjunktur	NOUN	NN	Case=Acc|Gender=Fem|Number=Sing	6	obl	_	_
-11	in	in	ADP	APPR	_	13	case	_	_
-12	überschaubarer	überschaubar	ADJ	ADJA	Case=Dat|Gender=Fem|Number=Sing	13	amod	_	_
-13	Zeit	Zeit	NOUN	NN	Case=Dat|Gender=Fem|Number=Sing	10	nmod	_	_
-14	als	als	CCONJ	KON	_	22	cc	_	_
-15	vielmehr	vielmehr	ADV	ADV	_	22	advmod	_	_
-16	für	für	ADP	APPR	_	22	case	_	_
-17	die	der	DET	ART	Case=Acc|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	18	det	_	_
-18	mittel	mitteln	NOUN	TRUNC	Case=Acc|Gender=Fem|Number=Sing	22	compound	_	SpaceAfter=No
-19	-	-	PUNCT	$(	_	21	punct	_	_
-20	und	und	CCONJ	KON	_	21	cc	_	_
-21	langfristige	langfristig	ADJ	ADJA	Case=Acc|Gender=Fem|Number=Sing	18	conj	_	_
-22	Perspektive	Perspektive	NOUN	NN	Case=Acc|Gender=Fem|Number=Sing	10	conj	_	SpaceAfter=No
-23	.	.	PUNCT	$.	_	6	punct	_	_
+# text = ``Anlaß zur Sorge'' besteht weniger für die Konjunktur in überschaubarer Zeit als vielmehr für die mittel- und langfristige Perspektive.
+1	``	``	PUNCT	$(	_	2	punct	_	FixTigerDep=Yes|SpaceAfter=No
+2	Anlaß	Anlaß	NOUN	NN	Case=Nom|Gender=Masc|Number=Sing	7	nsubj	_	_
+3-4	zur	_	_	_	_	_	_	_	_
+3	zu	zu	ADP	APPR	_	5	case	_	_
+4	der	der	DET	ART	Case=Dat|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	5	det	_	_
+5	Sorge	Sorge	NOUN	NN	Case=Dat|Gender=Fem|Number=Sing	2	nmod	_	SpaceAfter=No
+6	''	''	PUNCT	$(	_	7	punct	_	_
+7	besteht	bestehen	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	0	root	_	_
+8	weniger	weniger	CCONJ	ADV	_	11	cc	_	_
+9	für	für	ADP	APPR	_	11	case	_	_
+10	die	der	DET	ART	Case=Acc|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	11	det	_	_
+11	Konjunktur	Konjunktur	NOUN	NN	Case=Acc|Gender=Fem|Number=Sing	7	obl	_	_
+12	in	in	ADP	APPR	_	14	case	_	_
+13	überschaubarer	überschaubar	ADJ	ADJA	Case=Dat|Gender=Fem|Number=Sing	14	amod	_	_
+14	Zeit	Zeit	NOUN	NN	Case=Dat|Gender=Fem|Number=Sing	11	nmod	_	_
+15	als	als	CCONJ	KON	_	23	cc	_	_
+16	vielmehr	vielmehr	ADV	ADV	_	23	advmod	_	_
+17	für	für	ADP	APPR	_	23	case	_	_
+18	die	der	DET	ART	Case=Acc|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	19	det	_	_
+19	mittel	mitteln	NOUN	TRUNC	Case=Acc|Gender=Fem|Number=Sing	23	compound	_	SpaceAfter=No
+20	-	-	PUNCT	$(	_	22	punct	_	_
+21	und	und	CCONJ	KON	_	22	cc	_	_
+22	langfristige	langfristig	ADJ	ADJA	Case=Acc|Gender=Fem|Number=Sing	19	conj	_	_
+23	Perspektive	Perspektive	NOUN	NN	Case=Acc|Gender=Fem|Number=Sing	11	conj	_	SpaceAfter=No
+24	.	.	PUNCT	$.	_	7	punct	_	_
 
 # sent_id = dev-s553
 # text = Die Mehrheit der Bevölkerung beurteilte seine erste Amtszeit trotz der deutlichen Neigung des Präsidenten zum Autoritarismus positiv und bestätigte den Nachfahren japanischer Einwanderer im April dieses Jahres mit deutlicher Mehrheit.
@@ -9638,45 +9653,48 @@
 35	.	.	PUNCT	$.	_	10	punct	_	_
 
 # sent_id = dev-s560
-# text = Unglaublich instinktlos'' findet Katja Wolle das.
-1	Unglaublich	unglaublich	ADV	ADJD	_	2	advmod	_	_
-2	instinktlos	instinktlos	ADJ	ADJD	_	4	xcomp	_	SpaceAfter=No
-3	''	''	PUNCT	$(	_	4	punct	_	_
-4	findet	finden	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	0	root	_	_
-5	Katja	Katja	PROPN	NE	Case=Nom|Gender=Fem|Number=Sing	4	nsubj	_	_
-6	Wolle	wollen	PROPN	NE	Case=Nom|Gender=Fem|Number=Sing	5	flat	_	_
-7	das	der	PRON	PDS	Case=Acc|Gender=Neut|Number=Sing|PronType=Dem	4	obj	_	SpaceAfter=No
-8	.	.	PUNCT	$.	_	4	punct	_	_
+# text = ``Unglaublich instinktlos'' findet Katja Wolle das.
+1	``	``	PUNCT	$(	_	2	punct	_	FixTigerDep=Yes|SpaceAfter=No
+2	Unglaublich	unglaublich	ADV	ADJD	_	3	advmod	_	_
+3	instinktlos	instinktlos	ADJ	ADJD	_	5	xcomp	_	SpaceAfter=No
+4	''	''	PUNCT	$(	_	5	punct	_	_
+5	findet	finden	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	0	root	_	_
+6	Katja	Katja	PROPN	NE	Case=Nom|Gender=Fem|Number=Sing	5	nsubj	_	_
+7	Wolle	Wolle	PROPN	NE	Case=Nom|Gender=Fem|Number=Sing	6	flat	_	_
+8	das	der	PRON	PDS	Case=Acc|Gender=Neut|Number=Sing|PronType=Dem	5	obj	_	SpaceAfter=No
+9	.	.	PUNCT	$.	_	5	punct	_	_
 
 # sent_id = dev-s561
-# text = Sensation, die niemand erwartet hatte?
-1	Sensation	Sensation	NOUN	NN	Case=Nom|Gender=Fem|Number=Sing	0	root	_	SpaceAfter=No
-2	,	,	PUNCT	$,	_	1	punct	_	_
-3	die	der	PRON	PRELS	Case=Acc|Gender=Fem|Number=Sing|PronType=Rel	5	obj	_	_
-4	niemand	niemand	PRON	PIS	Case=Nom|Definite=Ind|Gender=Masc|Number=Sing|PronType=Ind	5	nsubj	_	_
-5	erwartet	erwarten	VERB	VVPP	VerbForm=Part	1	acl	_	_
-6	hatte	haben	AUX	VAFIN	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	5	aux	_	SpaceAfter=No
-7	?	?	PUNCT	$.	_	1	punct	_	_
+# text = Die Sensation, die niemand erwartet hatte?
+1	Die	der	DET	ART	Case=Nom|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	2	dep	_	FixTigerDep=Yes
+2	Sensation	Sensation	NOUN	NN	Case=Nom|Gender=Fem|Number=Sing	0	root	_	SpaceAfter=No
+3	,	,	PUNCT	$,	_	2	punct	_	_
+4	die	der	PRON	PRELS	Case=Acc|Gender=Fem|Number=Sing|PronType=Rel	6	obj	_	_
+5	niemand	niemand	PRON	PIS	Case=Nom|Definite=Ind|Gender=Masc|Number=Sing|PronType=Ind	6	nsubj	_	_
+6	erwartet	erwarten	VERB	VVPP	VerbForm=Part	2	acl	_	_
+7	hatte	haben	AUX	VAFIN	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	6	aux	_	SpaceAfter=No
+8	?	?	PUNCT	$.	_	2	punct	_	_
 
 # sent_id = dev-s562
-# text = Wir stehen in einem harten internationalen Wettbewerb unter starkem wirtschaftspolitischen Druck'', heißt es darin.
-1	Wir	wir	PRON	PPER	Case=Nom|Number=Plur|Person=1|PronType=Prs	2	nsubj	_	_
-2	stehen	stehen	VERB	VVFIN	Mood=Ind|Number=Plur|Person=1|Tense=Pres|VerbForm=Fin	14	ccomp	_	_
-3	in	in	ADP	APPR	_	7	case	_	_
-4	einem	ein	DET	ART	Case=Dat|Definite=Ind|Gender=Masc|Number=Sing|PronType=Art	7	det	_	_
-5	harten	hart	ADJ	ADJA	Case=Dat|Gender=Masc|Number=Sing	7	amod	_	_
-6	internationalen	international	ADJ	ADJA	Case=Dat|Gender=Masc|Number=Sing	7	amod	_	_
-7	Wettbewerb	Wettbewerb	NOUN	NN	Case=Dat|Gender=Masc|Number=Sing	2	obl	_	_
-8	unter	unter	ADP	APPR	_	11	case	_	_
-9	starkem	stark	ADJ	ADJA	Case=Dat|Gender=Masc|Number=Sing	11	amod	_	_
-10	wirtschaftspolitischen	wirtschaftspolitisch	ADJ	ADJA	Case=Dat|Gender=Masc|Number=Sing	11	amod	_	_
-11	Druck	Druck	NOUN	NN	Case=Dat|Gender=Masc|Number=Sing	2	obl	_	SpaceAfter=No
-12	''	''	PUNCT	$(	_	14	punct	_	SpaceAfter=No
-13	,	,	PUNCT	$,	_	14	punct	_	_
-14	heißt	heißen	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	0	root	_	_
-15	es	es	PRON	PPER	Case=Nom|Gender=Neut|Number=Sing|Person=3|PronType=Prs	14	nsubj	_	_
-16	darin	darin	ADV	PAV	_	14	advmod	_	SpaceAfter=No
-17	.	.	PUNCT	$.	_	14	punct	_	_
+# text = ``Wir stehen in einem harten internationalen Wettbewerb unter starkem wirtschaftspolitischen Druck'', heißt es darin.
+1	``	``	PUNCT	$(	_	2	punct	_	FixTigerDep=Yes|SpaceAfter=No
+2	Wir	wir	PRON	PPER	Case=Nom|Number=Plur|Person=1|PronType=Prs	3	nsubj	_	_
+3	stehen	stehen	VERB	VVFIN	Mood=Ind|Number=Plur|Person=1|Tense=Pres|VerbForm=Fin	15	ccomp	_	_
+4	in	in	ADP	APPR	_	8	case	_	_
+5	einem	ein	DET	ART	Case=Dat|Definite=Ind|Gender=Masc|Number=Sing|PronType=Art	8	det	_	_
+6	harten	hart	ADJ	ADJA	Case=Dat|Gender=Masc|Number=Sing	8	amod	_	_
+7	internationalen	international	ADJ	ADJA	Case=Dat|Gender=Masc|Number=Sing	8	amod	_	_
+8	Wettbewerb	Wettbewerb	NOUN	NN	Case=Dat|Gender=Masc|Number=Sing	3	obl	_	_
+9	unter	unter	ADP	APPR	_	12	case	_	_
+10	starkem	stark	ADJ	ADJA	Case=Dat|Gender=Masc|Number=Sing	12	amod	_	_
+11	wirtschaftspolitischen	wirtschaftspolitisch	ADJ	ADJA	Case=Dat|Gender=Masc|Number=Sing	12	amod	_	_
+12	Druck	Druck	NOUN	NN	Case=Dat|Gender=Masc|Number=Sing	3	obl	_	SpaceAfter=No
+13	''	''	PUNCT	$(	_	15	punct	_	SpaceAfter=No
+14	,	,	PUNCT	$,	_	15	punct	_	_
+15	heißt	heißen	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	0	root	_	_
+16	es	es	PRON	PPER	Case=Nom|Gender=Neut|Number=Sing|Person=3|PronType=Prs	15	nsubj	_	_
+17	darin	darin	ADV	PAV	_	15	advmod	_	SpaceAfter=No
+18	.	.	PUNCT	$.	_	15	punct	_	_
 
 # sent_id = dev-s563
 # text = Offenbar gab es ein Mißverständnis, oder die staatlichen Gläubiger sind sich untereinander nicht einig.
@@ -9740,33 +9758,34 @@
 22	.	.	PUNCT	$.	_	11	punct	_	_
 
 # sent_id = dev-s566
-# text = Soziale Bewegungen leiten ihre Legitimation auch daraus ab, daß Parteien nicht imstande sind, Bürgeranliegen mit der gebotenen Konsequenz zu ihren eigenen zu machen.
-1	Soziale	sozial	ADJ	ADJA	Case=Nom|Gender=Fem|Number=Plur	2	amod	_	_
-2	Bewegungen	Bewegung	NOUN	NN	Case=Nom|Gender=Fem|Number=Plur	3	nsubj	_	_
-3	leiten	leiten	VERB	VVFIN	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	0	root	_	_
-4	ihre	ihr	PRON	PPOSAT	Case=Acc|Gender=Fem|Number=Sing|Poss=Yes	5	det:poss	_	_
-5	Legitimation	Legitimation	NOUN	NN	Case=Acc|Gender=Fem|Number=Sing	3	obj	_	_
-6	auch	auch	ADV	ADV	_	3	advmod	_	_
-7	daraus	daraus	ADV	PAV	_	3	advmod	_	_
-8	ab	ab	ADP	PTKVZ	_	3	compound:prt	_	SpaceAfter=No
-9	,	,	PUNCT	$,	_	3	punct	_	_
-10	daß	daß	CCONJ	KOUS	_	13	cc	_	_
-11	Parteien	Partei	NOUN	NN	Case=Nom|Gender=Fem|Number=Plur	13	nsubj	_	_
-12	nicht	nicht	PART	PTKNEG	Polarity=Neg	14	advmod	_	_
-13	imstande	imstande	ADJ	ADV	_	7	ccomp	_	_
-14	sind	sein	AUX	VAFIN	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	13	cop	_	SpaceAfter=No
-15	,	,	PUNCT	$,	_	3	punct	_	_
-16	Bürgeranliegen	Bürgeranliegen	NOUN	NN	Case=Acc|Gender=Neut|Number=Plur	25	obj	_	_
-17	mit	mit	ADP	APPR	_	20	case	_	_
-18	der	der	DET	ART	Case=Dat|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	20	det	_	_
-19	gebotenen	geboten	ADJ	ADJA	Case=Dat|Gender=Fem|Number=Sing	20	amod	_	_
-20	Konsequenz	Konsequenz	NOUN	NN	Case=Dat|Gender=Fem|Number=Sing	25	obl	_	_
-21	zu	zu	ADP	APPR	_	22	case	_	_
-22	ihren	ihr	PRON	PPOSAT	Case=Dat|Gender=Neut|Number=Plur|Poss=Yes	25	obl	_	_
-23	eigenen	eigen	ADJ	ADJA	Case=Dat|Gender=Neut|Number=Plur	22	amod	_	_
-24	zu	zu	PART	PTKZU	_	25	mark	_	_
-25	machen	machen	VERB	VVINF	VerbForm=Inf	13	xcomp	_	SpaceAfter=No
-26	.	.	PUNCT	$.	_	3	punct	_	_
+# text = 2. Soziale Bewegungen leiten ihre Legitimation auch daraus ab, daß Parteien nicht imstande sind, Bürgeranliegen mit der gebotenen Konsequenz zu ihren eigenen zu machen.
+1	2.	2.	ADV	ADV	_	2	dep	_	FixTigerDep=Yes
+2	Soziale	sozial	ADJ	ADJA	Case=Nom|Gender=Fem|Number=Plur	3	amod	_	_
+3	Bewegungen	Bewegung	NOUN	NN	Case=Nom|Gender=Fem|Number=Plur	4	nsubj	_	_
+4	leiten	leiten	VERB	VVFIN	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	0	root	_	_
+5	ihre	ihr	PRON	PPOSAT	Case=Acc|Gender=Fem|Number=Sing|Poss=Yes	6	det:poss	_	_
+6	Legitimation	Legitimation	NOUN	NN	Case=Acc|Gender=Fem|Number=Sing	4	obj	_	_
+7	auch	auch	ADV	ADV	_	4	advmod	_	_
+8	daraus	daraus	ADV	PAV	_	4	advmod	_	_
+9	ab	ab	ADP	PTKVZ	_	4	compound:prt	_	SpaceAfter=No
+10	,	,	PUNCT	$,	_	4	punct	_	_
+11	daß	daß	CCONJ	KOUS	_	14	cc	_	_
+12	Parteien	Partei	NOUN	NN	Case=Nom|Gender=Fem|Number=Plur	14	nsubj	_	_
+13	nicht	nicht	PART	PTKNEG	Polarity=Neg	15	advmod	_	_
+14	imstande	imstande	ADJ	ADV	_	8	ccomp	_	_
+15	sind	sein	AUX	VAFIN	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	14	cop	_	SpaceAfter=No
+16	,	,	PUNCT	$,	_	4	punct	_	_
+17	Bürgeranliegen	Bürgeranliegen	NOUN	NN	Case=Acc|Gender=Neut|Number=Plur	26	obj	_	_
+18	mit	mit	ADP	APPR	_	21	case	_	_
+19	der	der	DET	ART	Case=Dat|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	21	det	_	_
+20	gebotenen	geboten	ADJ	ADJA	Case=Dat|Gender=Fem|Number=Sing	21	amod	_	_
+21	Konsequenz	Konsequenz	NOUN	NN	Case=Dat|Gender=Fem|Number=Sing	26	obl	_	_
+22	zu	zu	ADP	APPR	_	23	case	_	_
+23	ihren	ihr	PRON	PPOSAT	Case=Dat|Gender=Neut|Number=Plur|Poss=Yes	26	obl	_	_
+24	eigenen	eigen	ADJ	ADJA	Case=Dat|Gender=Neut|Number=Plur	23	amod	_	_
+25	zu	zu	PART	PTKZU	_	26	mark	_	_
+26	machen	machen	VERB	VVINF	VerbForm=Inf	14	xcomp	_	SpaceAfter=No
+27	.	.	PUNCT	$.	_	4	punct	_	_
 
 # sent_id = dev-s567
 # text = Die Zahl der Kammern hängt von den gesellschaftlichen Feldern ab, für die die Gesellschaft bereit ist, eine Kammer einzurichten.
@@ -9794,23 +9813,24 @@
 22	.	.	PUNCT	$.	_	5	punct	_	_
 
 # sent_id = dev-s568
-# text = Horn, Louise Bourgeois, Rosemarie Trockel, Annette Messager und viele andere sind vertreten.
-1	Horn	Horn	PROPN	NE	Case=Nom|Gender=Fem|Number=Sing	15	nsubj	_	SpaceAfter=No
-2	,	,	PUNCT	$,	_	3	punct	_	_
-3	Louise	Louise	PROPN	NE	Case=Nom|Gender=Fem|Number=Sing	1	conj	_	_
-4	Bourgeois	Bourgeois	PROPN	NE	Case=Nom|Gender=Fem|Number=Sing	3	flat	_	SpaceAfter=No
-5	,	,	PUNCT	$,	_	6	punct	_	_
-6	Rosemarie	Rosemarie	PROPN	NE	Case=Nom|Gender=Fem|Number=Sing	1	conj	_	_
-7	Trockel	Trockel	PROPN	NE	Case=Nom|Gender=Fem|Number=Sing	6	flat	_	SpaceAfter=No
-8	,	,	PUNCT	$,	_	9	punct	_	_
-9	Annette	Annette	PROPN	NE	Case=Nom|Gender=Fem|Number=Sing	1	conj	_	_
-10	Messager	Messager	PROPN	NE	Case=Nom|Gender=Fem|Number=Sing	9	flat	_	_
-11	und	und	CCONJ	KON	_	13	cc	_	_
-12	viele	viel	PRON	PIAT	Case=Nom|Definite=Ind|Number=Plur|PronType=Ind	13	det	_	_
-13	andere	ander	PRON	PIS	Case=Nom|Definite=Ind|Number=Plur|PronType=Ind	1	conj	_	_
-14	sind	sein	AUX	VAFIN	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	15	cop	_	_
-15	vertreten	vertreten	ADJ	VVPP	VerbForm=Part	0	root	_	SpaceAfter=No
-16	.	.	PUNCT	$.	_	15	punct	_	_
+# text = Rebecca Horn, Louise Bourgeois, Rosemarie Trockel, Annette Messager und viele andere sind vertreten.
+1	Rebecca	Rebecca	PROPN	NE	Case=Nom|Gender=Fem|Number=Sing	2	dep	_	FixTigerDep=Yes
+2	Horn	Horn	PROPN	NE	Case=Nom|Gender=Fem|Number=Sing	16	nsubj	_	SpaceAfter=No
+3	,	,	PUNCT	$,	_	4	punct	_	_
+4	Louise	Louise	PROPN	NE	Case=Nom|Gender=Fem|Number=Sing	2	conj	_	_
+5	Bourgeois	Bourgeois	PROPN	NE	Case=Nom|Gender=Fem|Number=Sing	4	flat	_	SpaceAfter=No
+6	,	,	PUNCT	$,	_	7	punct	_	_
+7	Rosemarie	Rosemarie	PROPN	NE	Case=Nom|Gender=Fem|Number=Sing	2	conj	_	_
+8	Trockel	Trockel	PROPN	NE	Case=Nom|Gender=Fem|Number=Sing	7	flat	_	SpaceAfter=No
+9	,	,	PUNCT	$,	_	10	punct	_	_
+10	Annette	Annette	PROPN	NE	Case=Nom|Gender=Fem|Number=Sing	2	conj	_	_
+11	Messager	Messager	PROPN	NE	Case=Nom|Gender=Fem|Number=Sing	10	flat	_	_
+12	und	und	CCONJ	KON	_	14	cc	_	_
+13	viele	viel	PRON	PIAT	Case=Nom|Definite=Ind|Number=Plur|PronType=Ind	14	det	_	_
+14	andere	ander	PRON	PIS	Case=Nom|Definite=Ind|Number=Plur|PronType=Ind	2	conj	_	_
+15	sind	sein	AUX	VAFIN	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	16	cop	_	_
+16	vertreten	vertreten	ADJ	VVPP	VerbForm=Part	0	root	_	SpaceAfter=No
+17	.	.	PUNCT	$.	_	16	punct	_	_
 
 # sent_id = dev-s569
 # text = Ich wollte nicht warten, bis sich meine Einschätzung abgeklärt hat, ich wollte meine Eindrücke sofort umsetzen.
@@ -9835,27 +9855,28 @@
 19	.	.	PUNCT	$.	_	4	punct	_	_
 
 # sent_id = dev-s570
-# text = Wolff, der von der Zürcher Prognos AG zur Gütersloher Bertelsmann-Stiftung wechselt, verbreitete Optimismus.
-1	Wolff	Wolff	PROPN	NE	Case=Nom|Gender=Masc|Number=Sing	17	nsubj	_	SpaceAfter=No
-2	,	,	PUNCT	$,	_	17	punct	_	_
-3	der	der	PRON	PRELS	Case=Nom|Gender=Masc|Number=Sing|PronType=Rel	15	nsubj	_	_
-4	von	von	ADP	APPR	_	7	case	_	_
-5	der	der	DET	ART	Case=Dat|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	7	det	_	_
-6	Zürcher	Zürcher	ADJ	ADJA	_	7	amod	_	_
-7	Prognos	Prognos	PROPN	NE	_	15	obl	_	_
-8	AG	AG	PROPN	NN	Case=Dat|Gender=Fem|Number=Sing	7	flat	_	_
-9-10	zur	_	_	_	_	_	_	_	_
-9	zu	zu	ADP	APPR	_	12	case	_	_
-10	der	der	DET	ART	Case=Dat|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	12	det	_	_
-11	Gütersloher	Gütersloher	ADJ	ADJA	Case=Dat|Gender=Fem|Number=Sing	12	amod	_	_
-12	Bertelsmann	Bertelsmann	PROPN	NN	Case=Dat|Gender=Fem|Number=Sing	14	compound	_	SpaceAfter=No
-13	-	-	PUNCT	$(	_	12	punct	_	SpaceAfter=No
-14	Stiftung	Stiftung	PROPN	NN	Case=Dat|Gender=Fem|Number=Sing	15	obl	_	_
-15	wechselt	wechseln	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	1	acl	_	SpaceAfter=No
-16	,	,	PUNCT	$,	_	17	punct	_	_
-17	verbreitete	verbreiten	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	0	root	_	_
-18	Optimismus	Optimismus	NOUN	NN	Case=Acc|Gender=Masc|Number=Sing	17	obj	_	SpaceAfter=No
-19	.	.	PUNCT	$.	_	17	punct	_	_
+# text = Heimfrid Wolff, der von der Zürcher Prognos AG zur Gütersloher Bertelsmann-Stiftung wechselt, verbreitete Optimismus.
+1	Heimfrid	Heimfrid	PROPN	NE	Case=Nom|Gender=Masc|Number=Sing	2	dep	_	FixTigerDep=Yes
+2	Wolff	Wolff	PROPN	NE	Case=Nom|Gender=Masc|Number=Sing	18	nsubj	_	SpaceAfter=No
+3	,	,	PUNCT	$,	_	18	punct	_	_
+4	der	der	PRON	PRELS	Case=Nom|Gender=Masc|Number=Sing|PronType=Rel	16	nsubj	_	_
+5	von	von	ADP	APPR	_	8	case	_	_
+6	der	der	DET	ART	Case=Dat|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	8	det	_	_
+7	Zürcher	Zürcher	ADJ	ADJA	_	8	amod	_	_
+8	Prognos	Prognos	PROPN	NE	_	16	obl	_	_
+9	AG	AG	PROPN	NN	Case=Dat|Gender=Fem|Number=Sing	8	flat	_	_
+10-11	zur	_	_	_	_	_	_	_	_
+10	zu	zu	ADP	APPR	_	13	case	_	_
+11	der	der	DET	ART	Case=Dat|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	13	det	_	_
+12	Gütersloher	Gütersloher	ADJ	ADJA	Case=Dat|Gender=Fem|Number=Sing	13	amod	_	_
+13	Bertelsmann	Bertelsmann	PROPN	NN	Case=Dat|Gender=Fem|Number=Sing	15	compound	_	SpaceAfter=No
+14	-	-	PUNCT	$(	_	13	punct	_	SpaceAfter=No
+15	Stiftung	Stiftung	PROPN	NN	Case=Dat|Gender=Fem|Number=Sing	16	obl	_	_
+16	wechselt	wechseln	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	2	acl	_	SpaceAfter=No
+17	,	,	PUNCT	$,	_	18	punct	_	_
+18	verbreitete	verbreiten	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	0	root	_	_
+19	Optimismus	Optimismus	NOUN	NN	Case=Acc|Gender=Masc|Number=Sing	18	obj	_	SpaceAfter=No
+20	.	.	PUNCT	$.	_	18	punct	_	_
 
 # sent_id = dev-s571
 # text = Der rasante Prozeß der Medienentwicklung verändere die Formen des menschlichen Zusammenlebens, die Arbeit und die Werte.
@@ -9964,39 +9985,40 @@
 16	.	.	PUNCT	$.	_	15	punct	_	_
 
 # sent_id = dev-s576
-# text = Roman Herzog und Bundeswehr-Generalinspekteur Klaus Naumann gaben in ihren Eröffnungsreden auf der 35. Kommandeurstagung am Mittwoch in München das Thema vor: die wachsenden Personalprobleme der Bundeswehr.
-1	Roman	Roman	PROPN	NE	Case=Nom|Gender=Masc|Number=Sing	9	nsubj	_	_
-2	Herzog	Herzog	PROPN	NE	Case=Nom|Gender=Masc|Number=Sing	1	flat	_	_
-3	und	und	CCONJ	KON	_	4	cc	_	_
-4	Bundeswehr	Bundeswehr	PROPN	NN	Case=Nom|Gender=Masc|Number=Sing	6	compound	_	SpaceAfter=No
-5	-	-	PUNCT	$(	_	4	punct	_	SpaceAfter=No
-6	Generalinspekteur	Generalinspekteur	NOUN	NN	Case=Nom|Gender=Masc|Number=Sing	1	conj	_	_
-7	Klaus	Klaus	PROPN	NE	Case=Nom|Gender=Masc|Number=Sing	4	appos	_	_
-8	Naumann	Naumann	PROPN	NE	Case=Nom|Gender=Masc|Number=Sing	7	flat	_	_
-9	gaben	geben	VERB	VVFIN	Mood=Ind|Number=Plur|Person=3|Tense=Past|VerbForm=Fin	0	root	_	_
-10	in	in	ADP	APPR	_	12	case	_	_
-11	ihren	ihr	PRON	PPOSAT	Case=Dat|Gender=Fem|Number=Plur|Poss=Yes	12	det:poss	_	_
-12	Eröffnungsreden	Eröffnungsrede	NOUN	NN	Case=Dat|Gender=Fem|Number=Plur	9	obl	_	_
-13	auf	auf	ADP	APPR	_	16	case	_	_
-14	der	der	DET	ART	Case=Dat|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	16	det	_	_
-15	35.	35	ADJ	ADJA	Case=Dat|Gender=Fem|Number=Sing	16	amod	_	_
-16	Kommandeurstagung	Kommandeurstagung	NOUN	NN	Case=Dat|Gender=Fem|Number=Sing	9	obl	_	_
-17-18	am	_	_	_	_	_	_	_	_
-17	an	an	ADP	APPR	_	19	case	_	_
-18	dem	der	DET	ART	Case=Dat|Definite=Def|Gender=Masc|Number=Sing|PronType=Art	19	det	_	_
-19	Mittwoch	Mittwoch	PROPN	NN	Case=Dat|Gender=Masc|Number=Sing	9	obl	_	_
-20	in	in	ADP	APPR	_	21	case	_	_
-21	München	München	PROPN	NE	Case=Dat|Gender=Neut|Number=Sing	9	obl	_	_
-22	das	der	DET	ART	Case=Acc|Definite=Def|Gender=Neut|Number=Sing|PronType=Art	23	det	_	_
-23	Thema	Thema	NOUN	NN	Case=Acc|Gender=Neut|Number=Sing	9	obj	_	_
-24	vor	vor	ADP	PTKVZ	_	9	compound:prt	_	SpaceAfter=No
-25	:	:	PUNCT	$.	_	9	punct	_	_
-26	die	der	DET	ART	Case=Nom|Definite=Def|Gender=Neut|Number=Plur|PronType=Art	28	det	_	_
-27	wachsenden	wachsend	ADJ	ADJA	Case=Nom|Gender=Neut|Number=Plur	28	amod	_	_
-28	Personalprobleme	Personalproblem	NOUN	NN	Case=Nom|Gender=Neut|Number=Plur	9	appos	_	_
-29	der	der	DET	ART	Case=Gen|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	30	det	_	_
-30	Bundeswehr	Bundeswehr	PROPN	NN	Case=Gen|Gender=Fem|Number=Sing	28	nmod	_	SpaceAfter=No
-31	.	.	PUNCT	$.	_	9	punct	_	_
+# text = Bundespräsident Roman Herzog und Bundeswehr-Generalinspekteur Klaus Naumann gaben in ihren Eröffnungsreden auf der 35. Kommandeurstagung am Mittwoch in München das Thema vor: die wachsenden Personalprobleme der Bundeswehr.
+1	Bundespräsident	Bundespräsident	NOUN	NN	Case=Nom|Gender=Masc|Number=Sing	2	dep	_	FixTigerDep=Yes
+2	Roman	Roman	PROPN	NE	Case=Nom|Gender=Masc|Number=Sing	10	nsubj	_	_
+3	Herzog	Herzog	PROPN	NE	Case=Nom|Gender=Masc|Number=Sing	2	flat	_	_
+4	und	und	CCONJ	KON	_	5	cc	_	_
+5	Bundeswehr	Bundeswehr	PROPN	NN	Case=Nom|Gender=Masc|Number=Sing	7	compound	_	SpaceAfter=No
+6	-	-	PUNCT	$(	_	5	punct	_	SpaceAfter=No
+7	Generalinspekteur	Generalinspekteur	NOUN	NN	Case=Nom|Gender=Masc|Number=Sing	2	conj	_	_
+8	Klaus	Klaus	PROPN	NE	Case=Nom|Gender=Masc|Number=Sing	5	appos	_	_
+9	Naumann	Naumann	PROPN	NE	Case=Nom|Gender=Masc|Number=Sing	8	flat	_	_
+10	gaben	geben	VERB	VVFIN	Mood=Ind|Number=Plur|Person=3|Tense=Past|VerbForm=Fin	0	root	_	_
+11	in	in	ADP	APPR	_	13	case	_	_
+12	ihren	ihr	PRON	PPOSAT	Case=Dat|Gender=Fem|Number=Plur|Poss=Yes	13	det:poss	_	_
+13	Eröffnungsreden	Eröffnungsrede	NOUN	NN	Case=Dat|Gender=Fem|Number=Plur	10	obl	_	_
+14	auf	auf	ADP	APPR	_	17	case	_	_
+15	der	der	DET	ART	Case=Dat|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	17	det	_	_
+16	35.	35	ADJ	ADJA	Case=Dat|Gender=Fem|Number=Sing	17	amod	_	_
+17	Kommandeurstagung	Kommandeurstagung	NOUN	NN	Case=Dat|Gender=Fem|Number=Sing	10	obl	_	_
+18-19	am	_	_	_	_	_	_	_	_
+18	an	an	ADP	APPR	_	20	case	_	_
+19	dem	der	DET	ART	Case=Dat|Definite=Def|Gender=Masc|Number=Sing|PronType=Art	20	det	_	_
+20	Mittwoch	Mittwoch	PROPN	NN	Case=Dat|Gender=Masc|Number=Sing	10	obl	_	_
+21	in	in	ADP	APPR	_	22	case	_	_
+22	München	München	PROPN	NE	Case=Dat|Gender=Neut|Number=Sing	10	obl	_	_
+23	das	der	DET	ART	Case=Acc|Definite=Def|Gender=Neut|Number=Sing|PronType=Art	24	det	_	_
+24	Thema	Thema	NOUN	NN	Case=Acc|Gender=Neut|Number=Sing	10	obj	_	_
+25	vor	vor	ADP	PTKVZ	_	10	compound:prt	_	SpaceAfter=No
+26	:	:	PUNCT	$.	_	10	punct	_	_
+27	die	der	DET	ART	Case=Nom|Definite=Def|Gender=Neut|Number=Plur|PronType=Art	29	det	_	_
+28	wachsenden	wachsend	ADJ	ADJA	Case=Nom|Gender=Neut|Number=Plur	29	amod	_	_
+29	Personalprobleme	Personalproblem	NOUN	NN	Case=Nom|Gender=Neut|Number=Plur	10	appos	_	_
+30	der	der	DET	ART	Case=Gen|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	31	det	_	_
+31	Bundeswehr	Bundeswehr	PROPN	NN	Case=Gen|Gender=Fem|Number=Sing	29	nmod	_	SpaceAfter=No
+32	.	.	PUNCT	$.	_	10	punct	_	_
 
 # sent_id = dev-s577
 # text = Nach Angaben von Bundesgeschäftsführer Franz Müntefering wird das Parteipräsidium unmittelbar nach der Abstimmung entscheiden, ``ob es Konsequenzen aus dieser Wahl geben muß''.
@@ -10104,66 +10126,69 @@
 20	.	.	PUNCT	$.	_	14	punct	_	_
 
 # sent_id = dev-s581
-# text = 33 000 Wahlbüros öffneten um acht Uhr und sollen um 19 Uhr schließen.
-1	33	33	NUM	CARD	NumType=Card	2	nummod	_	_
-2	000	000	NUM	CARD	NumType=Card	3	nummod	_	_
-3	Wahlbüros	Wahlbüro	NOUN	NN	Case=Nom|Gender=Neut|Number=Plur	4	nsubj	_	_
-4	öffneten	öffnen	VERB	VVFIN	Mood=Ind|Number=Plur|Person=3|Tense=Past|VerbForm=Fin	0	root	_	_
-5	um	um	ADP	APPR	_	7	case	_	_
-6	acht	acht	NUM	CARD	NumType=Card	7	nummod	_	_
-7	Uhr	Uhr	NOUN	NN	Gender=Fem	4	obl	_	_
-8	und	und	CCONJ	KON	_	13	cc	_	_
-9	sollen	sollen	AUX	VMFIN	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	13	aux	_	_
-10	um	um	ADP	APPR	_	12	case	_	_
-11	19	19	NUM	CARD	NumType=Card	12	nummod	_	_
-12	Uhr	Uhr	NOUN	NN	Gender=Fem	13	obl	_	_
-13	schließen	schließen	VERB	VVINF	VerbForm=Inf	4	conj	_	SpaceAfter=No
-14	.	.	PUNCT	$.	_	4	punct	_	_
+# text = Die 33 000 Wahlbüros öffneten um acht Uhr und sollen um 19 Uhr schließen.
+1	Die	der	DET	ART	Case=Nom|Definite=Def|Gender=Neut|Number=Plur|PronType=Art	2	dep	_	FixTigerDep=Yes
+2	33	33	NUM	CARD	NumType=Card	3	nummod	_	_
+3	000	000	NUM	CARD	NumType=Card	4	nummod	_	_
+4	Wahlbüros	Wahlbüro	NOUN	NN	Case=Nom|Gender=Neut|Number=Plur	5	nsubj	_	_
+5	öffneten	öffnen	VERB	VVFIN	Mood=Ind|Number=Plur|Person=3|Tense=Past|VerbForm=Fin	0	root	_	_
+6	um	um	ADP	APPR	_	8	case	_	_
+7	acht	acht	NUM	CARD	NumType=Card	8	nummod	_	_
+8	Uhr	Uhr	NOUN	NN	Gender=Fem	5	obl	_	_
+9	und	und	CCONJ	KON	_	14	cc	_	_
+10	sollen	sollen	AUX	VMFIN	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	14	aux	_	_
+11	um	um	ADP	APPR	_	13	case	_	_
+12	19	19	NUM	CARD	NumType=Card	13	nummod	_	_
+13	Uhr	Uhr	NOUN	NN	Gender=Fem	14	obl	_	_
+14	schließen	schließen	VERB	VVINF	VerbForm=Inf	5	conj	_	SpaceAfter=No
+15	.	.	PUNCT	$.	_	5	punct	_	_
 
 # sent_id = dev-s582
-# text = Ministerpräsident Gyula Horn hatte das Gesetz in einem Brief an seinen slowakischen Kollegen Vladimir Meciar als ``unannehmbaren Schritt zurück'' bezeichnet.
-1	Ministerpräsident	Ministerpräsident	NOUN	NN	Case=Nom|Gender=Masc|Number=Sing	22	nsubj	_	_
-2	Gyula	Gyula	PROPN	NE	Case=Nom|Gender=Masc|Number=Sing	1	appos	_	_
-3	Horn	Horn	PROPN	NE	Case=Nom|Gender=Masc|Number=Sing	2	flat	_	_
-4	hatte	haben	AUX	VAFIN	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	22	aux	_	_
-5	das	der	DET	ART	Case=Acc|Definite=Def|Gender=Neut|Number=Sing|PronType=Art	6	det	_	_
-6	Gesetz	Gesetz	NOUN	NN	Case=Acc|Gender=Neut|Number=Sing	22	obj	_	_
-7	in	in	ADP	APPR	_	9	case	_	_
-8	einem	ein	DET	ART	Case=Dat|Definite=Ind|Gender=Masc|Number=Sing|PronType=Art	9	det	_	_
-9	Brief	Brief	NOUN	NN	Case=Dat|Gender=Masc|Number=Sing	22	obl	_	_
-10	an	an	ADP	APPR	_	13	case	_	_
-11	seinen	sein	PRON	PPOSAT	Case=Acc|Gender=Masc|Number=Sing|Poss=Yes	13	det:poss	_	_
-12	slowakischen	slowakisch	ADJ	ADJA	Case=Acc|Gender=Masc|Number=Sing	13	amod	_	_
-13	Kollegen	Kollege	NOUN	NN	Case=Acc|Gender=Masc|Number=Sing	9	nmod	_	_
-14	Vladimir	Vladimir	PROPN	NE	Case=Nom|Gender=Masc|Number=Sing	13	appos	_	_
-15	Meciar	Meciar	PROPN	NE	Case=Nom|Gender=Masc|Number=Sing	14	flat	_	_
-16	als	als	ADP	APPR	_	19	case	_	_
-17	``	``	PUNCT	$(	_	19	punct	_	SpaceAfter=No
-18	unannehmbaren	unannehmbar	ADJ	ADJA	Case=Acc|Gender=Masc|Number=Sing	19	amod	_	_
-19	Schritt	Schritt	NOUN	NN	Case=Acc|Gender=Masc|Number=Sing	22	obl	_	_
-20	zurück	zurück	ADV	ADV	_	19	advmod	_	SpaceAfter=No
-21	''	''	PUNCT	$(	_	19	punct	_	_
-22	bezeichnet	bezeichnen	VERB	VVPP	VerbForm=Part	0	root	_	SpaceAfter=No
-23	.	.	PUNCT	$.	_	22	punct	_	_
+# text = Ungarns Ministerpräsident Gyula Horn hatte das Gesetz in einem Brief an seinen slowakischen Kollegen Vladimir Meciar als ``unannehmbaren Schritt zurück'' bezeichnet.
+1	Ungarns	Ungarn	PROPN	NE	Case=Gen|Gender=Neut|Number=Sing	2	dep	_	FixTigerDep=Yes
+2	Ministerpräsident	Ministerpräsident	NOUN	NN	Case=Nom|Gender=Masc|Number=Sing	23	nsubj	_	_
+3	Gyula	Gyula	PROPN	NE	Case=Nom|Gender=Masc|Number=Sing	2	appos	_	_
+4	Horn	Horn	PROPN	NE	Case=Nom|Gender=Masc|Number=Sing	3	flat	_	_
+5	hatte	haben	AUX	VAFIN	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	23	aux	_	_
+6	das	der	DET	ART	Case=Acc|Definite=Def|Gender=Neut|Number=Sing|PronType=Art	7	det	_	_
+7	Gesetz	Gesetz	NOUN	NN	Case=Acc|Gender=Neut|Number=Sing	23	obj	_	_
+8	in	in	ADP	APPR	_	10	case	_	_
+9	einem	ein	DET	ART	Case=Dat|Definite=Ind|Gender=Masc|Number=Sing|PronType=Art	10	det	_	_
+10	Brief	Brief	NOUN	NN	Case=Dat|Gender=Masc|Number=Sing	23	obl	_	_
+11	an	an	ADP	APPR	_	14	case	_	_
+12	seinen	sein	PRON	PPOSAT	Case=Acc|Gender=Masc|Number=Sing|Poss=Yes	14	det:poss	_	_
+13	slowakischen	slowakisch	ADJ	ADJA	Case=Acc|Gender=Masc|Number=Sing	14	amod	_	_
+14	Kollegen	Kollege	NOUN	NN	Case=Acc|Gender=Masc|Number=Sing	10	nmod	_	_
+15	Vladimir	Vladimir	PROPN	NE	Case=Nom|Gender=Masc|Number=Sing	14	appos	_	_
+16	Meciar	Meciar	PROPN	NE	Case=Nom|Gender=Masc|Number=Sing	15	flat	_	_
+17	als	als	ADP	APPR	_	20	case	_	_
+18	``	``	PUNCT	$(	_	20	punct	_	SpaceAfter=No
+19	unannehmbaren	unannehmbar	ADJ	ADJA	Case=Acc|Gender=Masc|Number=Sing	20	amod	_	_
+20	Schritt	Schritt	NOUN	NN	Case=Acc|Gender=Masc|Number=Sing	23	obl	_	_
+21	zurück	zurück	ADV	ADV	_	20	advmod	_	SpaceAfter=No
+22	''	''	PUNCT	$(	_	20	punct	_	_
+23	bezeichnet	bezeichnen	VERB	VVPP	VerbForm=Part	0	root	_	SpaceAfter=No
+24	.	.	PUNCT	$.	_	23	punct	_	_
 
 # sent_id = dev-s583
-# text = Bis auf einen einzigen sind alle 206 Alteigentümer diesem Vorschlag gefolgt'', berichtet Bauman.
-1	Bis	bis	ADP	APPR	_	11	case	_	_
-2	auf	auf	ADP	APPR	_	4	case	_	_
-3	einen	ein	DET	ART	Case=Acc|Definite=Ind|Gender=Masc|Number=Sing|PronType=Art	4	det	_	_
-4	einzigen	einzig	ADJ	ADJA	Case=Acc|Gender=Masc|Number=Sing	1	nmod	_	_
-5	sind	sein	AUX	VAFIN	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	11	aux	_	_
-6	alle	aller	ADJ	PIAT	Case=Nom|Definite=Ind|Gender=Masc|Number=Plur|PronType=Ind	8	det	_	_
-7	206	206	NUM	CARD	NumType=Card	8	nummod	_	_
-8	Alteigentümer	Alteigentümer	NOUN	NN	Case=Nom|Gender=Masc|Number=Plur	11	nsubj	_	_
-9	diesem	dies	PRON	PDAT	Case=Dat|Gender=Masc|Number=Sing|PronType=Dem	10	det	_	_
-10	Vorschlag	Vorschlag	NOUN	NN	Case=Dat|Gender=Masc|Number=Sing	11	iobj	_	_
-11	gefolgt	folgen	VERB	VVPP	VerbForm=Part	14	ccomp	_	SpaceAfter=No
-12	''	''	PUNCT	$(	_	14	punct	_	SpaceAfter=No
-13	,	,	PUNCT	$,	_	14	punct	_	_
-14	berichtet	berichten	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	0	root	_	_
-15	Bauman	Bauman	NOUN	NE	Case=Nom|Number=Sing	14	nsubj	_	SpaceAfter=No
-16	.	.	PUNCT	$.	_	14	punct	_	_
+# text = ``Bis auf einen einzigen sind alle 206 Alteigentümer diesem Vorschlag gefolgt'', berichtet Bauman.
+1	``	``	PUNCT	$(	_	2	punct	_	FixTigerDep=Yes|SpaceAfter=No
+2	Bis	bis	ADP	APPR	_	12	case	_	_
+3	auf	auf	ADP	APPR	_	5	case	_	_
+4	einen	ein	DET	ART	Case=Acc|Definite=Ind|Gender=Masc|Number=Sing|PronType=Art	5	det	_	_
+5	einzigen	einzig	ADJ	ADJA	Case=Acc|Gender=Masc|Number=Sing	2	nmod	_	_
+6	sind	sein	AUX	VAFIN	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	12	aux	_	_
+7	alle	aller	ADJ	PIAT	Case=Nom|Definite=Ind|Gender=Masc|Number=Plur|PronType=Ind	9	det	_	_
+8	206	206	NUM	CARD	NumType=Card	9	nummod	_	_
+9	Alteigentümer	Alteigentümer	NOUN	NN	Case=Nom|Gender=Masc|Number=Plur	12	nsubj	_	_
+10	diesem	dies	PRON	PDAT	Case=Dat|Gender=Masc|Number=Sing|PronType=Dem	11	det	_	_
+11	Vorschlag	Vorschlag	NOUN	NN	Case=Dat|Gender=Masc|Number=Sing	12	iobj	_	_
+12	gefolgt	folgen	VERB	VVPP	VerbForm=Part	15	ccomp	_	SpaceAfter=No
+13	''	''	PUNCT	$(	_	15	punct	_	SpaceAfter=No
+14	,	,	PUNCT	$,	_	15	punct	_	_
+15	berichtet	berichten	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	0	root	_	_
+16	Bauman	Bauman	NOUN	NE	Case=Nom|Number=Sing	15	nsubj	_	SpaceAfter=No
+17	.	.	PUNCT	$.	_	15	punct	_	_
 
 # sent_id = dev-s584
 # text = Da kann man unbefangener und flexibler reden und Politik machen.
@@ -10191,23 +10216,24 @@
 7	.	.	PUNCT	$.	_	5	punct	_	_
 
 # sent_id = dev-s586
-# text = Peter lädt in Mai und Oktober zu'' Wandern, Schauen und Erleben ``ein.
-1	Peter	Peter	PROPN	NE	Case=Nom|Gender=Neut|Number=Sing	2	nsubj	_	_
-2	lädt	laden	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	0	root	_	_
-3	in	in	ADP	APPR	_	4	case	_	_
-4	Mai	Mai	PROPN	NN	Case=Dat|Gender=Masc|Number=Sing	2	obl	_	_
-5	und	und	CCONJ	KON	_	6	cc	_	_
-6	Oktober	Oktober	PROPN	NN	Case=Dat|Gender=Masc|Number=Sing	4	conj	_	_
-7	zu	zu	ADP	APPR	_	9	case	_	SpaceAfter=No
-8	''	''	PUNCT	$(	_	9	punct	_	_
-9	Wandern	Wandern	NOUN	NN	Case=Dat|Gender=Neut|Number=Sing	2	obl	_	SpaceAfter=No
-10	,	,	PUNCT	$,	_	11	punct	_	_
-11	Schauen	Schauen	NOUN	NN	Case=Dat|Gender=Neut|Number=Sing	9	conj	_	_
-12	und	und	CCONJ	KON	_	13	cc	_	_
-13	Erleben	Erleben	NOUN	NN	Case=Dat|Gender=Neut|Number=Sing	9	conj	_	_
-14	``	``	PUNCT	$(	_	9	punct	_	SpaceAfter=No
-15	ein	ein	ADV	PTKVZ	_	2	compound:prt	_	SpaceAfter=No
-16	.	.	PUNCT	$.	_	2	punct	_	_
+# text = St. Peter lädt in Mai und Oktober zu'' Wandern, Schauen und Erleben ``ein.
+1	St.	St.	PROPN	NE	_	2	dep	_	FixTigerDep=Yes
+2	Peter	Peter	PROPN	NE	Case=Nom|Gender=Neut|Number=Sing	3	nsubj	_	_
+3	lädt	laden	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	0	root	_	_
+4	in	in	ADP	APPR	_	5	case	_	_
+5	Mai	Mai	PROPN	NN	Case=Dat|Gender=Masc|Number=Sing	3	obl	_	_
+6	und	und	CCONJ	KON	_	7	cc	_	_
+7	Oktober	Oktober	PROPN	NN	Case=Dat|Gender=Masc|Number=Sing	5	conj	_	_
+8	zu	zu	ADP	APPR	_	10	case	_	SpaceAfter=No
+9	''	''	PUNCT	$(	_	10	punct	_	_
+10	Wandern	Wandern	NOUN	NN	Case=Dat|Gender=Neut|Number=Sing	3	obl	_	SpaceAfter=No
+11	,	,	PUNCT	$,	_	12	punct	_	_
+12	Schauen	Schauen	NOUN	NN	Case=Dat|Gender=Neut|Number=Sing	10	conj	_	_
+13	und	und	CCONJ	KON	_	14	cc	_	_
+14	Erleben	Erleben	NOUN	NN	Case=Dat|Gender=Neut|Number=Sing	10	conj	_	_
+15	``	``	PUNCT	$(	_	10	punct	_	SpaceAfter=No
+16	ein	ein	ADV	PTKVZ	_	3	compound:prt	_	SpaceAfter=No
+17	.	.	PUNCT	$.	_	3	punct	_	_
 
 # sent_id = dev-s587
 # text = Das Bundessozialgericht (BSG) hat Zweifel an der Rechtmäßigkeit einer gesetzlichen Regelung geäußert, aufgrund derer Arbeitnehmer mit einer Beschäftigung von unter 18 Wochenstunden keinen Anspruch auf Arbeitslosengeld erwerben können.
@@ -10245,71 +10271,74 @@
 32	.	.	PUNCT	$.	_	14	punct	_	_
 
 # sent_id = dev-s588
-# text = 18 Staaten streben eine Freihandelszone bis zum Jahr 2020 an.
-1	18	18	NUM	CARD	NumType=Card	2	nummod	_	_
-2	Staaten	Staat	NOUN	NN	Case=Nom|Gender=Masc|Number=Plur	3	nsubj	_	_
-3	streben	streben	VERB	VVFIN	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	0	root	_	_
-4	eine	ein	DET	ART	Case=Acc|Definite=Ind|Gender=Fem|Number=Sing|PronType=Art	5	det	_	_
-5	Freihandelszone	Freihandelszone	NOUN	NN	Case=Acc|Gender=Fem|Number=Sing	3	obj	_	_
-6	bis	bis	ADP	APPR	_	3	case	_	_
-7-8	zum	_	_	_	_	_	_	_	_
-7	zu	zu	ADP	APPR	_	9	case	_	_
-8	dem	der	DET	ART	Case=Dat|Definite=Def|Gender=Neut|Number=Sing|PronType=Art	9	det	_	_
-9	Jahr	Jahr	NOUN	NN	Case=Dat|Gender=Neut|Number=Sing	6	nmod	_	_
-10	2020	2020	NUM	CARD	NumType=Card	9	nmod	_	_
-11	an	an	ADP	PTKVZ	_	3	compound:prt	_	SpaceAfter=No
-12	.	.	PUNCT	$.	_	3	punct	_	_
+# text = Die 18 Staaten streben eine Freihandelszone bis zum Jahr 2020 an.
+1	Die	der	DET	ART	Case=Nom|Definite=Def|Gender=Masc|Number=Plur|PronType=Art	2	dep	_	FixTigerDep=Yes
+2	18	18	NUM	CARD	NumType=Card	3	nummod	_	_
+3	Staaten	Staat	NOUN	NN	Case=Nom|Gender=Masc|Number=Plur	4	nsubj	_	_
+4	streben	streben	VERB	VVFIN	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	0	root	_	_
+5	eine	ein	DET	ART	Case=Acc|Definite=Ind|Gender=Fem|Number=Sing|PronType=Art	6	det	_	_
+6	Freihandelszone	Freihandelszone	NOUN	NN	Case=Acc|Gender=Fem|Number=Sing	4	obj	_	_
+7	bis	bis	ADP	APPR	_	4	case	_	_
+8-9	zum	_	_	_	_	_	_	_	_
+8	zu	zu	ADP	APPR	_	10	case	_	_
+9	dem	der	DET	ART	Case=Dat|Definite=Def|Gender=Neut|Number=Sing|PronType=Art	10	det	_	_
+10	Jahr	Jahr	NOUN	NN	Case=Dat|Gender=Neut|Number=Sing	7	nmod	_	_
+11	2020	2020	NUM	CARD	NumType=Card	10	nmod	_	_
+12	an	an	ADP	PTKVZ	_	4	compound:prt	_	SpaceAfter=No
+13	.	.	PUNCT	$.	_	4	punct	_	_
 
 # sent_id = dev-s589
-# text = Edelmetall setzt sich auf dem japanischen Markt durch, und in den USA steigt der Anteil von Platin am Geschäft mit Brautgeschenken und Eheringen.
-1	Edelmetall	Edelmetall	NOUN	NN	Case=Nom|Gender=Neut|Number=Sing	2	nsubj	_	_
-2	setzt	setzen	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	0	root	_	_
-3	sich	er|es|sie	PRON	PRF	Case=Acc|Number=Sing|Person=3|PronType=Prs|Reflex=Yes	2	obj	_	_
-4	auf	auf	ADP	APPR	_	7	case	_	_
-5	dem	der	DET	ART	Case=Dat|Definite=Def|Gender=Masc|Number=Sing|PronType=Art	7	det	_	_
-6	japanischen	japanisch	ADJ	ADJA	Case=Dat|Gender=Masc|Number=Sing	7	amod	_	_
-7	Markt	Markt	NOUN	NN	Case=Dat|Gender=Masc|Number=Sing	2	obl	_	_
-8	durch	durch	ADP	PTKVZ	_	2	compound:prt	_	SpaceAfter=No
-9	,	,	PUNCT	$,	_	14	punct	_	_
-10	und	und	CCONJ	KON	_	14	cc	_	_
-11	in	in	ADP	APPR	_	13	case	_	_
-12	den	der	DET	ART	Case=Dat|Definite=Def|Number=Plur|PronType=Art	13	det	_	_
-13	USA	USA	PROPN	NE	Case=Dat|Number=Sing	14	obl	_	_
-14	steigt	steigen	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	2	conj	_	_
-15	der	der	DET	ART	Case=Nom|Definite=Def|Gender=Masc|Number=Sing|PronType=Art	16	det	_	_
-16	Anteil	Anteil	NOUN	NN	Case=Nom|Gender=Masc|Number=Sing	14	nsubj	_	_
-17	von	von	ADP	APPR	_	18	case	_	_
-18	Platin	Platin	PROPN	NN	Case=Dat|Gender=Neut|Number=Sing	16	nmod	_	_
-19-20	am	_	_	_	_	_	_	_	_
-19	an	an	ADP	APPR	_	21	case	_	_
-20	dem	der	DET	ART	Case=Dat|Definite=Def|Gender=Neut|Number=Sing|PronType=Art	21	det	_	_
-21	Geschäft	Geschäft	NOUN	NN	Case=Dat|Gender=Neut|Number=Sing	16	nmod	_	_
-22	mit	mit	ADP	APPR	_	23	case	_	_
-23	Brautgeschenken	Brautgeschenk	NOUN	NN	Case=Dat|Gender=Neut|Number=Plur	21	nmod	_	_
-24	und	und	CCONJ	KON	_	25	cc	_	_
-25	Eheringen	Ehering	NOUN	NN	Case=Dat|Gender=Masc|Number=Plur	23	conj	_	SpaceAfter=No
-26	.	.	PUNCT	$.	_	2	punct	_	_
+# text = Das Edelmetall setzt sich auf dem japanischen Markt durch, und in den USA steigt der Anteil von Platin am Geschäft mit Brautgeschenken und Eheringen.
+1	Das	der	DET	ART	Case=Nom|Definite=Def|Gender=Neut|Number=Sing|PronType=Art	2	dep	_	FixTigerDep=Yes
+2	Edelmetall	Edelmetall	NOUN	NN	Case=Nom|Gender=Neut|Number=Sing	3	nsubj	_	_
+3	setzt	setzen	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	0	root	_	_
+4	sich	er|es|sie	PRON	PRF	Case=Acc|Number=Sing|Person=3|PronType=Prs|Reflex=Yes	3	obj	_	_
+5	auf	auf	ADP	APPR	_	8	case	_	_
+6	dem	der	DET	ART	Case=Dat|Definite=Def|Gender=Masc|Number=Sing|PronType=Art	8	det	_	_
+7	japanischen	japanisch	ADJ	ADJA	Case=Dat|Gender=Masc|Number=Sing	8	amod	_	_
+8	Markt	Markt	NOUN	NN	Case=Dat|Gender=Masc|Number=Sing	3	obl	_	_
+9	durch	durch	ADP	PTKVZ	_	3	compound:prt	_	SpaceAfter=No
+10	,	,	PUNCT	$,	_	15	punct	_	_
+11	und	und	CCONJ	KON	_	15	cc	_	_
+12	in	in	ADP	APPR	_	14	case	_	_
+13	den	der	DET	ART	Case=Dat|Definite=Def|Number=Plur|PronType=Art	14	det	_	_
+14	USA	USA	PROPN	NE	Case=Dat|Number=Sing	15	obl	_	_
+15	steigt	steigen	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	3	conj	_	_
+16	der	der	DET	ART	Case=Nom|Definite=Def|Gender=Masc|Number=Sing|PronType=Art	17	det	_	_
+17	Anteil	Anteil	NOUN	NN	Case=Nom|Gender=Masc|Number=Sing	15	nsubj	_	_
+18	von	von	ADP	APPR	_	19	case	_	_
+19	Platin	Platin	PROPN	NN	Case=Dat|Gender=Neut|Number=Sing	17	nmod	_	_
+20-21	am	_	_	_	_	_	_	_	_
+20	an	an	ADP	APPR	_	22	case	_	_
+21	dem	der	DET	ART	Case=Dat|Definite=Def|Gender=Neut|Number=Sing|PronType=Art	22	det	_	_
+22	Geschäft	Geschäft	NOUN	NN	Case=Dat|Gender=Neut|Number=Sing	17	nmod	_	_
+23	mit	mit	ADP	APPR	_	24	case	_	_
+24	Brautgeschenken	Brautgeschenk	NOUN	NN	Case=Dat|Gender=Neut|Number=Plur	22	nmod	_	_
+25	und	und	CCONJ	KON	_	26	cc	_	_
+26	Eheringen	Ehering	NOUN	NN	Case=Dat|Gender=Masc|Number=Plur	24	conj	_	SpaceAfter=No
+27	.	.	PUNCT	$.	_	3	punct	_	_
 
 # sent_id = dev-s590
-# text = Horst Görtz denkt für die nächsten achtzehn Monate an einen Börsengang an der Nasdaq in den USA.
-1	Horst	Horst	PROPN	NE	Case=Nom|Gender=Masc|Number=Sing	3	nsubj	_	_
-2	Görtz	Görtz	PROPN	NE	Case=Nom|Gender=Masc|Number=Sing	1	flat	_	_
-3	denkt	denken	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	0	root	_	_
-4	für	für	ADP	APPR	_	8	case	_	_
-5	die	der	DET	ART	Case=Acc|Definite=Def|Gender=Masc|Number=Plur|PronType=Art	8	det	_	_
-6	nächsten	nächster	ADJ	ADJA	Case=Acc|Gender=Masc|Number=Plur	8	amod	_	_
-7	achtzehn	achtzehn	NUM	CARD	NumType=Card	8	nummod	_	_
-8	Monate	Monat	NOUN	NN	Case=Acc|Gender=Masc|Number=Plur	3	obl	_	_
-9	an	an	ADP	APPR	_	11	case	_	_
-10	einen	ein	DET	ART	Case=Acc|Definite=Ind|Gender=Masc|Number=Sing|PronType=Art	11	det	_	_
-11	Börsengang	Börsengang	NOUN	NN	Case=Acc|Gender=Masc|Number=Sing	3	obl	_	_
-12	an	an	ADP	APPR	_	14	case	_	_
-13	der	der	DET	ART	Case=Dat|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	14	det	_	_
-14	Nasdaq	Nasdaq	PROPN	NE	Case=Dat|Gender=Fem|Number=Sing	11	nmod	_	_
-15	in	in	ADP	APPR	_	17	case	_	_
-16	den	der	DET	ART	Case=Dat|Definite=Def|Number=Plur|PronType=Art	17	det	_	_
-17	USA	USA	PROPN	NE	Case=Dat|Number=Plur	14	nmod	_	SpaceAfter=No
-18	.	.	PUNCT	$.	_	3	punct	_	_
+# text = Vorstandschef Horst Görtz denkt für die nächsten achtzehn Monate an einen Börsengang an der Nasdaq in den USA.
+1	Vorstandschef	Vorstandschef	NOUN	NN	Case=Nom|Gender=Masc|Number=Sing	2	dep	_	FixTigerDep=Yes
+2	Horst	Horst	PROPN	NE	Case=Nom|Gender=Masc|Number=Sing	4	nsubj	_	_
+3	Görtz	Görtz	PROPN	NE	Case=Nom|Gender=Masc|Number=Sing	2	flat	_	_
+4	denkt	denken	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	0	root	_	_
+5	für	für	ADP	APPR	_	9	case	_	_
+6	die	der	DET	ART	Case=Acc|Definite=Def|Gender=Masc|Number=Plur|PronType=Art	9	det	_	_
+7	nächsten	nächster	ADJ	ADJA	Case=Acc|Gender=Masc|Number=Plur	9	amod	_	_
+8	achtzehn	achtzehn	NUM	CARD	NumType=Card	9	nummod	_	_
+9	Monate	Monat	NOUN	NN	Case=Acc|Gender=Masc|Number=Plur	4	obl	_	_
+10	an	an	ADP	APPR	_	12	case	_	_
+11	einen	ein	DET	ART	Case=Acc|Definite=Ind|Gender=Masc|Number=Sing|PronType=Art	12	det	_	_
+12	Börsengang	Börsengang	NOUN	NN	Case=Acc|Gender=Masc|Number=Sing	4	obl	_	_
+13	an	an	ADP	APPR	_	15	case	_	_
+14	der	der	DET	ART	Case=Dat|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	15	det	_	_
+15	Nasdaq	Nasdaq	PROPN	NE	Case=Dat|Gender=Fem|Number=Sing	12	nmod	_	_
+16	in	in	ADP	APPR	_	18	case	_	_
+17	den	der	DET	ART	Case=Dat|Definite=Def|Number=Plur|PronType=Art	18	det	_	_
+18	USA	USA	PROPN	NE	Case=Dat|Number=Plur	15	nmod	_	SpaceAfter=No
+19	.	.	PUNCT	$.	_	4	punct	_	_
 
 # sent_id = dev-s591
 # text = Die Medizintechnik -- und Pharmakonzern Fresenius will künftig nur noch jenseits der Grenzen in Erweiterungsprojekte investieren, berichtet Firmenchef Gerd Krick.
@@ -10363,44 +10392,47 @@
 8	.	.	PUNCT	$.	_	3	punct	_	_
 
 # sent_id = dev-s594
-# text = Sie braucht Klarheit, auch personelle Klarheit'', sagt er.
-1	Sie	Sie|sie	PRON	PPER	Case=Nom|Gender=Fem|Number=Sing|Person=3|PronType=Prs	2	nsubj	_	_
-2	braucht	brauchen	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	10	ccomp	_	_
-3	Klarheit	Klarheit	NOUN	NN	Case=Acc|Gender=Fem|Number=Sing	2	obj	_	SpaceAfter=No
-4	,	,	PUNCT	$,	_	10	punct	_	_
-5	auch	auch	ADV	ADV	_	7	advmod	_	_
-6	personelle	personell	ADJ	ADJA	Case=Acc|Gender=Fem|Number=Sing	7	amod	_	_
-7	Klarheit	Klarheit	NOUN	NN	Case=Acc|Gender=Fem|Number=Sing	3	appos	_	SpaceAfter=No
-8	''	''	PUNCT	$(	_	10	punct	_	SpaceAfter=No
-9	,	,	PUNCT	$,	_	10	punct	_	_
-10	sagt	sagen	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	0	root	_	_
-11	er	er	PRON	PPER	Case=Nom|Gender=Masc|Number=Sing|Person=3|PronType=Prs	10	nsubj	_	SpaceAfter=No
-12	.	.	PUNCT	$.	_	10	punct	_	_
+# text = ``Sie braucht Klarheit, auch personelle Klarheit'', sagt er.
+1	``	``	PUNCT	$(	_	2	punct	_	FixTigerDep=Yes|SpaceAfter=No
+2	Sie	Sie|sie	PRON	PPER	Case=Nom|Gender=Fem|Number=Sing|Person=3|PronType=Prs	3	nsubj	_	_
+3	braucht	brauchen	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	11	ccomp	_	_
+4	Klarheit	Klarheit	NOUN	NN	Case=Acc|Gender=Fem|Number=Sing	3	obj	_	SpaceAfter=No
+5	,	,	PUNCT	$,	_	11	punct	_	_
+6	auch	auch	ADV	ADV	_	8	advmod	_	_
+7	personelle	personell	ADJ	ADJA	Case=Acc|Gender=Fem|Number=Sing	8	amod	_	_
+8	Klarheit	Klarheit	NOUN	NN	Case=Acc|Gender=Fem|Number=Sing	4	appos	_	SpaceAfter=No
+9	''	''	PUNCT	$(	_	11	punct	_	SpaceAfter=No
+10	,	,	PUNCT	$,	_	11	punct	_	_
+11	sagt	sagen	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	0	root	_	_
+12	er	er	PRON	PPER	Case=Nom|Gender=Masc|Number=Sing|Person=3|PronType=Prs	11	nsubj	_	SpaceAfter=No
+13	.	.	PUNCT	$.	_	11	punct	_	_
 
 # sent_id = dev-s595
-# text = Präsident Bill Clinton sagte am Donnerstag die Teilnahme am Asien-Pazifik-Gipfel in Japan ab.
-1	Präsident	Präsident	NOUN	NN	Case=Nom|Gender=Masc|Number=Sing	4	nsubj	_	_
-2	Bill	Bill	PROPN	NE	Case=Nom|Gender=Masc|Number=Sing	1	appos	_	_
-3	Clinton	Clinton	PROPN	NE	Case=Nom|Gender=Masc|Number=Sing	2	flat	_	_
-4	sagte	sagen	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	0	root	_	_
-5-6	am	_	_	_	_	_	_	_	_
-5	an	an	ADP	APPR	_	7	case	_	_
-6	dem	der	DET	ART	Case=Dat|Definite=Def|Gender=Masc|Number=Sing|PronType=Art	7	det	_	_
-7	Donnerstag	Donnerstag	PROPN	NN	Case=Dat|Gender=Masc|Number=Sing	4	obl	_	_
-8	die	der	DET	ART	Case=Acc|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	9	det	_	_
-9	Teilnahme	Teilnahme	NOUN	NN	Case=Acc|Gender=Fem|Number=Sing	4	obj	_	_
-10-11	am	_	_	_	_	_	_	_	_
-10	an	an	ADP	APPR	_	12	case	_	_
-11	dem	der	DET	ART	Case=Dat|Definite=Def|Gender=Neut|Number=Sing|PronType=Art	12	det	_	_
-12	Asien	Asien	PROPN	NN	Case=Dat|Gender=Masc|Number=Sing	14	compound	_	SpaceAfter=No
-13	-	-	PUNCT	$(	_	12	punct	_	SpaceAfter=No
-14	Pazifik	Pazifik	PROPN	NN	Case=Dat|Gender=Masc|Number=Sing	16	compound	_	SpaceAfter=No
+# text = US-Präsident Bill Clinton sagte am Donnerstag die Teilnahme am Asien-Pazifik-Gipfel in Japan ab.
+1	US	US	NOUN	NN	Case=Nom|Gender=Masc|Number=Sing	3	compound	_	SpaceAfter=No
+2	-	-	PUNCT	_	_	3	punct	_	SpaceAfter=No
+3	Präsident	Präsident	NOUN	NN	Case=Nom|Gender=Masc|Number=Sing	6	nsubj	_	_
+4	Bill	Bill	PROPN	NE	Case=Nom|Gender=Masc|Number=Sing	1	appos	_	_
+5	Clinton	Clinton	PROPN	NE	Case=Nom|Gender=Masc|Number=Sing	4	flat	_	_
+6	sagte	sagen	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	0	root	_	_
+7-8	am	_	_	_	_	_	_	_	_
+7	an	an	ADP	APPR	_	9	case	_	_
+8	dem	der	DET	ART	Case=Dat|Definite=Def|Gender=Masc|Number=Sing|PronType=Art	9	det	_	_
+9	Donnerstag	Donnerstag	PROPN	NN	Case=Dat|Gender=Masc|Number=Sing	6	obl	_	_
+10	die	der	DET	ART	Case=Acc|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	11	det	_	_
+11	Teilnahme	Teilnahme	NOUN	NN	Case=Acc|Gender=Fem|Number=Sing	6	obj	_	_
+12-13	am	_	_	_	_	_	_	_	_
+12	an	an	ADP	APPR	_	14	case	_	_
+13	dem	der	DET	ART	Case=Dat|Definite=Def|Gender=Neut|Number=Sing|PronType=Art	14	det	_	_
+14	Asien	Asien	PROPN	NN	Case=Dat|Gender=Masc|Number=Sing	16	compound	_	SpaceAfter=No
 15	-	-	PUNCT	$(	_	14	punct	_	SpaceAfter=No
-16	Gipfel	Gipfel	NOUN	NN	Case=Dat|Gender=Masc|Number=Sing	9	nmod	_	_
-17	in	in	ADP	APPR	_	18	case	_	_
-18	Japan	Japan	PROPN	NE	Case=Dat|Gender=Neut|Number=Sing	12	nmod	_	_
-19	ab	ab	ADP	PTKVZ	_	4	compound:prt	_	SpaceAfter=No
-20	.	.	PUNCT	$.	_	4	punct	_	_
+16	Pazifik	Pazifik	PROPN	NN	Case=Dat|Gender=Masc|Number=Sing	18	compound	_	SpaceAfter=No
+17	-	-	PUNCT	$(	_	16	punct	_	SpaceAfter=No
+18	Gipfel	Gipfel	NOUN	NN	Case=Dat|Gender=Masc|Number=Sing	11	nmod	_	_
+19	in	in	ADP	APPR	_	20	case	_	_
+20	Japan	Japan	PROPN	NE	Case=Dat|Gender=Neut|Number=Sing	14	nmod	_	_
+21	ab	ab	ADP	PTKVZ	_	6	compound:prt	_	SpaceAfter=No
+22	.	.	PUNCT	$.	_	6	punct	_	_
 
 # sent_id = dev-s596
 # text = France Telecom hat uns ein Angebot unterbreitet'', erklärt ein Sprecher.
@@ -10429,39 +10461,40 @@
 7	.	.	PUNCT	$.	_	6	punct	_	_
 
 # sent_id = dev-s598
-# text = Leider gibt es in der Tat eine Reihe von Unternehmen, die mit Schmiergeldzahlungen an öffentliche Aufträge gelangt sind'', sagte er bei einer vom BVMB veranstalteten Tagung.
-1	Leider	leider	ADV	ADV	_	2	advmod	_	_
-2	gibt	geben	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	22	ccomp	_	_
-3	es	es	PRON	PPER	Case=Nom|Gender=Neut|Number=Sing|Person=3|PronType=Prs	2	nsubj	_	_
-4	in	in	ADP	APPR	_	6	case	_	_
-5	der	der	DET	ART	Case=Dat|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	6	det	_	_
-6	Tat	Tat	NOUN	NN	Case=Dat|Gender=Fem|Number=Sing	2	obl	_	_
-7	eine	ein	DET	ART	Case=Acc|Definite=Ind|Gender=Fem|Number=Sing|PronType=Art	8	det	_	_
-8	Reihe	Reihe	NOUN	NN	Case=Acc|Gender=Fem|Number=Sing	2	obj	_	_
-9	von	von	ADP	APPR	_	10	case	_	_
-10	Unternehmen	Unternehmen	NOUN	NN	Case=Dat|Gender=Neut|Number=Plur	8	nmod	_	SpaceAfter=No
-11	,	,	PUNCT	$,	_	22	punct	_	_
-12	die	der	PRON	PRELS	Case=Nom|Gender=Neut|Number=Plur|PronType=Rel	18	nsubj	_	_
-13	mit	mit	ADP	APPR	_	14	case	_	_
-14	Schmiergeldzahlungen	Schmiergeldzahlung	NOUN	NN	Case=Dat|Gender=Fem|Number=Plur	18	obl	_	_
-15	an	an	ADP	APPR	_	17	case	_	_
-16	öffentliche	öffentlich	ADJ	ADJA	Case=Acc|Gender=Masc|Number=Plur	17	amod	_	_
-17	Aufträge	Auftrag	NOUN	NN	Case=Acc|Gender=Masc|Number=Plur	18	obl	_	_
-18	gelangt	gelangen	VERB	VVPP	VerbForm=Part	10	acl	_	_
-19	sind	sein	AUX	VAFIN	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	18	aux	_	SpaceAfter=No
-20	''	''	PUNCT	$(	_	22	punct	_	SpaceAfter=No
-21	,	,	PUNCT	$,	_	22	punct	_	_
-22	sagte	sagen	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	0	root	_	_
-23	er	er	PRON	PPER	Case=Nom|Gender=Masc|Number=Sing|Person=3|PronType=Prs	22	nsubj	_	_
-24	bei	bei	ADP	APPR	_	30	case	_	_
-25	einer	ein	DET	ART	Case=Dat|Definite=Ind|Gender=Fem|Number=Sing|PronType=Art	30	det	_	_
-26-27	vom	_	_	_	_	_	_	_	_
-26	von	von	ADP	APPR	_	28	case	_	_
-27	dem	der	DET	ART	Case=Dat|Definite=Def|Gender=Masc|Number=Sing|PronType=Art	28	det	_	_
-28	BVMB	BVMB	PROPN	NE	Case=Dat|Number=Sing	29	nmod	_	_
-29	veranstalteten	veranstaltet	ADJ	ADJA	Case=Dat|Gender=Fem|Number=Sing	30	amod	_	_
-30	Tagung	Tagung	NOUN	NN	Case=Dat|Gender=Fem|Number=Sing	22	obl	_	SpaceAfter=No
-31	.	.	PUNCT	$.	_	22	punct	_	_
+# text = ``Leider gibt es in der Tat eine Reihe von Unternehmen, die mit Schmiergeldzahlungen an öffentliche Aufträge gelangt sind'', sagte er bei einer vom BVMB veranstalteten Tagung.
+1	``	``	PUNCT	$(	_	2	punct	_	FixTigerDep=Yes|SpaceAfter=No
+2	Leider	leider	ADV	ADV	_	3	advmod	_	_
+3	gibt	geben	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	23	ccomp	_	_
+4	es	es	PRON	PPER	Case=Nom|Gender=Neut|Number=Sing|Person=3|PronType=Prs	3	nsubj	_	_
+5	in	in	ADP	APPR	_	7	case	_	_
+6	der	der	DET	ART	Case=Dat|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	7	det	_	_
+7	Tat	Tat	NOUN	NN	Case=Dat|Gender=Fem|Number=Sing	3	obl	_	_
+8	eine	ein	DET	ART	Case=Acc|Definite=Ind|Gender=Fem|Number=Sing|PronType=Art	9	det	_	_
+9	Reihe	Reihe	NOUN	NN	Case=Acc|Gender=Fem|Number=Sing	3	obj	_	_
+10	von	von	ADP	APPR	_	11	case	_	_
+11	Unternehmen	Unternehmen	NOUN	NN	Case=Dat|Gender=Neut|Number=Plur	9	nmod	_	SpaceAfter=No
+12	,	,	PUNCT	$,	_	23	punct	_	_
+13	die	der	PRON	PRELS	Case=Nom|Gender=Neut|Number=Plur|PronType=Rel	19	nsubj	_	_
+14	mit	mit	ADP	APPR	_	15	case	_	_
+15	Schmiergeldzahlungen	Schmiergeldzahlung	NOUN	NN	Case=Dat|Gender=Fem|Number=Plur	19	obl	_	_
+16	an	an	ADP	APPR	_	18	case	_	_
+17	öffentliche	öffentlich	ADJ	ADJA	Case=Acc|Gender=Masc|Number=Plur	18	amod	_	_
+18	Aufträge	Auftrag	NOUN	NN	Case=Acc|Gender=Masc|Number=Plur	19	obl	_	_
+19	gelangt	gelangen	VERB	VVPP	VerbForm=Part	11	acl	_	_
+20	sind	sein	AUX	VAFIN	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	19	aux	_	SpaceAfter=No
+21	''	''	PUNCT	$(	_	23	punct	_	SpaceAfter=No
+22	,	,	PUNCT	$,	_	23	punct	_	_
+23	sagte	sagen	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	0	root	_	_
+24	er	er	PRON	PPER	Case=Nom|Gender=Masc|Number=Sing|Person=3|PronType=Prs	23	nsubj	_	_
+25	bei	bei	ADP	APPR	_	31	case	_	_
+26	einer	ein	DET	ART	Case=Dat|Definite=Ind|Gender=Fem|Number=Sing|PronType=Art	31	det	_	_
+27-28	vom	_	_	_	_	_	_	_	_
+27	von	von	ADP	APPR	_	29	case	_	_
+28	dem	der	DET	ART	Case=Dat|Definite=Def|Gender=Masc|Number=Sing|PronType=Art	29	det	_	_
+29	BVMB	BVMB	PROPN	NE	Case=Dat|Number=Sing	30	nmod	_	_
+30	veranstalteten	veranstaltet	ADJ	ADJA	Case=Dat|Gender=Fem|Number=Sing	31	amod	_	_
+31	Tagung	Tagung	NOUN	NN	Case=Dat|Gender=Fem|Number=Sing	23	obl	_	SpaceAfter=No
+32	.	.	PUNCT	$.	_	23	punct	_	_
 
 # sent_id = dev-s599
 # text = Der PDS-Vorsitzende Lothar Bisky äußerte die Hoffnung, daß die Sozialdemokraten nun den Mut zu einem Kurswechsel im Umgang mit der PDS aufbrächten.
@@ -10554,22 +10587,23 @@
 28	.	.	PUNCT	$.	_	3	punct	_	_
 
 # sent_id = dev-s602
-# text = Hamas warf den Behörden vor, es habe bei der Abstimmung große Unregelmäßigkeiten gegeben.
-1	Hamas	Hamas	PROPN	NE	Case=Nom|Gender=Fem|Number=Sing	2	nsubj	_	_
-2	warf	werfen	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	0	root	_	_
-3	den	der	DET	ART	Case=Dat|Definite=Def|Gender=Fem|Number=Plur|PronType=Art	4	det	_	_
-4	Behörden	Behörde	NOUN	NN	Case=Dat|Gender=Fem|Number=Plur	2	iobj	_	_
-5	vor	vor	ADP	PTKVZ	_	2	compound:prt	_	SpaceAfter=No
-6	,	,	PUNCT	$,	_	2	punct	_	_
-7	es	es	PRON	PPER	Case=Nom|Gender=Neut|Number=Sing|Person=3|PronType=Prs	14	nsubj	_	_
-8	habe	haben	AUX	VAFIN	Mood=Sub|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	14	aux	_	_
-9	bei	bei	ADP	APPR	_	11	case	_	_
-10	der	der	DET	ART	Case=Dat|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	11	det	_	_
-11	Abstimmung	Abstimmung	NOUN	NN	Case=Dat|Gender=Fem|Number=Sing	14	obl	_	_
-12	große	groß	ADJ	ADJA	Case=Acc|Gender=Fem|Number=Plur	13	amod	_	_
-13	Unregelmäßigkeiten	Unregelmäßigkeit	NOUN	NN	Case=Acc|Gender=Fem|Number=Plur	14	obj	_	_
-14	gegeben	geben	VERB	VVPP	VerbForm=Part	2	ccomp	_	SpaceAfter=No
-15	.	.	PUNCT	$.	_	2	punct	_	_
+# text = Die Hamas warf den Behörden vor, es habe bei der Abstimmung große Unregelmäßigkeiten gegeben.
+1	Die	der	DET	ART	Case=Nom|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	2	dep	_	FixTigerDep=Yes
+2	Hamas	Hamas	PROPN	NE	Case=Nom|Gender=Fem|Number=Sing	3	nsubj	_	_
+3	warf	werfen	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	0	root	_	_
+4	den	der	DET	ART	Case=Dat|Definite=Def|Gender=Fem|Number=Plur|PronType=Art	5	det	_	_
+5	Behörden	Behörde	NOUN	NN	Case=Dat|Gender=Fem|Number=Plur	3	iobj	_	_
+6	vor	vor	ADP	PTKVZ	_	3	compound:prt	_	SpaceAfter=No
+7	,	,	PUNCT	$,	_	3	punct	_	_
+8	es	es	PRON	PPER	Case=Nom|Gender=Neut|Number=Sing|Person=3|PronType=Prs	15	nsubj	_	_
+9	habe	haben	AUX	VAFIN	Mood=Sub|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	15	aux	_	_
+10	bei	bei	ADP	APPR	_	12	case	_	_
+11	der	der	DET	ART	Case=Dat|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	12	det	_	_
+12	Abstimmung	Abstimmung	NOUN	NN	Case=Dat|Gender=Fem|Number=Sing	15	obl	_	_
+13	große	groß	ADJ	ADJA	Case=Acc|Gender=Fem|Number=Plur	14	amod	_	_
+14	Unregelmäßigkeiten	Unregelmäßigkeit	NOUN	NN	Case=Acc|Gender=Fem|Number=Plur	15	obj	_	_
+15	gegeben	geben	VERB	VVPP	VerbForm=Part	3	ccomp	_	SpaceAfter=No
+16	.	.	PUNCT	$.	_	3	punct	_	_
 
 # sent_id = dev-s603
 # text = Die Teilnehmer der Tagung waren sich darüber einig, daß zwischen deren Erwerbstätigkeit und Ausbeutung unterschieden werden müsse.
@@ -10620,66 +10654,69 @@
 6	.	.	PUNCT	$.	_	4	punct	_	_
 
 # sent_id = dev-s606
-# text = Menschen, die meisten deutschsprechend, leben in den vier Orten St. Pankraz, St. Walburg, St. Nikolaus und St. Gertraud.
-1	Menschen	Mensch	NOUN	NN	Case=Nom|Gender=Masc|Number=Plur	7	nsubj	_	SpaceAfter=No
-2	,	,	PUNCT	$,	_	7	punct	_	_
-3	die	der	DET	ART	Case=Nom|Definite=Def|Gender=Masc|Number=Plur|PronType=Art	4	det	_	_
-4	meisten	meist	PRON	PIS	Case=Nom|Definite=Ind|Gender=Masc|Number=Plur|PronType=Ind	1	appos	_	_
-5	deutschsprechend	deutschsprechend	ADV	ADJD	_	4	advmod	_	SpaceAfter=No
-6	,	,	PUNCT	$,	_	7	punct	_	_
-7	leben	leben	VERB	VVFIN	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	0	root	_	_
-8	in	in	ADP	APPR	_	11	case	_	_
-9	den	der	DET	ART	Case=Dat|Definite=Def|Gender=Masc|Number=Plur|PronType=Art	11	det	_	_
-10	vier	vier	NUM	CARD	NumType=Card	11	nummod	_	_
-11	Orten	Ort	NOUN	NN	Case=Dat|Gender=Masc|Number=Plur	7	obl	_	_
-12	St.	St.	NOUN	ADJA	_	13	compound	_	_
-13	Pankraz	Pankraz	PROPN	NE	Case=Nom|Gender=Neut|Number=Sing	11	appos	_	SpaceAfter=No
-14	,	,	PUNCT	$,	_	16	punct	_	_
-15	St.	St.	NOUN	ADJA	_	16	compound	_	_
-16	Walburg	Walburg	PROPN	NE	Case=Nom|Gender=Neut|Number=Sing	13	conj	_	SpaceAfter=No
-17	,	,	PUNCT	$,	_	19	punct	_	_
-18	St.	St.	NOUN	ADJA	_	19	compound	_	_
-19	Nikolaus	Nikolaus	PROPN	NE	Case=Nom|Gender=Neut|Number=Sing	13	conj	_	_
-20	und	und	CCONJ	KON	_	22	cc	_	_
-21	St.	St.	NOUN	ADJA	_	22	compound	_	_
-22	Gertraud	Gertraud	PROPN	NE	Case=Nom|Gender=Neut|Number=Sing	13	conj	_	SpaceAfter=No
-23	.	.	PUNCT	$.	_	7	punct	_	_
+# text = 4600 Menschen, die meisten deutschsprechend, leben in den vier Orten St. Pankraz, St. Walburg, St. Nikolaus und St. Gertraud.
+1	4600	4600	NUM	CARD	NumType=Card	2	dep	_	FixTigerDep=Yes
+2	Menschen	Mensch	NOUN	NN	Case=Nom|Gender=Masc|Number=Plur	8	nsubj	_	SpaceAfter=No
+3	,	,	PUNCT	$,	_	8	punct	_	_
+4	die	der	DET	ART	Case=Nom|Definite=Def|Gender=Masc|Number=Plur|PronType=Art	5	det	_	_
+5	meisten	meist	PRON	PIS	Case=Nom|Definite=Ind|Gender=Masc|Number=Plur|PronType=Ind	2	appos	_	_
+6	deutschsprechend	deutschsprechend	ADV	ADJD	_	5	advmod	_	SpaceAfter=No
+7	,	,	PUNCT	$,	_	8	punct	_	_
+8	leben	leben	VERB	VVFIN	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	0	root	_	_
+9	in	in	ADP	APPR	_	12	case	_	_
+10	den	der	DET	ART	Case=Dat|Definite=Def|Gender=Masc|Number=Plur|PronType=Art	12	det	_	_
+11	vier	vier	NUM	CARD	NumType=Card	12	nummod	_	_
+12	Orten	Ort	NOUN	NN	Case=Dat|Gender=Masc|Number=Plur	8	obl	_	_
+13	St.	St.	NOUN	ADJA	_	14	compound	_	_
+14	Pankraz	Pankraz	PROPN	NE	Case=Nom|Gender=Neut|Number=Sing	12	appos	_	SpaceAfter=No
+15	,	,	PUNCT	$,	_	17	punct	_	_
+16	St.	St.	NOUN	ADJA	_	17	compound	_	_
+17	Walburg	Walburg	PROPN	NE	Case=Nom|Gender=Neut|Number=Sing	14	conj	_	SpaceAfter=No
+18	,	,	PUNCT	$,	_	20	punct	_	_
+19	St.	St.	NOUN	ADJA	_	20	compound	_	_
+20	Nikolaus	Nikolaus	PROPN	NE	Case=Nom|Gender=Neut|Number=Sing	14	conj	_	_
+21	und	und	CCONJ	KON	_	23	cc	_	_
+22	St.	St.	NOUN	ADJA	_	23	compound	_	_
+23	Gertraud	Gertraud	PROPN	NE	Case=Nom|Gender=Neut|Number=Sing	14	conj	_	SpaceAfter=No
+24	.	.	PUNCT	$.	_	8	punct	_	_
 
 # sent_id = dev-s607
-# text = Straßen mit Kopfsteinpflaster und pastellfarbene Gipsfassaden aus dem 18. Jahrhundert machen das Boheme-Viertel interessant.
-1	Straßen	Straße	NOUN	NN	Case=Nom|Gender=Fem|Number=Plur	11	nsubj	_	_
-2	mit	mit	ADP	APPR	_	3	case	_	_
-3	Kopfsteinpflaster	Kopfsteinpflaster	NOUN	NN	Case=Dat|Gender=Neut|Number=Sing	1	nmod	_	_
-4	und	und	CCONJ	KON	_	6	cc	_	_
-5	pastellfarbene	pastellfarben	ADJ	ADJA	Case=Nom|Gender=Fem|Number=Plur	6	amod	_	_
-6	Gipsfassaden	Gipsfassade	NOUN	NN	Case=Nom|Gender=Fem|Number=Plur	1	conj	_	_
-7	aus	aus	ADP	APPR	_	10	case	_	_
-8	dem	der	DET	ART	Case=Dat|Definite=Def|Gender=Neut|Number=Sing|PronType=Art	10	det	_	_
-9	18.	18	ADJ	ADJA	Case=Dat|Gender=Neut|Number=Sing	10	amod	_	_
-10	Jahrhundert	Jahrhundert	NOUN	NN	Case=Dat|Gender=Neut|Number=Sing	1	nmod	_	_
-11	machen	machen	VERB	VVFIN	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	0	root	_	_
-12	das	der	DET	ART	Case=Acc|Definite=Def|Gender=Neut|Number=Sing|PronType=Art	15	det	_	_
-13	Boheme	Boheme	NOUN	NN	Case=Acc|Gender=Neut|Number=Sing	15	compound	_	SpaceAfter=No
-14	-	-	PUNCT	$(	_	13	punct	_	SpaceAfter=No
-15	Viertel	Viertel	NOUN	NN	Case=Acc|Gender=Neut|Number=Sing	11	obj	_	_
-16	interessant	interessant	ADJ	ADJD	_	11	xcomp	_	SpaceAfter=No
-17	.	.	PUNCT	$.	_	11	punct	_	_
+# text = Baumbestandene Straßen mit Kopfsteinpflaster und pastellfarbene Gipsfassaden aus dem 18. Jahrhundert machen das Boheme-Viertel interessant.
+1	Baumbestandene	baumbestanden	ADJ	ADJA	Case=Nom|Gender=Fem|Number=Plur	2	dep	_	FixTigerDep=Yes
+2	Straßen	Straße	NOUN	NN	Case=Nom|Gender=Fem|Number=Plur	12	nsubj	_	_
+3	mit	mit	ADP	APPR	_	4	case	_	_
+4	Kopfsteinpflaster	Kopfsteinpflaster	NOUN	NN	Case=Dat|Gender=Neut|Number=Sing	2	nmod	_	_
+5	und	und	CCONJ	KON	_	7	cc	_	_
+6	pastellfarbene	pastellfarben	ADJ	ADJA	Case=Nom|Gender=Fem|Number=Plur	7	amod	_	_
+7	Gipsfassaden	Gipsfassade	NOUN	NN	Case=Nom|Gender=Fem|Number=Plur	2	conj	_	_
+8	aus	aus	ADP	APPR	_	11	case	_	_
+9	dem	der	DET	ART	Case=Dat|Definite=Def|Gender=Neut|Number=Sing|PronType=Art	11	det	_	_
+10	18.	18	ADJ	ADJA	Case=Dat|Gender=Neut|Number=Sing	11	amod	_	_
+11	Jahrhundert	Jahrhundert	NOUN	NN	Case=Dat|Gender=Neut|Number=Sing	2	nmod	_	_
+12	machen	machen	VERB	VVFIN	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	0	root	_	_
+13	das	der	DET	ART	Case=Acc|Definite=Def|Gender=Neut|Number=Sing|PronType=Art	16	det	_	_
+14	Boheme	Boheme	NOUN	NN	Case=Acc|Gender=Neut|Number=Sing	16	compound	_	SpaceAfter=No
+15	-	-	PUNCT	$(	_	14	punct	_	SpaceAfter=No
+16	Viertel	Viertel	NOUN	NN	Case=Acc|Gender=Neut|Number=Sing	12	obj	_	_
+17	interessant	interessant	ADJ	ADJD	_	12	xcomp	_	SpaceAfter=No
+18	.	.	PUNCT	$.	_	12	punct	_	_
 
 # sent_id = dev-s608
-# text = Wissen um Elend und Not wirft plötzlich Schatten auf Gold und Himmelblau.
-1	Wissen	Wissen	NOUN	NN	Case=Nom|Gender=Neut|Number=Sing	6	nsubj	_	_
-2	um	um	ADP	APPR	_	3	case	_	_
-3	Elend	Elend	NOUN	NN	Case=Acc|Gender=Neut|Number=Sing	1	nmod	_	_
-4	und	und	CCONJ	KON	_	5	cc	_	_
-5	Not	Not	NOUN	NN	Case=Acc|Gender=Fem|Number=Sing	3	conj	_	_
-6	wirft	werfen	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	0	root	_	_
-7	plötzlich	plötzlich	ADV	ADJD	_	6	advmod	_	_
-8	Schatten	Schatten	NOUN	NN	Case=Acc|Gender=Masc|Number=Plur	6	obj	_	_
-9	auf	auf	ADP	APPR	_	10	case	_	_
-10	Gold	Gold	NOUN	NN	Case=Acc|Gender=Neut|Number=Sing	6	obl	_	_
-11	und	und	CCONJ	KON	_	12	cc	_	_
-12	Himmelblau	Himmelblaue	NOUN	NN	Case=Acc|Gender=Neut|Number=Sing	10	conj	_	SpaceAfter=No
-13	.	.	PUNCT	$.	_	6	punct	_	_
+# text = Das Wissen um Elend und Not wirft plötzlich Schatten auf Gold und Himmelblau.
+1	Das	der	DET	ART	Case=Nom|Definite=Def|Gender=Neut|Number=Sing|PronType=Art	2	dep	_	FixTigerDep=Yes
+2	Wissen	Wissen	NOUN	NN	Case=Nom|Gender=Neut|Number=Sing	7	nsubj	_	_
+3	um	um	ADP	APPR	_	4	case	_	_
+4	Elend	Elend	NOUN	NN	Case=Acc|Gender=Neut|Number=Sing	2	nmod	_	_
+5	und	und	CCONJ	KON	_	6	cc	_	_
+6	Not	Not	NOUN	NN	Case=Acc|Gender=Fem|Number=Sing	4	conj	_	_
+7	wirft	werfen	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	0	root	_	_
+8	plötzlich	plötzlich	ADV	ADJD	_	7	advmod	_	_
+9	Schatten	Schatten	NOUN	NN	Case=Acc|Gender=Masc|Number=Plur	7	obj	_	_
+10	auf	auf	ADP	APPR	_	11	case	_	_
+11	Gold	Gold	NOUN	NN	Case=Acc|Gender=Neut|Number=Sing	7	obl	_	_
+12	und	und	CCONJ	KON	_	13	cc	_	_
+13	Himmelblau	Himmelblaue	NOUN	NN	Case=Acc|Gender=Neut|Number=Sing	11	conj	_	SpaceAfter=No
+14	.	.	PUNCT	$.	_	7	punct	_	_
 
 # sent_id = dev-s609
 # text = Die Ausgrabungszeit dauert vom 2. Juli bis 13. August.
@@ -10717,93 +10754,96 @@
 16	.	.	PUNCT	$.	_	4	punct	_	_
 
 # sent_id = dev-s611
-# text = Darauf haben wir so lange gewartet'', entschuldigen die royalen Reporter ihren Überschwang, der sich in Tausenden von Zeitungs- und Illustriertenseiten niederschlug, seit Joachim und Alexandra am 31. Mai aus heiterem Himmel ihre Verlobung bekanntgaben.
-1	Darauf	darauf	ADV	PAV	_	6	advmod	_	_
-2	haben	haben	AUX	VAFIN	Mood=Ind|Number=Plur|Person=1|Tense=Pres|VerbForm=Fin	6	aux	_	_
-3	wir	wir	PRON	PPER	Case=Nom|Number=Plur|Person=1|PronType=Prs	6	nsubj	_	_
-4	so	so	ADV	ADV	_	5	advmod	_	_
-5	lange	lange	ADV	ADV	_	6	advmod	_	_
-6	gewartet	warten	VERB	VVPP	VerbForm=Part	9	ccomp	_	SpaceAfter=No
-7	''	''	PUNCT	$(	_	9	punct	_	SpaceAfter=No
-8	,	,	PUNCT	$,	_	9	punct	_	_
-9	entschuldigen	entschuldigen	VERB	VVFIN	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	0	root	_	_
-10	die	der	DET	ART	Case=Nom|Definite=Def|Gender=Masc|Number=Plur|PronType=Art	12	det	_	_
-11	royalen	royal	ADJ	ADJA	Case=Nom|Gender=Masc|Number=Plur	12	amod	_	_
-12	Reporter	Reporter	NOUN	NN	Case=Nom|Gender=Masc|Number=Plur	9	nsubj	_	_
-13	ihren	ihr	PRON	PPOSAT	Case=Acc|Gender=Masc|Number=Sing|Poss=Yes	14	det:poss	_	_
-14	Überschwang	Überschwang	NOUN	NN	Case=Acc|Gender=Masc|Number=Sing	9	obj	_	SpaceAfter=No
-15	,	,	PUNCT	$,	_	9	punct	_	_
-16	der	der	PRON	PRELS	Case=Nom|Gender=Masc|Number=Sing|PronType=Rel	25	nsubj	_	_
-17	sich	er|es|sie	PRON	PRF	Case=Acc|Number=Sing|Person=3|PronType=Prs|Reflex=Yes	25	obj	_	_
-18	in	in	ADP	APPR	_	19	case	_	_
-19	Tausenden	Tausend	NOUN	NN	Case=Dat|Gender=Neut|Number=Plur	25	obl	_	_
-20	von	von	ADP	APPR	_	21	case	_	_
-21	Zeitungs	Zeitungs	NOUN	TRUNC	Case=Dat|Gender=Fem|Number=Plur	19	compound	_	SpaceAfter=No
-22	-	-	PUNCT	$(	_	24	punct	_	_
-23	und	und	CCONJ	KON	_	24	cc	_	_
-24	Illustriertenseiten	Illustriertenseite	NOUN	NN	Case=Dat|Gender=Fem|Number=Plur	21	conj	_	_
-25	niederschlug	niederschlagen	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	14	acl	_	SpaceAfter=No
-26	,	,	PUNCT	$,	_	9	punct	_	_
-27	seit	seit	SCONJ	KOUS	_	40	mark	_	_
-28	Joachim	Joachim	PROPN	NE	Case=Nom|Gender=Masc|Number=Sing	40	nsubj	_	_
-29	und	und	CCONJ	KON	_	30	cc	_	_
-30	Alexandra	Alexandra	PROPN	NE	Case=Nom|Gender=Fem|Number=Sing	28	conj	_	_
-31-32	am	_	_	_	_	_	_	_	_
-31	an	an	ADP	APPR	_	40	case	_	_
-32	dem	der	DET	ART	Case=Dat|Definite=Def|Gender=Neut|Number=Sing|PronType=Art	40	det	_	_
-33	31.	31	ADJ	ADJA	Case=Dat|Gender=Masc|Number=Sing	34	amod	_	_
-34	Mai	Mai	PROPN	NN	Case=Dat|Gender=Masc|Number=Sing	31	obj	_	_
-35	aus	aus	ADP	APPR	_	37	case	_	_
-36	heiterem	heiter	ADJ	ADJA	Case=Dat|Gender=Masc|Number=Sing	37	amod	_	_
-37	Himmel	Himmel	NOUN	NN	Case=Dat|Gender=Masc|Number=Sing	40	obl	_	_
-38	ihre	ihr	PRON	PPOSAT	Case=Acc|Gender=Fem|Number=Sing|Poss=Yes	39	det:poss	_	_
-39	Verlobung	Verlobung	NOUN	NN	Case=Acc|Gender=Fem|Number=Sing	40	obj	_	_
-40	bekanntgaben	bekanntgeben	VERB	VVFIN	Mood=Ind|Number=Plur|Person=3|Tense=Past|VerbForm=Fin	25	advcl	_	SpaceAfter=No
-41	.	.	PUNCT	$.	_	9	punct	_	_
+# text = ``Darauf haben wir so lange gewartet'', entschuldigen die royalen Reporter ihren Überschwang, der sich in Tausenden von Zeitungs- und Illustriertenseiten niederschlug, seit Joachim und Alexandra am 31. Mai aus heiterem Himmel ihre Verlobung bekanntgaben.
+1	``	``	PUNCT	$(	_	2	punct	_	FixTigerDep=Yes|SpaceAfter=No
+2	Darauf	darauf	ADV	PAV	_	7	advmod	_	_
+3	haben	haben	AUX	VAFIN	Mood=Ind|Number=Plur|Person=1|Tense=Pres|VerbForm=Fin	7	aux	_	_
+4	wir	wir	PRON	PPER	Case=Nom|Number=Plur|Person=1|PronType=Prs	7	nsubj	_	_
+5	so	so	ADV	ADV	_	6	advmod	_	_
+6	lange	lange	ADV	ADV	_	7	advmod	_	_
+7	gewartet	warten	VERB	VVPP	VerbForm=Part	10	ccomp	_	SpaceAfter=No
+8	''	''	PUNCT	$(	_	10	punct	_	SpaceAfter=No
+9	,	,	PUNCT	$,	_	10	punct	_	_
+10	entschuldigen	entschuldigen	VERB	VVFIN	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	0	root	_	_
+11	die	der	DET	ART	Case=Nom|Definite=Def|Gender=Masc|Number=Plur|PronType=Art	13	det	_	_
+12	royalen	royal	ADJ	ADJA	Case=Nom|Gender=Masc|Number=Plur	13	amod	_	_
+13	Reporter	Reporter	NOUN	NN	Case=Nom|Gender=Masc|Number=Plur	10	nsubj	_	_
+14	ihren	ihr	PRON	PPOSAT	Case=Acc|Gender=Masc|Number=Sing|Poss=Yes	15	det:poss	_	_
+15	Überschwang	Überschwang	NOUN	NN	Case=Acc|Gender=Masc|Number=Sing	10	obj	_	SpaceAfter=No
+16	,	,	PUNCT	$,	_	10	punct	_	_
+17	der	der	PRON	PRELS	Case=Nom|Gender=Masc|Number=Sing|PronType=Rel	26	nsubj	_	_
+18	sich	er|es|sie	PRON	PRF	Case=Acc|Number=Sing|Person=3|PronType=Prs|Reflex=Yes	26	obj	_	_
+19	in	in	ADP	APPR	_	20	case	_	_
+20	Tausenden	Tausend	NOUN	NN	Case=Dat|Gender=Neut|Number=Plur	26	obl	_	_
+21	von	von	ADP	APPR	_	22	case	_	_
+22	Zeitungs	Zeitungs	NOUN	TRUNC	Case=Dat|Gender=Fem|Number=Plur	20	compound	_	SpaceAfter=No
+23	-	-	PUNCT	$(	_	25	punct	_	_
+24	und	und	CCONJ	KON	_	25	cc	_	_
+25	Illustriertenseiten	Illustriertenseite	NOUN	NN	Case=Dat|Gender=Fem|Number=Plur	22	conj	_	_
+26	niederschlug	niederschlagen	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	15	acl	_	SpaceAfter=No
+27	,	,	PUNCT	$,	_	10	punct	_	_
+28	seit	seit	SCONJ	KOUS	_	41	mark	_	_
+29	Joachim	Joachim	PROPN	NE	Case=Nom|Gender=Masc|Number=Sing	41	nsubj	_	_
+30	und	und	CCONJ	KON	_	31	cc	_	_
+31	Alexandra	Alexandra	PROPN	NE	Case=Nom|Gender=Fem|Number=Sing	29	conj	_	_
+32-33	am	_	_	_	_	_	_	_	_
+32	an	an	ADP	APPR	_	41	case	_	_
+33	dem	der	DET	ART	Case=Dat|Definite=Def|Gender=Neut|Number=Sing|PronType=Art	41	det	_	_
+34	31.	31	ADJ	ADJA	Case=Dat|Gender=Masc|Number=Sing	35	amod	_	_
+35	Mai	Mai	PROPN	NN	Case=Dat|Gender=Masc|Number=Sing	32	obj	_	_
+36	aus	aus	ADP	APPR	_	38	case	_	_
+37	heiterem	heiter	ADJ	ADJA	Case=Dat|Gender=Masc|Number=Sing	38	amod	_	_
+38	Himmel	Himmel	NOUN	NN	Case=Dat|Gender=Masc|Number=Sing	41	obl	_	_
+39	ihre	ihr	PRON	PPOSAT	Case=Acc|Gender=Fem|Number=Sing|Poss=Yes	40	det:poss	_	_
+40	Verlobung	Verlobung	NOUN	NN	Case=Acc|Gender=Fem|Number=Sing	41	obj	_	_
+41	bekanntgaben	bekanntgeben	VERB	VVFIN	Mood=Ind|Number=Plur|Person=3|Tense=Past|VerbForm=Fin	26	advcl	_	SpaceAfter=No
+42	.	.	PUNCT	$.	_	10	punct	_	_
 
 # sent_id = dev-s612
-# text = Ministerpräsident Manfred Stolpe rief Lafontaine am Freitag dazu auf, sein Verhältnis zu Ostdeutschland klarzustellen.
-1	Ministerpräsident	Ministerpräsident	NOUN	NN	Case=Nom|Gender=Masc|Number=Sing	4	nsubj	_	_
-2	Manfred	Manfred	PROPN	NE	Case=Nom|Gender=Masc|Number=Sing	1	appos	_	_
-3	Stolpe	Stolpe	PROPN	NE	Case=Nom|Gender=Masc|Number=Sing	2	flat	_	_
-4	rief	rufen	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	0	root	_	_
-5	Lafontaine	Lafontaine	PROPN	NE	Case=Acc|Number=Sing	4	obj	_	_
-6-7	am	_	_	_	_	_	_	_	_
-6	an	an	ADP	APPR	_	8	case	_	_
-7	dem	der	DET	ART	Case=Dat|Definite=Def|Gender=Masc|Number=Sing|PronType=Art	8	det	_	_
-8	Freitag	Freitag	PROPN	NN	Case=Dat|Gender=Masc|Number=Sing	4	obl	_	_
-9	dazu	dazu	ADV	PAV	_	4	advmod	_	_
-10	auf	auf	ADP	PTKVZ	_	4	compound:prt	_	SpaceAfter=No
-11	,	,	PUNCT	$,	_	4	punct	_	_
-12	sein	sein	PRON	PPOSAT	Case=Acc|Gender=Neut|Number=Sing|Poss=Yes	13	det:poss	_	_
-13	Verhältnis	Verhältnis	NOUN	NN	Case=Acc|Gender=Neut|Number=Sing	16	obj	_	_
-14	zu	zu	ADP	APPR	_	15	case	_	_
-15	Ostdeutschland	Ostdeutschland	PROPN	NE	Case=Dat|Gender=Neut|Number=Sing	13	nmod	_	_
-16	klarzustellen	klarstellen	VERB	VVIZU	VerbForm=Inf	4	xcomp	_	SpaceAfter=No
-17	.	.	PUNCT	$.	_	4	punct	_	_
+# text = Brandenburgs Ministerpräsident Manfred Stolpe rief Lafontaine am Freitag dazu auf, sein Verhältnis zu Ostdeutschland klarzustellen.
+1	Brandenburgs	Brandenburg	PROPN	NE	Case=Gen|Gender=Neut|Number=Sing	2	dep	_	FixTigerDep=Yes
+2	Ministerpräsident	Ministerpräsident	NOUN	NN	Case=Nom|Gender=Masc|Number=Sing	5	nsubj	_	_
+3	Manfred	Manfred	PROPN	NE	Case=Nom|Gender=Masc|Number=Sing	2	appos	_	_
+4	Stolpe	Stolpe	PROPN	NE	Case=Nom|Gender=Masc|Number=Sing	3	flat	_	_
+5	rief	rufen	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	0	root	_	_
+6	Lafontaine	Lafontaine	PROPN	NE	Case=Acc|Number=Sing	5	obj	_	_
+7-8	am	_	_	_	_	_	_	_	_
+7	an	an	ADP	APPR	_	9	case	_	_
+8	dem	der	DET	ART	Case=Dat|Definite=Def|Gender=Masc|Number=Sing|PronType=Art	9	det	_	_
+9	Freitag	Freitag	PROPN	NN	Case=Dat|Gender=Masc|Number=Sing	5	obl	_	_
+10	dazu	dazu	ADV	PAV	_	5	advmod	_	_
+11	auf	auf	ADP	PTKVZ	_	5	compound:prt	_	SpaceAfter=No
+12	,	,	PUNCT	$,	_	5	punct	_	_
+13	sein	sein	PRON	PPOSAT	Case=Acc|Gender=Neut|Number=Sing|Poss=Yes	14	det:poss	_	_
+14	Verhältnis	Verhältnis	NOUN	NN	Case=Acc|Gender=Neut|Number=Sing	17	obj	_	_
+15	zu	zu	ADP	APPR	_	16	case	_	_
+16	Ostdeutschland	Ostdeutschland	PROPN	NE	Case=Dat|Gender=Neut|Number=Sing	14	nmod	_	_
+17	klarzustellen	klarstellen	VERB	VVIZU	VerbForm=Inf	5	xcomp	_	SpaceAfter=No
+18	.	.	PUNCT	$.	_	5	punct	_	_
 
 # sent_id = dev-s613
-# text = Pflanzen bestehen aus einem einzelnen, bandförmigen Blatt, einem Blattstiel und einem wurzelähnlichen Organ zum Festhalten.
-1	Pflanzen	Pflanze	NOUN	NN	Case=Nom|Gender=Fem|Number=Plur	2	nsubj	_	_
-2	bestehen	bestehen	VERB	VVFIN	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	0	root	_	_
-3	aus	aus	ADP	APPR	_	8	case	_	_
-4	einem	ein	DET	ART	Case=Dat|Definite=Ind|Gender=Neut|Number=Sing|PronType=Art	8	det	_	_
-5	einzelnen	einzeln	ADJ	ADJA	Case=Dat|Gender=Neut|Number=Sing	8	amod	_	SpaceAfter=No
-6	,	,	PUNCT	$,	_	7	punct	_	_
-7	bandförmigen	bandförmig	ADJ	ADJA	Case=Dat|Gender=Neut|Number=Sing	5	conj	_	_
-8	Blatt	Blatt	NOUN	NN	Case=Dat|Gender=Neut|Number=Sing	2	obl	_	SpaceAfter=No
-9	,	,	PUNCT	$,	_	11	punct	_	_
-10	einem	ein	DET	ART	Case=Dat|Definite=Ind|Gender=Masc|Number=Sing|PronType=Art	11	det	_	_
-11	Blattstiel	Blattstiel	NOUN	NN	Case=Dat|Gender=Masc|Number=Sing	8	conj	_	_
-12	und	und	CCONJ	KON	_	15	cc	_	_
-13	einem	ein	DET	ART	Case=Dat|Definite=Ind|Gender=Neut|Number=Sing|PronType=Art	15	det	_	_
-14	wurzelähnlichen	wurzelähnlich	ADJ	ADJA	Case=Dat|Gender=Neut|Number=Sing	15	amod	_	_
-15	Organ	Organ	NOUN	NN	Case=Dat|Gender=Neut|Number=Sing	8	conj	_	_
-16-17	zum	_	_	_	_	_	_	_	_
-16	zu	zu	ADP	APPR	_	18	case	_	_
-17	dem	der	DET	ART	Case=Dat|Definite=Def|Gender=Neut|Number=Sing|PronType=Art	18	det	_	_
-18	Festhalten	Festhalten	NOUN	NN	Case=Dat|Gender=Neut|Number=Sing	15	nmod	_	SpaceAfter=No
-19	.	.	PUNCT	$.	_	2	punct	_	_
+# text = Die Pflanzen bestehen aus einem einzelnen, bandförmigen Blatt, einem Blattstiel und einem wurzelähnlichen Organ zum Festhalten.
+1	Die	der	DET	ART	Case=Nom|Definite=Def|Gender=Fem|Number=Plur|PronType=Art	2	dep	_	FixTigerDep=Yes
+2	Pflanzen	Pflanze	NOUN	NN	Case=Nom|Gender=Fem|Number=Plur	3	nsubj	_	_
+3	bestehen	bestehen	VERB	VVFIN	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	0	root	_	_
+4	aus	aus	ADP	APPR	_	9	case	_	_
+5	einem	ein	DET	ART	Case=Dat|Definite=Ind|Gender=Neut|Number=Sing|PronType=Art	9	det	_	_
+6	einzelnen	einzeln	ADJ	ADJA	Case=Dat|Gender=Neut|Number=Sing	9	amod	_	SpaceAfter=No
+7	,	,	PUNCT	$,	_	8	punct	_	_
+8	bandförmigen	bandförmig	ADJ	ADJA	Case=Dat|Gender=Neut|Number=Sing	6	conj	_	_
+9	Blatt	Blatt	NOUN	NN	Case=Dat|Gender=Neut|Number=Sing	3	obl	_	SpaceAfter=No
+10	,	,	PUNCT	$,	_	12	punct	_	_
+11	einem	ein	DET	ART	Case=Dat|Definite=Ind|Gender=Masc|Number=Sing|PronType=Art	12	det	_	_
+12	Blattstiel	Blattstiel	NOUN	NN	Case=Dat|Gender=Masc|Number=Sing	9	conj	_	_
+13	und	und	CCONJ	KON	_	16	cc	_	_
+14	einem	ein	DET	ART	Case=Dat|Definite=Ind|Gender=Neut|Number=Sing|PronType=Art	16	det	_	_
+15	wurzelähnlichen	wurzelähnlich	ADJ	ADJA	Case=Dat|Gender=Neut|Number=Sing	16	amod	_	_
+16	Organ	Organ	NOUN	NN	Case=Dat|Gender=Neut|Number=Sing	9	conj	_	_
+17-18	zum	_	_	_	_	_	_	_	_
+17	zu	zu	ADP	APPR	_	19	case	_	_
+18	dem	der	DET	ART	Case=Dat|Definite=Def|Gender=Neut|Number=Sing|PronType=Art	19	det	_	_
+19	Festhalten	Festhalten	NOUN	NN	Case=Dat|Gender=Neut|Number=Sing	16	nmod	_	SpaceAfter=No
+20	.	.	PUNCT	$.	_	3	punct	_	_
 
 # sent_id = dev-s614
 # text = Alle kamen erst im zweiten Anlauf durch -- auf Kosten des Nachwuchses.
@@ -10838,27 +10878,28 @@
 11	.	.	PUNCT	$.	_	4	punct	_	_
 
 # sent_id = dev-s616
-# text = Es ärgert uns, daß das Amt schlechter mißt als unsere externen Prüfer'', sagt Sprecher Norbert Schäfer.
-1	Es	es	PRON	PPER	Case=Nom|Gender=Neut|Number=Sing|Person=3|PronType=Prs	2	nsubj	_	_
-2	ärgert	ärgern	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	16	ccomp	_	_
-3	uns	wir	PRON	PPER	Case=Acc|Number=Plur|Person=1|PronType=Prs	2	obj	_	SpaceAfter=No
-4	,	,	PUNCT	$,	_	16	punct	_	_
-5	daß	daß	SCONJ	KOUS	_	9	mark	_	_
-6	das	der	DET	ART	Case=Nom|Definite=Def|Gender=Neut|Number=Sing|PronType=Art	7	det	_	_
-7	Amt	Amt	NOUN	NN	Case=Nom|Gender=Neut|Number=Sing	9	nsubj	_	_
-8	schlechter	schlecht	ADV	ADJD	_	9	advmod	_	_
-9	mißt	messen	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	2	ccomp	_	_
-10	als	als	CCONJ	KOKOM	_	13	case	_	_
-11	unsere	unser	PRON	PPOSAT	Case=Nom|Gender=Masc|Number=Plur|Poss=Yes	13	det:poss	_	_
-12	externen	extern	ADJ	ADJA	Case=Nom|Gender=Masc|Number=Plur	13	amod	_	_
-13	Prüfer	Prüfer	NOUN	NN	Case=Nom|Gender=Masc|Number=Plur	8	nmod	_	SpaceAfter=No
-14	''	''	PUNCT	$(	_	16	punct	_	SpaceAfter=No
-15	,	,	PUNCT	$,	_	16	punct	_	_
-16	sagt	sagen	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	0	root	_	_
-17	Sprecher	Sprecher	NOUN	NN	Case=Nom|Gender=Masc|Number=Sing	16	nsubj	_	_
-18	Norbert	Norbert	PROPN	NE	Case=Nom|Gender=Masc|Number=Sing	17	appos	_	_
-19	Schäfer	Schäfer	PROPN	NE	Case=Nom|Gender=Masc|Number=Sing	18	flat	_	SpaceAfter=No
-20	.	.	PUNCT	$.	_	16	punct	_	_
+# text = ``Es ärgert uns, daß das Amt schlechter mißt als unsere externen Prüfer'', sagt Sprecher Norbert Schäfer.
+1	``	``	PUNCT	$(	_	2	punct	_	FixTigerDep=Yes|SpaceAfter=No
+2	Es	es	PRON	PPER	Case=Nom|Gender=Neut|Number=Sing|Person=3|PronType=Prs	3	nsubj	_	_
+3	ärgert	ärgern	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	17	ccomp	_	_
+4	uns	wir	PRON	PPER	Case=Acc|Number=Plur|Person=1|PronType=Prs	3	obj	_	SpaceAfter=No
+5	,	,	PUNCT	$,	_	17	punct	_	_
+6	daß	daß	SCONJ	KOUS	_	10	mark	_	_
+7	das	der	DET	ART	Case=Nom|Definite=Def|Gender=Neut|Number=Sing|PronType=Art	8	det	_	_
+8	Amt	Amt	NOUN	NN	Case=Nom|Gender=Neut|Number=Sing	10	nsubj	_	_
+9	schlechter	schlecht	ADV	ADJD	_	10	advmod	_	_
+10	mißt	messen	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	3	ccomp	_	_
+11	als	als	CCONJ	KOKOM	_	14	case	_	_
+12	unsere	unser	PRON	PPOSAT	Case=Nom|Gender=Masc|Number=Plur|Poss=Yes	14	det:poss	_	_
+13	externen	extern	ADJ	ADJA	Case=Nom|Gender=Masc|Number=Plur	14	amod	_	_
+14	Prüfer	Prüfer	NOUN	NN	Case=Nom|Gender=Masc|Number=Plur	9	nmod	_	SpaceAfter=No
+15	''	''	PUNCT	$(	_	17	punct	_	SpaceAfter=No
+16	,	,	PUNCT	$,	_	17	punct	_	_
+17	sagt	sagen	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	0	root	_	_
+18	Sprecher	Sprecher	NOUN	NN	Case=Nom|Gender=Masc|Number=Sing	17	nsubj	_	_
+19	Norbert	Norbert	PROPN	NE	Case=Nom|Gender=Masc|Number=Sing	18	appos	_	_
+20	Schäfer	Schäfer	PROPN	NE	Case=Nom|Gender=Masc|Number=Sing	19	flat	_	SpaceAfter=No
+21	.	.	PUNCT	$.	_	17	punct	_	_
 
 # sent_id = dev-s617
 # text = Jetzt reagiere ein Teil der Zugewanderten mit ``abgrenzender Gruppenbildung'' auf den Haß, der ihnen in Deutschland entgegenschlage.
@@ -10885,28 +10926,29 @@
 21	.	.	PUNCT	$.	_	2	punct	_	_
 
 # sent_id = dev-s618
-# text = Argument: Wenn nur wenige große Parteien in die Duma einziehen und viele kleine scheitern, werde der Wählerwillen verzerrt.
-1	Argument	Argument	NOUN	NN	Case=Nom|Gender=Neut|Number=Sing	20	appos	_	SpaceAfter=No
-2	:	:	PUNCT	$.	_	20	punct	_	_
-3	Wenn	wenn	SCONJ	KOUS	_	11	mark	_	_
-4	nur	nur	ADV	ADV	_	11	advmod	_	_
-5	wenige	weniger	ADJ	PIAT	Case=Nom|Definite=Ind|Gender=Fem|Number=Plur|PronType=Ind	7	amod	_	_
-6	große	groß	ADJ	ADJA	Case=Nom|Gender=Fem|Number=Plur	7	amod	_	_
-7	Parteien	Partei	NOUN	NN	Case=Nom|Gender=Fem|Number=Plur	11	nsubj	_	_
-8	in	in	ADP	APPR	_	10	case	_	_
-9	die	der	DET	ART	Case=Acc|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	10	det	_	_
-10	Duma	Duma	PROPN	NE	Case=Acc|Gender=Fem|Number=Sing	11	obl	_	_
-11	einziehen	einziehen	VERB	VVFIN	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	20	advcl	_	_
-12	und	und	CCONJ	KON	_	15	cc	_	_
-13	viele	viel	PRON	PIAT	Case=Nom|Definite=Ind|Gender=Fem|Number=Plur|PronType=Ind	15	det	_	_
-14	kleine	klein	ADJ	ADJA	Case=Nom|Gender=Fem|Number=Plur	13	amod	_	_
-15	scheitern	scheitern	VERB	VVFIN	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	11	conj	_	SpaceAfter=No
-16	,	,	PUNCT	$,	_	20	punct	_	_
-17	werde	werden	AUX	VAFIN	Mood=Sub|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin|Voice=Pass	20	aux:pass	_	_
-18	der	der	DET	ART	Case=Nom|Definite=Def|Gender=Masc|Number=Sing|PronType=Art	19	det	_	_
-19	Wählerwillen	Wählerwille	NOUN	NN	Case=Nom|Gender=Masc|Number=Sing	20	nsubj:pass	_	_
-20	verzerrt	verzerren	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	0	root	_	SpaceAfter=No
-21	.	.	PUNCT	$.	_	20	punct	_	_
+# text = Ihr Argument: Wenn nur wenige große Parteien in die Duma einziehen und viele kleine scheitern, werde der Wählerwillen verzerrt.
+1	Ihr	ihr	DET	PPOSAT	Case=Nom|Gender=Neut|Number=Sing|Poss=Yes	2	dep	_	FixTigerDep=Yes
+2	Argument	Argument	NOUN	NN	Case=Nom|Gender=Neut|Number=Sing	21	appos	_	SpaceAfter=No
+3	:	:	PUNCT	$.	_	21	punct	_	_
+4	Wenn	wenn	SCONJ	KOUS	_	12	mark	_	_
+5	nur	nur	ADV	ADV	_	12	advmod	_	_
+6	wenige	weniger	ADJ	PIAT	Case=Nom|Definite=Ind|Gender=Fem|Number=Plur|PronType=Ind	8	amod	_	_
+7	große	groß	ADJ	ADJA	Case=Nom|Gender=Fem|Number=Plur	8	amod	_	_
+8	Parteien	Partei	NOUN	NN	Case=Nom|Gender=Fem|Number=Plur	12	nsubj	_	_
+9	in	in	ADP	APPR	_	11	case	_	_
+10	die	der	DET	ART	Case=Acc|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	11	det	_	_
+11	Duma	Duma	PROPN	NE	Case=Acc|Gender=Fem|Number=Sing	12	obl	_	_
+12	einziehen	einziehen	VERB	VVFIN	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	21	advcl	_	_
+13	und	und	CCONJ	KON	_	16	cc	_	_
+14	viele	viel	PRON	PIAT	Case=Nom|Definite=Ind|Gender=Fem|Number=Plur|PronType=Ind	16	det	_	_
+15	kleine	klein	ADJ	ADJA	Case=Nom|Gender=Fem|Number=Plur	14	amod	_	_
+16	scheitern	scheitern	VERB	VVFIN	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	12	conj	_	SpaceAfter=No
+17	,	,	PUNCT	$,	_	21	punct	_	_
+18	werde	werden	AUX	VAFIN	Mood=Sub|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin|Voice=Pass	21	aux:pass	_	_
+19	der	der	DET	ART	Case=Nom|Definite=Def|Gender=Masc|Number=Sing|PronType=Art	20	det	_	_
+20	Wählerwillen	Wählerwille	NOUN	NN	Case=Nom|Gender=Masc|Number=Sing	21	nsubj:pass	_	_
+21	verzerrt	verzerren	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	0	root	_	SpaceAfter=No
+22	.	.	PUNCT	$.	_	21	punct	_	_
 
 # sent_id = dev-s619
 # text = Der Beschluß muß noch vom Senat bestätigt werden.
@@ -10947,49 +10989,51 @@
 20	.	.	PUNCT	$.	_	12	punct	_	_
 
 # sent_id = dev-s621
-# text = Die gängige Auffassung, Wohlstand und Arbeitsplätze seien um so sicherer, je größer der Export sei, muß eingeschränkt werden.
-1	Die	der	DET	ART	Case=Nom|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	3	det	_	_
-2	gängige	gängig	ADJ	ADJA	Case=Nom|Gender=Fem|Number=Sing	3	amod	_	_
-3	Auffassung	Auffassung	NOUN	NN	Case=Nom|Gender=Fem|Number=Sing	20	nsubj:pass	_	SpaceAfter=No
-4	,	,	PUNCT	$,	_	20	punct	_	_
-5	Wohlstand	Wohlstand	NOUN	NN	Case=Nom|Gender=Masc|Number=Sing	11	nsubj	_	_
-6	und	und	CCONJ	KON	_	7	cc	_	_
-7	Arbeitsplätze	Arbeitsplatz	NOUN	NN	Case=Nom|Gender=Masc|Number=Plur	5	conj	_	_
-8	seien	sein	AUX	VAFIN	Mood=Sub|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	11	cop	_	_
-9	um	um	CCONJ	ADV	_	11	cc	_	_
-10	so	so	ADV	ADV	_	9	fixed	_	_
-11	sicherer	sicher	ADJ	ADJD	_	3	ccomp	_	SpaceAfter=No
-12	,	,	PUNCT	$,	_	20	punct	_	_
-13	je	je	SCONJ	ADV	_	14	mark	_	_
-14	größer	groß	ADJ	ADJD	_	11	advcl	_	_
-15	der	der	DET	ART	Case=Nom|Definite=Def|Gender=Masc|Number=Sing|PronType=Art	16	det	_	_
-16	Export	Export	NOUN	NN	Case=Nom|Gender=Masc|Number=Sing	14	nsubj	_	_
-17	sei	sein	AUX	VAFIN	Mood=Sub|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	14	cop	_	SpaceAfter=No
-18	,	,	PUNCT	$,	_	20	punct	_	_
-19	muß	müssen	AUX	VMFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	20	aux	_	_
-20	eingeschränkt	einschränken	VERB	VVPP	VerbForm=Part	0	root	_	_
-21	werden	werden	AUX	VAINF	VerbForm=Inf|Voice=Pass	20	aux:pass	_	SpaceAfter=No
-22	.	.	PUNCT	$.	_	20	punct	_	_
+# text = 4. Die gängige Auffassung, Wohlstand und Arbeitsplätze seien um so sicherer, je größer der Export sei, muß eingeschränkt werden.
+1	4.	4.	ADV	ADV	_	2	dep	_	FixTigerDep=Yes
+2	Die	der	DET	ART	Case=Nom|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	4	det	_	_
+3	gängige	gängig	ADJ	ADJA	Case=Nom|Gender=Fem|Number=Sing	4	amod	_	_
+4	Auffassung	Auffassung	NOUN	NN	Case=Nom|Gender=Fem|Number=Sing	21	nsubj:pass	_	SpaceAfter=No
+5	,	,	PUNCT	$,	_	21	punct	_	_
+6	Wohlstand	Wohlstand	NOUN	NN	Case=Nom|Gender=Masc|Number=Sing	12	nsubj	_	_
+7	und	und	CCONJ	KON	_	8	cc	_	_
+8	Arbeitsplätze	Arbeitsplatz	NOUN	NN	Case=Nom|Gender=Masc|Number=Plur	6	conj	_	_
+9	seien	sein	AUX	VAFIN	Mood=Sub|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	12	cop	_	_
+10	um	um	CCONJ	ADV	_	12	cc	_	_
+11	so	so	ADV	ADV	_	10	fixed	_	_
+12	sicherer	sicher	ADJ	ADJD	_	4	ccomp	_	SpaceAfter=No
+13	,	,	PUNCT	$,	_	21	punct	_	_
+14	je	je	SCONJ	ADV	_	15	mark	_	_
+15	größer	groß	ADJ	ADJD	_	12	advcl	_	_
+16	der	der	DET	ART	Case=Nom|Definite=Def|Gender=Masc|Number=Sing|PronType=Art	17	det	_	_
+17	Export	Export	NOUN	NN	Case=Nom|Gender=Masc|Number=Sing	15	nsubj	_	_
+18	sei	sein	AUX	VAFIN	Mood=Sub|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	15	cop	_	SpaceAfter=No
+19	,	,	PUNCT	$,	_	21	punct	_	_
+20	muß	müssen	AUX	VMFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	21	aux	_	_
+21	eingeschränkt	einschränken	VERB	VVPP	VerbForm=Part	0	root	_	_
+22	werden	werden	AUX	VAINF	VerbForm=Inf|Voice=Pass	21	aux:pass	_	SpaceAfter=No
+23	.	.	PUNCT	$.	_	21	punct	_	_
 
 # sent_id = dev-s622
-# text = Sachzwänge des Weltmarktes und nicht mehr der Wille der Bürgerinnen und Bürger bestimmen dann die Politik.
-1	Sachzwänge	Sachzwang	NOUN	NN	Case=Nom|Gender=Masc|Number=Plur	13	nsubj	_	_
-2	des	der	DET	ART	Case=Gen|Definite=Def|Gender=Masc|Number=Sing|PronType=Art	3	det	_	_
-3	Weltmarktes	Weltmarkt	NOUN	NN	Case=Gen|Gender=Masc|Number=Sing	1	nmod	_	_
-4	und	und	CCONJ	KON	_	8	cc	_	_
-5	nicht	nicht	PART	PTKNEG	Polarity=Neg	8	advmod	_	_
-6	mehr	mehr	ADV	ADV	_	8	advmod	_	_
-7	der	der	DET	ART	Case=Nom|Definite=Def|Gender=Masc|Number=Sing|PronType=Art	8	det	_	_
-8	Wille	Wille	NOUN	NN	Case=Nom|Gender=Masc|Number=Sing	1	conj	_	_
-9	der	der	DET	ART	Case=Gen|Definite=Def|Number=Plur|PronType=Art	10	det	_	_
-10	Bürgerinnen	Bürgerin	NOUN	NN	Case=Gen|Gender=Fem|Number=Plur	8	nmod	_	_
-11	und	und	CCONJ	KON	_	12	cc	_	_
-12	Bürger	Bürger	NOUN	NN	Case=Gen|Gender=Masc|Number=Plur	10	conj	_	_
-13	bestimmen	bestimmen	VERB	VVFIN	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	0	root	_	_
-14	dann	dann	ADV	ADV	_	13	advmod	_	_
-15	die	der	DET	ART	Case=Acc|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	16	det	_	_
-16	Politik	Politik	NOUN	NN	Case=Acc|Gender=Fem|Number=Sing	13	obj	_	SpaceAfter=No
-17	.	.	PUNCT	$.	_	13	punct	_	_
+# text = Die Sachzwänge des Weltmarktes und nicht mehr der Wille der Bürgerinnen und Bürger bestimmen dann die Politik.
+1	Die	der	DET	ART	Case=Nom|Definite=Def|Gender=Masc|Number=Plur|PronType=Art	2	dep	_	FixTigerDep=Yes
+2	Sachzwänge	Sachzwang	NOUN	NN	Case=Nom|Gender=Masc|Number=Plur	14	nsubj	_	_
+3	des	der	DET	ART	Case=Gen|Definite=Def|Gender=Masc|Number=Sing|PronType=Art	4	det	_	_
+4	Weltmarktes	Weltmarkt	NOUN	NN	Case=Gen|Gender=Masc|Number=Sing	2	nmod	_	_
+5	und	und	CCONJ	KON	_	9	cc	_	_
+6	nicht	nicht	PART	PTKNEG	Polarity=Neg	9	advmod	_	_
+7	mehr	mehr	ADV	ADV	_	9	advmod	_	_
+8	der	der	DET	ART	Case=Nom|Definite=Def|Gender=Masc|Number=Sing|PronType=Art	9	det	_	_
+9	Wille	Wille	NOUN	NN	Case=Nom|Gender=Masc|Number=Sing	2	conj	_	_
+10	der	der	DET	ART	Case=Gen|Definite=Def|Number=Plur|PronType=Art	11	det	_	_
+11	Bürgerinnen	Bürgerin	NOUN	NN	Case=Gen|Gender=Fem|Number=Plur	9	nmod	_	_
+12	und	und	CCONJ	KON	_	13	cc	_	_
+13	Bürger	Bürger	NOUN	NN	Case=Gen|Gender=Masc|Number=Plur	11	conj	_	_
+14	bestimmen	bestimmen	VERB	VVFIN	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	0	root	_	_
+15	dann	dann	ADV	ADV	_	14	advmod	_	_
+16	die	der	DET	ART	Case=Acc|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	17	det	_	_
+17	Politik	Politik	NOUN	NN	Case=Acc|Gender=Fem|Number=Sing	14	obj	_	SpaceAfter=No
+18	.	.	PUNCT	$.	_	14	punct	_	_
 
 # sent_id = dev-s623
 # text = Die Jugend verweigert sich, weil Gewerkschaften verkrustet und nicht attraktiv sind.
@@ -11039,50 +11083,52 @@
 12	.	.	PUNCT	$.	_	3	punct	_	_
 
 # sent_id = dev-s626
-# text = 22 000 Urteile wurden vollstreckt, der Rest in Haftstrafen umgewandelt.
-1	22	22	NUM	CARD	NumType=Card	2	nummod	_	_
-2	000	000	NUM	CARD	NumType=Card	3	nummod	_	_
-3	Urteile	Urteil	NOUN	NN	Case=Nom|Gender=Neut|Number=Plur	5	nsubj:pass	_	_
-4	wurden	werden	AUX	VAFIN	Mood=Ind|Number=Plur|Person=3|Tense=Past|VerbForm=Fin|Voice=Pass	5	aux:pass	_	_
-5	vollstreckt	vollstrecken	VERB	VVPP	VerbForm=Part	0	root	_	SpaceAfter=No
-6	,	,	PUNCT	$,	_	11	punct	_	_
-7	der	der	DET	ART	Case=Nom|Definite=Def|Gender=Masc|Number=Sing|PronType=Art	8	det	_	_
-8	Rest	Rest	NOUN	NN	Case=Nom|Gender=Masc|Number=Sing	11	nsubj:pass	_	_
-9	in	in	ADP	APPR	_	10	case	_	_
-10	Haftstrafen	Haftstrafe	NOUN	NN	Case=Acc|Gender=Fem|Number=Plur	11	obl	_	_
-11	umgewandelt	umwandeln	VERB	VVPP	VerbForm=Part	5	conj	_	SpaceAfter=No
-12	.	.	PUNCT	$.	_	5	punct	_	_
+# text = Über 22 000 Urteile wurden vollstreckt, der Rest in Haftstrafen umgewandelt.
+1	Über	über	ADV	ADV	_	2	dep	_	FixTigerDep=Yes
+2	22	22	NUM	CARD	NumType=Card	3	nummod	_	_
+3	000	000	NUM	CARD	NumType=Card	4	nummod	_	_
+4	Urteile	Urteil	NOUN	NN	Case=Nom|Gender=Neut|Number=Plur	6	nsubj:pass	_	_
+5	wurden	werden	AUX	VAFIN	Mood=Ind|Number=Plur|Person=3|Tense=Past|VerbForm=Fin|Voice=Pass	6	aux:pass	_	_
+6	vollstreckt	vollstrecken	VERB	VVPP	VerbForm=Part	0	root	_	SpaceAfter=No
+7	,	,	PUNCT	$,	_	12	punct	_	_
+8	der	der	DET	ART	Case=Nom|Definite=Def|Gender=Masc|Number=Sing|PronType=Art	9	det	_	_
+9	Rest	Rest	NOUN	NN	Case=Nom|Gender=Masc|Number=Sing	12	nsubj:pass	_	_
+10	in	in	ADP	APPR	_	11	case	_	_
+11	Haftstrafen	Haftstrafe	NOUN	NN	Case=Acc|Gender=Fem|Number=Plur	12	obl	_	_
+12	umgewandelt	umwandeln	VERB	VVPP	VerbForm=Part	6	conj	_	SpaceAfter=No
+13	.	.	PUNCT	$.	_	6	punct	_	_
 
 # sent_id = dev-s627
-# text = Vietnam kämpft mit den üblichen Schwierigkeiten sozialistischer Regimes beim ersten Flirt mit der Marktwirtschaft, vor allem mit Bürokratismus und Korruption.
-1	Vietnam	Vietnam	PROPN	NE	Case=Nom|Gender=Neut|Number=Sing	2	nsubj	_	_
-2	kämpft	kämpfen	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	0	root	_	_
-3	mit	mit	ADP	APPR	_	6	case	_	_
-4	den	der	DET	ART	Case=Dat|Definite=Def|Gender=Fem|Number=Plur|PronType=Art	6	det	_	_
-5	üblichen	üblich	ADJ	ADJA	Case=Dat|Gender=Fem|Number=Plur	6	amod	_	_
-6	Schwierigkeiten	Schwierigkeit	NOUN	NN	Case=Dat|Gender=Fem|Number=Plur	2	obl	_	_
-7	sozialistischer	sozialistisch	ADJ	ADJA	Case=Gen|Gender=Neut|Number=Plur	8	amod	_	_
-8	Regimes	Regime	NOUN	NN	Case=Gen|Gender=Neut|Number=Plur	6	nmod	_	_
-9-10	beim	_	_	_	_	_	_	_	_
-9	bei	bei	ADP	APPR	_	12	case	_	_
-10	dem	der	DET	ART	Case=Dat|Definite=Def|Gender=Neut|Number=Sing|PronType=Art	12	det	_	_
-11	ersten	erster	ADJ	ADJA	Case=Dat|Gender=Masc|Number=Sing	12	amod	_	_
-12	Flirt	Flirt	NOUN	NN	Case=Dat|Gender=Masc|Number=Sing	2	obl	_	_
-13	mit	mit	ADP	APPR	_	15	case	_	_
-14	der	der	DET	ART	Case=Dat|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	15	det	_	_
-15	Marktwirtschaft	Marktwirtschaft	NOUN	NN	Case=Dat|Gender=Fem|Number=Sing	12	nmod	_	SpaceAfter=No
-16	,	,	PUNCT	$,	_	2	punct	_	_
-17	vor	vor	ADP	APPR	_	18	case	_	_
-18	allem	alle	PRON	PIS	Case=Dat|Definite=Ind|Gender=Neut|Number=Sing|PronType=Ind	2	obl	_	_
-19	mit	mit	ADP	APPR	_	20	case	_	_
-20	Bürokratismus	Bürokratismus	NOUN	NN	Case=Dat|Gender=Masc|Number=Sing	2	obl	_	_
-21	und	und	CCONJ	KON	_	22	cc	_	_
-22	Korruption	Korruption	NOUN	NN	Case=Dat|Gender=Fem|Number=Sing	20	conj	_	SpaceAfter=No
-23	.	.	PUNCT	$.	_	2	punct	_	_
+# text = Doch Vietnam kämpft mit den üblichen Schwierigkeiten sozialistischer Regimes beim ersten Flirt mit der Marktwirtschaft, vor allem mit Bürokratismus und Korruption.
+1	Doch	doch	CCONJ	KON	_	2	dep	_	FixTigerDep=Yes
+2	Vietnam	Vietnam	PROPN	NE	Case=Nom|Gender=Neut|Number=Sing	3	nsubj	_	_
+3	kämpft	kämpfen	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	0	root	_	_
+4	mit	mit	ADP	APPR	_	7	case	_	_
+5	den	der	DET	ART	Case=Dat|Definite=Def|Gender=Fem|Number=Plur|PronType=Art	7	det	_	_
+6	üblichen	üblich	ADJ	ADJA	Case=Dat|Gender=Fem|Number=Plur	7	amod	_	_
+7	Schwierigkeiten	Schwierigkeit	NOUN	NN	Case=Dat|Gender=Fem|Number=Plur	3	obl	_	_
+8	sozialistischer	sozialistisch	ADJ	ADJA	Case=Gen|Gender=Neut|Number=Plur	9	amod	_	_
+9	Regimes	Regime	NOUN	NN	Case=Gen|Gender=Neut|Number=Plur	7	nmod	_	_
+10-11	beim	_	_	_	_	_	_	_	_
+10	bei	bei	ADP	APPR	_	13	case	_	_
+11	dem	der	DET	ART	Case=Dat|Definite=Def|Gender=Neut|Number=Sing|PronType=Art	13	det	_	_
+12	ersten	erster	ADJ	ADJA	Case=Dat|Gender=Masc|Number=Sing	13	amod	_	_
+13	Flirt	Flirt	NOUN	NN	Case=Dat|Gender=Masc|Number=Sing	3	obl	_	_
+14	mit	mit	ADP	APPR	_	16	case	_	_
+15	der	der	DET	ART	Case=Dat|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	16	det	_	_
+16	Marktwirtschaft	Marktwirtschaft	NOUN	NN	Case=Dat|Gender=Fem|Number=Sing	13	nmod	_	SpaceAfter=No
+17	,	,	PUNCT	$,	_	3	punct	_	_
+18	vor	vor	ADP	APPR	_	19	case	_	_
+19	allem	alle	PRON	PIS	Case=Dat|Definite=Ind|Gender=Neut|Number=Sing|PronType=Ind	3	obl	_	_
+20	mit	mit	ADP	APPR	_	21	case	_	_
+21	Bürokratismus	Bürokratismus	NOUN	NN	Case=Dat|Gender=Masc|Number=Sing	3	obl	_	_
+22	und	und	CCONJ	KON	_	23	cc	_	_
+23	Korruption	Korruption	NOUN	NN	Case=Dat|Gender=Fem|Number=Sing	21	conj	_	SpaceAfter=No
+24	.	.	PUNCT	$.	_	3	punct	_	_
 
 # sent_id = dev-s628
-# text = "Slow Speed'' ist da auf eine Wand geschrieben.
-1	"	"	PUNCT	$(	_	3	punct	_	SpaceAfter=No
+# text = ``Slow Speed'' ist da auf eine Wand geschrieben.
+1	``	"	PUNCT	$(	_	2	punct	_	FixTigerDep=Yes|SpaceAfter=No
 2	Slow	Slow	X	FM	Foreign=Yes	3	compound	_	_
 3	Speed	Speed	X	FM	Foreign=Yes	10	nsubj:pass	_	SpaceAfter=No
 4	''	''	PUNCT	$(	_	3	punct	_	_
@@ -11095,17 +11141,18 @@
 11	.	.	PUNCT	$.	_	10	punct	_	_
 
 # sent_id = dev-s629
-# text = Birkut wurde bei den Arbeiterunruhen 1970 in Danzig erschossen.
-1	Birkut	Birkut	PROPN	NE	Case=Nom|Gender=Masc|Number=Sing	9	nsubj:pass	_	_
-2	wurde	werden	AUX	VAFIN	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin|Voice=Pass	9	aux:pass	_	_
-3	bei	bei	ADP	APPR	_	5	case	_	_
-4	den	der	DET	ART	Case=Dat|Definite=Def|Gender=Fem|Number=Plur|PronType=Art	5	det	_	_
-5	Arbeiterunruhen	Arbeiterunruhe	NOUN	NN	Case=Dat|Gender=Fem|Number=Plur	9	obl	_	_
-6	1970	1970	NUM	CARD	NumType=Card	9	obl	_	_
-7	in	in	ADP	APPR	_	8	case	_	_
-8	Danzig	Danzig	PROPN	NE	Case=Dat|Gender=Neut|Number=Sing	9	obl	_	_
-9	erschossen	erschießen	VERB	VVPP	VerbForm=Part	0	root	_	SpaceAfter=No
-10	.	.	PUNCT	$.	_	9	punct	_	_
+# text = Aber Birkut wurde bei den Arbeiterunruhen 1970 in Danzig erschossen.
+1	Aber	aber	CCONJ	KON	_	2	dep	_	FixTigerDep=Yes
+2	Birkut	Birkut	PROPN	NE	Case=Nom|Gender=Masc|Number=Sing	10	nsubj:pass	_	_
+3	wurde	werden	AUX	VAFIN	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin|Voice=Pass	10	aux:pass	_	_
+4	bei	bei	ADP	APPR	_	6	case	_	_
+5	den	der	DET	ART	Case=Dat|Definite=Def|Gender=Fem|Number=Plur|PronType=Art	6	det	_	_
+6	Arbeiterunruhen	Arbeiterunruhe	NOUN	NN	Case=Dat|Gender=Fem|Number=Plur	10	obl	_	_
+7	1970	1970	NUM	CARD	NumType=Card	10	obl	_	_
+8	in	in	ADP	APPR	_	9	case	_	_
+9	Danzig	Danzig	PROPN	NE	Case=Dat|Gender=Neut|Number=Sing	10	obl	_	_
+10	erschossen	erschießen	VERB	VVPP	VerbForm=Part	0	root	_	SpaceAfter=No
+11	.	.	PUNCT	$.	_	10	punct	_	_
 
 # sent_id = dev-s630
 # text = Höhere Wertschöpfung fließt freilich weitgehend in die Taschen der Unternehmer und Vermögensbesitzer.
@@ -11124,13 +11171,14 @@
 13	.	.	PUNCT	$.	_	3	punct	_	_
 
 # sent_id = dev-s631
-# text = Wie reimt sich das zusammen?
-1	Wie	wie	ADV	PWAV	PronType=Int	2	advmod	_	_
-2	reimt	reimen	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	0	root	_	_
-3	sich	er|es|sie	PRON	PRF	Case=Acc|Number=Sing|Person=3|PronType=Prs|Reflex=Yes	2	obj	_	_
-4	das	der	PRON	PDS	Case=Nom|Gender=Neut|Number=Sing|PronType=Dem	2	nsubj	_	_
-5	zusammen	zusammen	ADV	PTKVZ	_	2	compound:prt	_	SpaceAfter=No
-6	?	?	PUNCT	$.	_	2	punct	_	_
+# text = -Wie reimt sich das zusammen?
+1	-	-	PUNCT	$(	_	2	punct	_	FixTigerDep=Yes|SpaceAfter=No
+2	Wie	wie	ADV	PWAV	PronType=Int	3	advmod	_	_
+3	reimt	reimen	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	0	root	_	_
+4	sich	er|es|sie	PRON	PRF	Case=Acc|Number=Sing|Person=3|PronType=Prs|Reflex=Yes	3	obj	_	_
+5	das	der	PRON	PDS	Case=Nom|Gender=Neut|Number=Sing|PronType=Dem	3	nsubj	_	_
+6	zusammen	zusammen	ADV	PTKVZ	_	3	compound:prt	_	SpaceAfter=No
+7	?	?	PUNCT	$.	_	3	punct	_	_
 
 # sent_id = dev-s632
 # text = Die Bankschulden wurden von 930 Millionen Mark in der Spitze auf 430 Millionen verringert.
@@ -11151,35 +11199,36 @@
 15	.	.	PUNCT	$.	_	14	punct	_	_
 
 # sent_id = dev-s633
-# text = Wir wären weitaus weiter, hätte man uns keine Steine in den Weg gelegt'', sagt der inzwischen in den Aufsichtsrat des hanseatischen Renommierklubs aufgerückte Versicherungsmakler.
-1	Wir	wir	PRON	PPER	Case=Nom|Number=Plur|Person=1|PronType=Prs	4	nsubj	_	_
-2	wären	sein	AUX	VAFIN	Mood=Sub|Number=Plur|Person=1|Tense=Past|VerbForm=Fin	4	cop	_	_
-3	weitaus	weitaus	ADV	ADV	_	4	advmod	_	_
-4	weiter	weiter	ADJ	ADV	_	17	ccomp	_	SpaceAfter=No
-5	,	,	PUNCT	$,	_	17	punct	_	_
-6	hätte	haben	AUX	VAFIN	Mood=Sub|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	14	aux	_	_
-7	man	man	PRON	PIS	Case=Nom|Definite=Ind|Number=Sing|PronType=Ind	14	nsubj	_	_
-8	uns	wir	PRON	PPER	Case=Dat|Number=Plur|Person=1|PronType=Prs	14	iobj	_	_
-9	keine	kein	PRON	PIAT	Case=Acc|Definite=Ind|Gender=Masc|Number=Plur|Polarity=Neg|PronType=Neg	10	advmod	_	_
-10	Steine	Stein	NOUN	NN	Case=Acc|Gender=Masc|Number=Plur	14	obj	_	_
-11	in	in	ADP	APPR	_	13	case	_	_
-12	den	der	DET	ART	Case=Acc|Definite=Def|Gender=Masc|Number=Sing|PronType=Art	13	det	_	_
-13	Weg	Weg	NOUN	NN	Case=Acc|Gender=Masc|Number=Sing	14	obl	_	_
-14	gelegt	legen	VERB	VVPP	VerbForm=Part	4	advcl	_	SpaceAfter=No
-15	''	''	PUNCT	$(	_	17	punct	_	SpaceAfter=No
-16	,	,	PUNCT	$,	_	17	punct	_	_
-17	sagt	sagen	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	0	root	_	_
-18	der	der	DET	ART	Case=Nom|Definite=Def|Gender=Masc|Number=Sing|PronType=Art	27	det	_	_
-19	inzwischen	inzwischen	ADV	ADV	_	26	advmod	_	_
-20	in	in	ADP	APPR	_	22	case	_	_
-21	den	der	DET	ART	Case=Acc|Definite=Def|Gender=Masc|Number=Sing|PronType=Art	22	det	_	_
-22	Aufsichtsrat	Aufsichtsrat	NOUN	NN	Case=Acc|Gender=Masc|Number=Sing	26	nmod	_	_
-23	des	der	DET	ART	Case=Gen|Definite=Def|Gender=Masc|Number=Sing|PronType=Art	25	det	_	_
-24	hanseatischen	hanseatisch	ADJ	ADJA	Case=Gen|Gender=Masc|Number=Sing	25	amod	_	_
-25	Renommierklubs	Renommierklub	NOUN	NN	Case=Gen|Gender=Masc|Number=Sing	22	nmod	_	_
-26	aufgerückte	aufgerückt	ADJ	ADJA	Case=Nom|Gender=Masc|Number=Sing	27	amod	_	_
-27	Versicherungsmakler	Versicherungsmakler	NOUN	NN	Case=Nom|Gender=Masc|Number=Sing	17	nsubj	_	SpaceAfter=No
-28	.	.	PUNCT	$.	_	17	punct	_	_
+# text = ``Wir wären weitaus weiter, hätte man uns keine Steine in den Weg gelegt'', sagt der inzwischen in den Aufsichtsrat des hanseatischen Renommierklubs aufgerückte Versicherungsmakler.
+1	``	``	PUNCT	$(	_	2	punct	_	FixTigerDep=Yes|SpaceAfter=No
+2	Wir	wir	PRON	PPER	Case=Nom|Number=Plur|Person=1|PronType=Prs	5	nsubj	_	_
+3	wären	sein	AUX	VAFIN	Mood=Sub|Number=Plur|Person=1|Tense=Past|VerbForm=Fin	5	cop	_	_
+4	weitaus	weitaus	ADV	ADV	_	5	advmod	_	_
+5	weiter	weiter	ADJ	ADV	_	18	ccomp	_	SpaceAfter=No
+6	,	,	PUNCT	$,	_	18	punct	_	_
+7	hätte	haben	AUX	VAFIN	Mood=Sub|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	15	aux	_	_
+8	man	man	PRON	PIS	Case=Nom|Definite=Ind|Number=Sing|PronType=Ind	15	nsubj	_	_
+9	uns	wir	PRON	PPER	Case=Dat|Number=Plur|Person=1|PronType=Prs	15	iobj	_	_
+10	keine	kein	PRON	PIAT	Case=Acc|Definite=Ind|Gender=Masc|Number=Plur|Polarity=Neg|PronType=Neg	11	advmod	_	_
+11	Steine	Stein	NOUN	NN	Case=Acc|Gender=Masc|Number=Plur	15	obj	_	_
+12	in	in	ADP	APPR	_	14	case	_	_
+13	den	der	DET	ART	Case=Acc|Definite=Def|Gender=Masc|Number=Sing|PronType=Art	14	det	_	_
+14	Weg	Weg	NOUN	NN	Case=Acc|Gender=Masc|Number=Sing	15	obl	_	_
+15	gelegt	legen	VERB	VVPP	VerbForm=Part	5	advcl	_	SpaceAfter=No
+16	''	''	PUNCT	$(	_	18	punct	_	SpaceAfter=No
+17	,	,	PUNCT	$,	_	18	punct	_	_
+18	sagt	sagen	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	0	root	_	_
+19	der	der	DET	ART	Case=Nom|Definite=Def|Gender=Masc|Number=Sing|PronType=Art	28	det	_	_
+20	inzwischen	inzwischen	ADV	ADV	_	27	advmod	_	_
+21	in	in	ADP	APPR	_	23	case	_	_
+22	den	der	DET	ART	Case=Acc|Definite=Def|Gender=Masc|Number=Sing|PronType=Art	23	det	_	_
+23	Aufsichtsrat	Aufsichtsrat	NOUN	NN	Case=Acc|Gender=Masc|Number=Sing	27	nmod	_	_
+24	des	der	DET	ART	Case=Gen|Definite=Def|Gender=Masc|Number=Sing|PronType=Art	26	det	_	_
+25	hanseatischen	hanseatisch	ADJ	ADJA	Case=Gen|Gender=Masc|Number=Sing	26	amod	_	_
+26	Renommierklubs	Renommierklub	NOUN	NN	Case=Gen|Gender=Masc|Number=Sing	23	nmod	_	_
+27	aufgerückte	aufgerückt	ADJ	ADJA	Case=Nom|Gender=Masc|Number=Sing	28	amod	_	_
+28	Versicherungsmakler	Versicherungsmakler	NOUN	NN	Case=Nom|Gender=Masc|Number=Sing	18	nsubj	_	SpaceAfter=No
+29	.	.	PUNCT	$.	_	18	punct	_	_
 
 # sent_id = dev-s634
 # text = Die Partner wollen in den ersten fünf Jahren 85 Millionen Dollar investieren.
@@ -11198,66 +11247,68 @@
 13	.	.	PUNCT	$.	_	12	punct	_	_
 
 # sent_id = dev-s635
-# text = Disney ist im ersten Halbjahr des laufenden Geschäftjahres per Ende September tiefer in die roten Zahlen gerutscht.
-1	Disney	Disney	PROPN	NE	Case=Nom|Number=Sing	18	nsubj	_	_
-2	ist	sein	AUX	VAFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	18	aux	_	_
-3-4	im	_	_	_	_	_	_	_	_
-3	in	in	ADP	APPR	_	6	case	_	_
-4	dem	der	DET	ART	Case=Dat|Definite=Def|Gender=Neut|Number=Sing|PronType=Art	6	det	_	_
-5	ersten	erster	ADJ	ADJA	Case=Dat|Gender=Neut|Number=Sing	6	amod	_	_
-6	Halbjahr	Halbjahr	NOUN	NN	Case=Dat|Gender=Neut|Number=Sing	18	obl	_	_
-7	des	der	DET	ART	Case=Gen|Definite=Def|Gender=Neut|Number=Sing|PronType=Art	9	det	_	_
-8	laufenden	laufend	ADJ	ADJA	Case=Gen|Gender=Neut|Number=Sing	9	amod	_	_
-9	Geschäftjahres	Geschäftjahr	NOUN	NN	Case=Gen|Gender=Neut|Number=Sing	6	nmod	_	_
-10	per	per	ADP	APPR	_	12	case	_	_
-11	Ende	Ende	NOUN	NN	Case=Acc|Gender=Neut|Number=Sing	12	compound	_	_
-12	September	September	PROPN	NN	Case=Nom|Gender=Masc|Number=Sing	18	obl	_	_
-13	tiefer	tief	ADV	ADJD	_	17	advmod	_	_
-14	in	in	ADP	APPR	_	17	case	_	_
-15	die	der	DET	ART	Case=Acc|Definite=Def|Gender=Fem|Number=Plur|PronType=Art	17	det	_	_
-16	roten	rot	ADJ	ADJA	Case=Acc|Gender=Fem|Number=Plur	17	amod	_	_
-17	Zahlen	Zahl	NOUN	NN	Case=Acc|Gender=Fem|Number=Plur	18	obl	_	_
-18	gerutscht	rutschen	VERB	VVPP	VerbForm=Part	0	root	_	SpaceAfter=No
-19	.	.	PUNCT	$.	_	18	punct	_	_
+# text = Euro Disney ist im ersten Halbjahr des laufenden Geschäftjahres per Ende September tiefer in die roten Zahlen gerutscht.
+1	Euro	Euro	PROPN	NE	_	2	dep	_	FixTigerDep=Yes
+2	Disney	Disney	PROPN	NE	Case=Nom|Number=Sing	19	nsubj	_	_
+3	ist	sein	AUX	VAFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	19	aux	_	_
+4-5	im	_	_	_	_	_	_	_	_
+4	in	in	ADP	APPR	_	7	case	_	_
+5	dem	der	DET	ART	Case=Dat|Definite=Def|Gender=Neut|Number=Sing|PronType=Art	7	det	_	_
+6	ersten	erster	ADJ	ADJA	Case=Dat|Gender=Neut|Number=Sing	7	amod	_	_
+7	Halbjahr	Halbjahr	NOUN	NN	Case=Dat|Gender=Neut|Number=Sing	19	obl	_	_
+8	des	der	DET	ART	Case=Gen|Definite=Def|Gender=Neut|Number=Sing|PronType=Art	10	det	_	_
+9	laufenden	laufend	ADJ	ADJA	Case=Gen|Gender=Neut|Number=Sing	10	amod	_	_
+10	Geschäftjahres	Geschäftjahr	NOUN	NN	Case=Gen|Gender=Neut|Number=Sing	7	nmod	_	_
+11	per	per	ADP	APPR	_	13	case	_	_
+12	Ende	Ende	NOUN	NN	Case=Acc|Gender=Neut|Number=Sing	13	compound	_	_
+13	September	September	PROPN	NN	Case=Nom|Gender=Masc|Number=Sing	19	obl	_	_
+14	tiefer	tief	ADV	ADJD	_	18	advmod	_	_
+15	in	in	ADP	APPR	_	18	case	_	_
+16	die	der	DET	ART	Case=Acc|Definite=Def|Gender=Fem|Number=Plur|PronType=Art	18	det	_	_
+17	roten	rot	ADJ	ADJA	Case=Acc|Gender=Fem|Number=Plur	18	amod	_	_
+18	Zahlen	Zahl	NOUN	NN	Case=Acc|Gender=Fem|Number=Plur	19	obl	_	_
+19	gerutscht	rutschen	VERB	VVPP	VerbForm=Part	0	root	_	SpaceAfter=No
+20	.	.	PUNCT	$.	_	19	punct	_	_
 
 # sent_id = dev-s636
-# text = Früher hatten die Pensionäre Tränen in den Augen, wenn sie gehen mußten, heute stöhnt, wer dabei bleiben soll'', berichtet Ewald Grom, Betriebsrats-Vize im Werk Höchst.
-1	Früher	früher	ADV	ADV	_	2	advmod	_	_
-2	hatten	haben	VERB	VAFIN	Mood=Ind|Number=Plur|Person=3|Tense=Past|VerbForm=Fin	24	ccomp	_	_
-3	die	der	DET	ART	Case=Nom|Definite=Def|Gender=Masc|Number=Plur|PronType=Art	4	det	_	_
-4	Pensionäre	Pensionär	NOUN	NN	Case=Nom|Gender=Masc|Number=Plur	2	nsubj	_	_
-5	Tränen	Träne	NOUN	NN	Case=Acc|Gender=Fem|Number=Plur	2	obj	_	_
-6	in	in	ADP	APPR	_	8	case	_	_
-7	den	der	DET	ART	Case=Dat|Definite=Def|Gender=Neut|Number=Plur|PronType=Art	8	det	_	_
-8	Augen	Auge	NOUN	NN	Case=Dat|Gender=Neut|Number=Plur	2	obl	_	SpaceAfter=No
-9	,	,	PUNCT	$,	_	24	punct	_	_
-10	wenn	wenn	SCONJ	KOUS	_	12	mark	_	_
-11	sie	sie	PRON	PPER	Case=Nom|Gender=Masc|Number=Plur|Person=3|PronType=Prs	12	nsubj	_	_
-12	gehen	gehen	VERB	VVINF	VerbForm=Inf	2	advcl	_	_
-13	mußten	müssen	AUX	VMFIN	Mood=Ind|Number=Plur|Person=3|Tense=Past|VerbForm=Fin	12	aux	_	SpaceAfter=No
-14	,	,	PUNCT	$,	_	16	punct	_	_
-15	heute	heute	ADV	ADV	_	16	advmod	_	_
-16	stöhnt	stöhnen	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	2	conj	_	SpaceAfter=No
-17	,	,	PUNCT	$,	_	24	punct	_	_
-18	wer	wer	PRON	PWS	Case=Nom|Gender=Masc|Number=Sing|PronType=Int	20	nsubj	_	_
-19	dabei	dabei	ADV	PAV	_	20	advmod	_	_
-20	bleiben	bleiben	VERB	VVINF	VerbForm=Inf	16	csubj	_	_
-21	soll	sollen	AUX	VMFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	20	aux	_	SpaceAfter=No
-22	''	''	PUNCT	$(	_	24	punct	_	SpaceAfter=No
-23	,	,	PUNCT	$,	_	24	punct	_	_
-24	berichtet	berichten	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	0	root	_	_
-25	Ewald	Ewald	PROPN	NE	Case=Nom|Gender=Masc|Number=Sing	24	nsubj	_	_
-26	Grom	Grom	PROPN	NE	Case=Nom|Gender=Masc|Number=Sing	25	flat	_	SpaceAfter=No
-27	,	,	PUNCT	$,	_	24	punct	_	_
-28	Betriebsrats	Betriebsrat	NOUN	NN	Case=Nom|Gender=Masc|Number=Sing	30	compound	_	SpaceAfter=No
-29	-	-	PUNCT	$(	_	28	punct	_	SpaceAfter=No
-30	Vize	Vize	NOUN	NN	Case=Nom|Gender=Masc|Number=Sing	25	appos	_	_
-31-32	im	_	_	_	_	_	_	_	_
-31	in	in	ADP	APPR	_	33	case	_	_
-32	dem	der	DET	ART	Case=Dat|Definite=Def|Gender=Neut|Number=Sing|PronType=Art	33	det	_	_
-33	Werk	Werk	NOUN	NN	Case=Dat|Gender=Neut|Number=Sing	30	nmod	_	_
-34	Höchst	Höchst	PROPN	NE	Case=Nom|Number=Sing	33	appos	_	SpaceAfter=No
-35	.	.	PUNCT	$.	_	24	punct	_	_
+# text = ``Früher hatten die Pensionäre Tränen in den Augen, wenn sie gehen mußten, heute stöhnt, wer dabei bleiben soll'', berichtet Ewald Grom, Betriebsrats-Vize im Werk Höchst.
+1	``	``	PUNCT	$(	_	2	punct	_	FixTigerDep=Yes|SpaceAfter=No
+2	Früher	früher	ADV	ADV	_	3	advmod	_	_
+3	hatten	haben	VERB	VAFIN	Mood=Ind|Number=Plur|Person=3|Tense=Past|VerbForm=Fin	25	ccomp	_	_
+4	die	der	DET	ART	Case=Nom|Definite=Def|Gender=Masc|Number=Plur|PronType=Art	5	det	_	_
+5	Pensionäre	Pensionär	NOUN	NN	Case=Nom|Gender=Masc|Number=Plur	3	nsubj	_	_
+6	Tränen	Träne	NOUN	NN	Case=Acc|Gender=Fem|Number=Plur	3	obj	_	_
+7	in	in	ADP	APPR	_	9	case	_	_
+8	den	der	DET	ART	Case=Dat|Definite=Def|Gender=Neut|Number=Plur|PronType=Art	9	det	_	_
+9	Augen	Auge	NOUN	NN	Case=Dat|Gender=Neut|Number=Plur	3	obl	_	SpaceAfter=No
+10	,	,	PUNCT	$,	_	25	punct	_	_
+11	wenn	wenn	SCONJ	KOUS	_	13	mark	_	_
+12	sie	sie	PRON	PPER	Case=Nom|Gender=Masc|Number=Plur|Person=3|PronType=Prs	13	nsubj	_	_
+13	gehen	gehen	VERB	VVINF	VerbForm=Inf	3	advcl	_	_
+14	mußten	müssen	AUX	VMFIN	Mood=Ind|Number=Plur|Person=3|Tense=Past|VerbForm=Fin	13	aux	_	SpaceAfter=No
+15	,	,	PUNCT	$,	_	17	punct	_	_
+16	heute	heute	ADV	ADV	_	17	advmod	_	_
+17	stöhnt	stöhnen	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	3	conj	_	SpaceAfter=No
+18	,	,	PUNCT	$,	_	25	punct	_	_
+19	wer	wer	PRON	PWS	Case=Nom|Gender=Masc|Number=Sing|PronType=Int	21	nsubj	_	_
+20	dabei	dabei	ADV	PAV	_	21	advmod	_	_
+21	bleiben	bleiben	VERB	VVINF	VerbForm=Inf	17	csubj	_	_
+22	soll	sollen	AUX	VMFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	21	aux	_	SpaceAfter=No
+23	''	''	PUNCT	$(	_	25	punct	_	SpaceAfter=No
+24	,	,	PUNCT	$,	_	25	punct	_	_
+25	berichtet	berichten	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	0	root	_	_
+26	Ewald	Ewald	PROPN	NE	Case=Nom|Gender=Masc|Number=Sing	25	nsubj	_	_
+27	Grom	Grom	PROPN	NE	Case=Nom|Gender=Masc|Number=Sing	26	flat	_	SpaceAfter=No
+28	,	,	PUNCT	$,	_	25	punct	_	_
+29	Betriebsrats	Betriebsrat	NOUN	NN	Case=Nom|Gender=Masc|Number=Sing	31	compound	_	SpaceAfter=No
+30	-	-	PUNCT	$(	_	29	punct	_	SpaceAfter=No
+31	Vize	Vize	NOUN	NN	Case=Nom|Gender=Masc|Number=Sing	26	appos	_	_
+32-33	im	_	_	_	_	_	_	_	_
+32	in	in	ADP	APPR	_	34	case	_	_
+33	dem	der	DET	ART	Case=Dat|Definite=Def|Gender=Neut|Number=Sing|PronType=Art	34	det	_	_
+34	Werk	Werk	NOUN	NN	Case=Dat|Gender=Neut|Number=Sing	31	nmod	_	_
+35	Höchst	Höchst	PROPN	NE	Case=Nom|Number=Sing	34	appos	_	SpaceAfter=No
+36	.	.	PUNCT	$.	_	25	punct	_	_
 
 # sent_id = dev-s637
 # text = Die Beschäftigten werden vom 1. Juli an 38 statt bisher 36 Stunden in der Woche tätig sein.
@@ -11283,86 +11334,89 @@
 19	.	.	PUNCT	$.	_	17	punct	_	_
 
 # sent_id = dev-s638
-# text = Ziel ist es, die Verbrauchsteuern zu senken und die Steuern auf Vermögen anzuheben.
-1	Ziel	Ziel	NOUN	NN	Case=Nom|Gender=Neut|Number=Sing	2	nsubj	_	_
-2	ist	sein	VERB	VAFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	0	root	_	_
-3	es	es	PRON	PPER	Case=Nom|Gender=Neut|Number=Sing|Person=3|PronType=Prs	2	expl	_	SpaceAfter=No
-4	,	,	PUNCT	$,	_	2	punct	_	_
-5	die	der	DET	ART	Case=Acc|Definite=Def|Gender=Fem|Number=Plur|PronType=Art	6	det	_	_
-6	Verbrauchsteuern	Verbrauchsteuer	NOUN	NN	Case=Acc|Gender=Fem|Number=Plur	8	obj	_	_
-7	zu	zu	PART	PTKZU	_	8	mark	_	_
-8	senken	senken	VERB	VVINF	VerbForm=Inf	2	xcomp	_	_
-9	und	und	CCONJ	KON	_	14	cc	_	_
-10	die	der	DET	ART	Case=Acc|Definite=Def|Gender=Fem|Number=Plur|PronType=Art	11	det	_	_
-11	Steuern	Steuer	NOUN	NN	Case=Acc|Gender=Fem|Number=Plur	14	obj	_	_
-12	auf	auf	ADP	APPR	_	13	case	_	_
-13	Vermögen	Vermögen	NOUN	NN	Case=Dat|Gender=Neut|Number=Sing	11	nmod	_	_
-14	anzuheben	anheben	VERB	VVIZU	VerbForm=Inf	8	conj	_	SpaceAfter=No
-15	.	.	PUNCT	$.	_	2	punct	_	_
+# text = Sein Ziel ist es, die Verbrauchsteuern zu senken und die Steuern auf Vermögen anzuheben.
+1	Sein	sein	DET	PPOSAT	Case=Nom|Gender=Neut|Number=Sing|Poss=Yes	2	dep	_	FixTigerDep=Yes
+2	Ziel	Ziel	NOUN	NN	Case=Nom|Gender=Neut|Number=Sing	3	nsubj	_	_
+3	ist	sein	VERB	VAFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	0	root	_	_
+4	es	es	PRON	PPER	Case=Nom|Gender=Neut|Number=Sing|Person=3|PronType=Prs	3	expl	_	SpaceAfter=No
+5	,	,	PUNCT	$,	_	3	punct	_	_
+6	die	der	DET	ART	Case=Acc|Definite=Def|Gender=Fem|Number=Plur|PronType=Art	7	det	_	_
+7	Verbrauchsteuern	Verbrauchsteuer	NOUN	NN	Case=Acc|Gender=Fem|Number=Plur	9	obj	_	_
+8	zu	zu	PART	PTKZU	_	9	mark	_	_
+9	senken	senken	VERB	VVINF	VerbForm=Inf	3	xcomp	_	_
+10	und	und	CCONJ	KON	_	15	cc	_	_
+11	die	der	DET	ART	Case=Acc|Definite=Def|Gender=Fem|Number=Plur|PronType=Art	12	det	_	_
+12	Steuern	Steuer	NOUN	NN	Case=Acc|Gender=Fem|Number=Plur	15	obj	_	_
+13	auf	auf	ADP	APPR	_	14	case	_	_
+14	Vermögen	Vermögen	NOUN	NN	Case=Dat|Gender=Neut|Number=Sing	12	nmod	_	_
+15	anzuheben	anheben	VERB	VVIZU	VerbForm=Inf	9	conj	_	SpaceAfter=No
+16	.	.	PUNCT	$.	_	3	punct	_	_
 
 # sent_id = dev-s639
-# text = Die Welt nach Krupp / Thyssen ist nicht mehr die, die sie davor war'', meint Breuer.
-1	Die	der	DET	ART	Case=Nom|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	2	det	_	_
-2	Welt	Welt	NOUN	NN	Case=Nom|Gender=Fem|Number=Sing	10	nsubj	_	_
-3	nach	nach	ADP	APPR	_	6	case	_	_
-4	Krupp	Krupp	PROPN	NE	Case=Dat|Number=Sing	2	nmod	_	_
-5	/	/	PUNCT	$(	_	6	punct	_	_
-6	Thyssen	Thyssen	PROPN	NE	Case=Dat|Number=Sing	4	conj	_	_
-7	ist	sein	AUX	VAFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	10	cop	_	_
-8	nicht	nicht	PART	PTKNEG	Polarity=Neg	7	advmod	_	_
-9	mehr	mehr	ADV	ADV	_	8	advmod	_	_
-10	die	der	PRON	PDS	Case=Nom|Gender=Neut|Number=Sing|PronType=Dem	18	ccomp	_	SpaceAfter=No
-11	,	,	PUNCT	$,	_	18	punct	_	_
-12	die	der	PRON	PRELS	Case=Nom|Gender=Fem|Number=Sing|PronType=Rel	15	obj	_	_
-13	sie	sie	PRON	PPER	Case=Nom|Gender=Fem|Number=Sing|Person=3|PronType=Prs	15	nsubj	_	_
-14	davor	davor	ADV	PAV	_	15	advmod	_	_
-15	war	sein	VERB	VAFIN	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	10	acl	_	SpaceAfter=No
-16	''	''	PUNCT	$(	_	18	punct	_	SpaceAfter=No
-17	,	,	PUNCT	$,	_	18	punct	_	_
-18	meint	meinen	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	0	root	_	_
-19	Breuer	Breuer	PROPN	NE	Case=Nom|Number=Sing	18	nsubj	_	SpaceAfter=No
-20	.	.	PUNCT	$.	_	18	punct	_	_
+# text = ``Die Welt nach Krupp / Thyssen ist nicht mehr die, die sie davor war'', meint Breuer.
+1	``	``	PUNCT	$(	_	2	punct	_	FixTigerDep=Yes|SpaceAfter=No
+2	Die	der	DET	ART	Case=Nom|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	3	det	_	_
+3	Welt	Welt	NOUN	NN	Case=Nom|Gender=Fem|Number=Sing	11	nsubj	_	_
+4	nach	nach	ADP	APPR	_	7	case	_	_
+5	Krupp	Krupp	PROPN	NE	Case=Dat|Number=Sing	3	nmod	_	_
+6	/	/	PUNCT	$(	_	7	punct	_	_
+7	Thyssen	Thyssen	PROPN	NE	Case=Dat|Number=Sing	5	conj	_	_
+8	ist	sein	AUX	VAFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	11	cop	_	_
+9	nicht	nicht	PART	PTKNEG	Polarity=Neg	8	advmod	_	_
+10	mehr	mehr	ADV	ADV	_	9	advmod	_	_
+11	die	der	PRON	PDS	Case=Nom|Gender=Neut|Number=Sing|PronType=Dem	19	ccomp	_	SpaceAfter=No
+12	,	,	PUNCT	$,	_	19	punct	_	_
+13	die	der	PRON	PRELS	Case=Nom|Gender=Fem|Number=Sing|PronType=Rel	16	obj	_	_
+14	sie	sie	PRON	PPER	Case=Nom|Gender=Fem|Number=Sing|Person=3|PronType=Prs	16	nsubj	_	_
+15	davor	davor	ADV	PAV	_	16	advmod	_	_
+16	war	sein	VERB	VAFIN	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	11	acl	_	SpaceAfter=No
+17	''	''	PUNCT	$(	_	19	punct	_	SpaceAfter=No
+18	,	,	PUNCT	$,	_	19	punct	_	_
+19	meint	meinen	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	0	root	_	_
+20	Breuer	Breuer	PROPN	NE	Case=Nom|Number=Sing	19	nsubj	_	SpaceAfter=No
+21	.	.	PUNCT	$.	_	19	punct	_	_
 
 # sent_id = dev-s640
-# text = Kernpunkte der Dubliner Vereinbarungen sind die Einführung eines ``Frühwarnsystems'' für finanzpolitische Fehlentwicklungen, die Präzisierung und Straffung der Abläufe bei übermäßigen Defiziten unter anderem durch Selbstbindungen der Länder und EU-Gremien sowie klare Terminvorgaben.
-1	Kernpunkte	Kernpunkt	NOUN	NN	Case=Nom|Gender=Masc|Number=Plur	7	nsubj	_	_
-2	der	der	DET	ART	Case=Gen|Definite=Def|Gender=Fem|Number=Plur|PronType=Art	4	det	_	_
-3	Dubliner	Dubliner	ADJ	ADJA	_	4	amod	_	_
-4	Vereinbarungen	Vereinbarung	NOUN	NN	Case=Gen|Gender=Fem|Number=Plur	1	nmod	_	_
-5	sind	sein	AUX	VAFIN	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	7	cop	_	_
-6	die	der	DET	ART	Case=Nom|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	7	det	_	_
-7	Einführung	Einführung	NOUN	NN	Case=Nom|Gender=Fem|Number=Sing	0	root	_	_
-8	eines	ein	DET	ART	Case=Gen|Definite=Ind|Gender=Neut|Number=Sing|PronType=Art	10	det	_	_
-9	``	``	PUNCT	$(	_	10	punct	_	SpaceAfter=No
-10	Frühwarnsystems	Frühwarnsystem	NOUN	NN	Case=Gen|Gender=Neut|Number=Sing	7	nmod	_	SpaceAfter=No
-11	''	''	PUNCT	$(	_	10	punct	_	_
-12	für	für	ADP	APPR	_	14	case	_	_
-13	finanzpolitische	finanzpolitisch	ADJ	ADJA	Case=Acc|Gender=Fem|Number=Plur	14	amod	_	_
-14	Fehlentwicklungen	Fehlentwicklung	NOUN	NN	Case=Acc|Gender=Fem|Number=Plur	10	nmod	_	SpaceAfter=No
-15	,	,	PUNCT	$,	_	17	punct	_	_
-16	die	der	DET	ART	Case=Nom|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	17	det	_	_
-17	Präzisierung	Präzisierung	NOUN	NN	Case=Nom|Gender=Fem|Number=Sing	7	conj	_	_
-18	und	und	CCONJ	KON	_	19	cc	_	_
-19	Straffung	Straffung	NOUN	NN	Case=Nom|Gender=Fem|Number=Sing	17	conj	_	_
-20	der	der	DET	ART	Case=Gen|Definite=Def|Gender=Masc|Number=Plur|PronType=Art	21	det	_	_
-21	Abläufe	Ablauf	NOUN	NN	Case=Gen|Gender=Masc|Number=Plur	17	nmod	_	_
-22	bei	bei	ADP	APPR	_	24	case	_	_
-23	übermäßigen	übermäßig	ADJ	ADJA	Case=Dat|Gender=Neut|Number=Plur	24	amod	_	_
-24	Defiziten	Defizit	NOUN	NN	Case=Dat|Gender=Neut|Number=Plur	21	nmod	_	_
-25	unter	unter	ADP	APPR	_	17	appos	_	_
-26	anderem	ander	PRON	PIS	Case=Dat|Definite=Ind|Gender=Neut|Number=Sing|PronType=Ind	25	fixed	_	_
-27	durch	durch	ADP	APPR	_	28	case	_	_
-28	Selbstbindungen	Selbstbindung	NOUN	NN	Case=Acc|Gender=Fem|Number=Plur	25	nmod	_	_
-29	der	der	DET	ART	Case=Gen|Definite=Def|Gender=Neut|Number=Plur|PronType=Art	30	det	_	_
-30	Länder	Land	NOUN	NN	Case=Gen|Gender=Neut|Number=Plur	28	nmod	_	_
-31	und	und	CCONJ	KON	_	32	cc	_	_
-32	EU	EU	PROPN	NN	Case=Gen|Gender=Neut|Number=Plur	34	compound	_	SpaceAfter=No
-33	-	-	PUNCT	$(	_	32	punct	_	SpaceAfter=No
-34	Gremien	Gremium	NOUN	NN	Case=Gen|Gender=Neut|Number=Plur	30	conj	_	_
-35	sowie	sowie	CCONJ	KON	_	37	cc	_	_
-36	klare	klar	ADJ	ADJA	Case=Nom|Gender=Fem|Number=Plur	37	amod	_	_
-37	Terminvorgaben	Terminvorgabe	NOUN	NN	Case=Nom|Gender=Fem|Number=Plur	17	conj	_	SpaceAfter=No
-38	.	.	PUNCT	$.	_	7	punct	_	_
+# text = Weitere Kernpunkte der Dubliner Vereinbarungen sind die Einführung eines ``Frühwarnsystems'' für finanzpolitische Fehlentwicklungen, die Präzisierung und Straffung der Abläufe bei übermäßigen Defiziten unter anderem durch Selbstbindungen der Länder und EU-Gremien sowie klare Terminvorgaben.
+1	Weitere	weit	ADJ	ADJA	Case=Nom|Gender=Masc|Number=Plur	2	dep	_	FixTigerDep=Yes
+2	Kernpunkte	Kernpunkt	NOUN	NN	Case=Nom|Gender=Masc|Number=Plur	8	nsubj	_	_
+3	der	der	DET	ART	Case=Gen|Definite=Def|Gender=Fem|Number=Plur|PronType=Art	5	det	_	_
+4	Dubliner	Dubliner	ADJ	ADJA	_	5	amod	_	_
+5	Vereinbarungen	Vereinbarung	NOUN	NN	Case=Gen|Gender=Fem|Number=Plur	2	nmod	_	_
+6	sind	sein	AUX	VAFIN	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	8	cop	_	_
+7	die	der	DET	ART	Case=Nom|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	8	det	_	_
+8	Einführung	Einführung	NOUN	NN	Case=Nom|Gender=Fem|Number=Sing	0	root	_	_
+9	eines	ein	DET	ART	Case=Gen|Definite=Ind|Gender=Neut|Number=Sing|PronType=Art	11	det	_	_
+10	``	``	PUNCT	$(	_	11	punct	_	SpaceAfter=No
+11	Frühwarnsystems	Frühwarnsystem	NOUN	NN	Case=Gen|Gender=Neut|Number=Sing	8	nmod	_	SpaceAfter=No
+12	''	''	PUNCT	$(	_	11	punct	_	_
+13	für	für	ADP	APPR	_	15	case	_	_
+14	finanzpolitische	finanzpolitisch	ADJ	ADJA	Case=Acc|Gender=Fem|Number=Plur	15	amod	_	_
+15	Fehlentwicklungen	Fehlentwicklung	NOUN	NN	Case=Acc|Gender=Fem|Number=Plur	11	nmod	_	SpaceAfter=No
+16	,	,	PUNCT	$,	_	18	punct	_	_
+17	die	der	DET	ART	Case=Nom|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	18	det	_	_
+18	Präzisierung	Präzisierung	NOUN	NN	Case=Nom|Gender=Fem|Number=Sing	8	conj	_	_
+19	und	und	CCONJ	KON	_	20	cc	_	_
+20	Straffung	Straffung	NOUN	NN	Case=Nom|Gender=Fem|Number=Sing	18	conj	_	_
+21	der	der	DET	ART	Case=Gen|Definite=Def|Gender=Masc|Number=Plur|PronType=Art	22	det	_	_
+22	Abläufe	Ablauf	NOUN	NN	Case=Gen|Gender=Masc|Number=Plur	18	nmod	_	_
+23	bei	bei	ADP	APPR	_	25	case	_	_
+24	übermäßigen	übermäßig	ADJ	ADJA	Case=Dat|Gender=Neut|Number=Plur	25	amod	_	_
+25	Defiziten	Defizit	NOUN	NN	Case=Dat|Gender=Neut|Number=Plur	22	nmod	_	_
+26	unter	unter	ADP	APPR	_	18	appos	_	_
+27	anderem	ander	PRON	PIS	Case=Dat|Definite=Ind|Gender=Neut|Number=Sing|PronType=Ind	26	fixed	_	_
+28	durch	durch	ADP	APPR	_	29	case	_	_
+29	Selbstbindungen	Selbstbindung	NOUN	NN	Case=Acc|Gender=Fem|Number=Plur	26	nmod	_	_
+30	der	der	DET	ART	Case=Gen|Definite=Def|Gender=Neut|Number=Plur|PronType=Art	31	det	_	_
+31	Länder	Land	NOUN	NN	Case=Gen|Gender=Neut|Number=Plur	29	nmod	_	_
+32	und	und	CCONJ	KON	_	33	cc	_	_
+33	EU	EU	PROPN	NN	Case=Gen|Gender=Neut|Number=Plur	35	compound	_	SpaceAfter=No
+34	-	-	PUNCT	$(	_	33	punct	_	SpaceAfter=No
+35	Gremien	Gremium	NOUN	NN	Case=Gen|Gender=Neut|Number=Plur	31	conj	_	_
+36	sowie	sowie	CCONJ	KON	_	38	cc	_	_
+37	klare	klar	ADJ	ADJA	Case=Nom|Gender=Fem|Number=Plur	38	amod	_	_
+38	Terminvorgaben	Terminvorgabe	NOUN	NN	Case=Nom|Gender=Fem|Number=Plur	18	conj	_	SpaceAfter=No
+39	.	.	PUNCT	$.	_	8	punct	_	_
 
 # sent_id = dev-s641
 # text = Die Politik verliere durch die Globalisierung der Wirtschaft an Bedeutung, begründen die Frankfurter ihren Schritt, gleichzeitig wachse die Eigenverantwortung international tätiger Unternehmen.
@@ -11393,23 +11447,24 @@
 25	.	.	PUNCT	$.	_	3	punct	_	_
 
 # sent_id = dev-s642
-# text = Ich hoffe, auch aus der Direktion des EWI ein Team machen zu können.''
-1	Ich	ich	PRON	PPER	Case=Nom|Number=Sing|Person=1|PronType=Prs	2	nsubj	_	_
-2	hoffe	hoffen	VERB	VVFIN	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	0	root	_	SpaceAfter=No
-3	,	,	PUNCT	$,	_	2	punct	_	_
-4	auch	auch	ADV	ADV	_	12	advmod	_	_
-5	aus	aus	ADP	APPR	_	7	case	_	_
-6	der	der	DET	ART	Case=Dat|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	7	det	_	_
-7	Direktion	Direktion	NOUN	NN	Case=Dat|Gender=Fem|Number=Sing	12	obl	_	_
-8	des	der	DET	ART	Case=Gen|Definite=Def|Gender=Neut|Number=Sing|PronType=Art	9	det	_	_
-9	EWI	EWI	PROPN	NE	Case=Gen|Gender=Neut|Number=Sing	7	nmod	_	_
-10	ein	ein	DET	ART	Case=Acc|Definite=Ind|Gender=Neut|Number=Sing|PronType=Art	11	det	_	_
-11	Team	Team	NOUN	NN	Case=Acc|Gender=Neut|Number=Sing	12	obj	_	_
-12	machen	machen	VERB	VVINF	VerbForm=Inf	2	xcomp	_	_
-13	zu	zu	PART	PTKZU	_	14	mark	_	_
-14	können	können	AUX	VMINF	VerbForm=Inf	12	xcomp	_	SpaceAfter=No
-15	.	.	PUNCT	$.	_	2	punct	_	SpaceAfter=No
-16	''	''	PUNCT	$(	_	2	punct	_	_
+# text = ``Ich hoffe, auch aus der Direktion des EWI ein Team machen zu können.''
+1	``	``	PUNCT	$(	_	2	punct	_	FixTigerDep=Yes|SpaceAfter=No
+2	Ich	ich	PRON	PPER	Case=Nom|Number=Sing|Person=1|PronType=Prs	3	nsubj	_	_
+3	hoffe	hoffen	VERB	VVFIN	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	0	root	_	SpaceAfter=No
+4	,	,	PUNCT	$,	_	3	punct	_	_
+5	auch	auch	ADV	ADV	_	13	advmod	_	_
+6	aus	aus	ADP	APPR	_	8	case	_	_
+7	der	der	DET	ART	Case=Dat|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	8	det	_	_
+8	Direktion	Direktion	NOUN	NN	Case=Dat|Gender=Fem|Number=Sing	13	obl	_	_
+9	des	der	DET	ART	Case=Gen|Definite=Def|Gender=Neut|Number=Sing|PronType=Art	10	det	_	_
+10	EWI	EWI	PROPN	NE	Case=Gen|Gender=Neut|Number=Sing	8	nmod	_	_
+11	ein	ein	DET	ART	Case=Acc|Definite=Ind|Gender=Neut|Number=Sing|PronType=Art	12	det	_	_
+12	Team	Team	NOUN	NN	Case=Acc|Gender=Neut|Number=Sing	13	obj	_	_
+13	machen	machen	VERB	VVINF	VerbForm=Inf	3	xcomp	_	_
+14	zu	zu	PART	PTKZU	_	15	mark	_	_
+15	können	können	AUX	VMINF	VerbForm=Inf	13	xcomp	_	SpaceAfter=No
+16	.	.	PUNCT	$.	_	3	punct	_	SpaceAfter=No
+17	''	''	PUNCT	$(	_	3	punct	_	_
 
 # sent_id = dev-s643
 # text = Das Kölner Unternehmen Gastro Unlimited hat das Modell entwickelt und liefert Betreiberkonzepte für die Bank-Cafés beziehungsweise bietet sich auch selbst als deren Betreiber an.
@@ -11442,49 +11497,50 @@
 27	.	.	PUNCT	$.	_	9	punct	_	_
 
 # sent_id = dev-s644
-# text = Ende letzten Jahres kommen täglich eine Handvoll Ermittler des niedersächsischen Landeskriminalamtes (LKA) aus Hannover nach Göttingen, um die autonome Szene wegen des Verdachts der Gründung, Mitgliedschaft oder Unterstützung einer terroristischen Vereinigung nach Paragraph 129 a Strafgesetzbuch auszuforschen.
-1	Ende	Ende	NOUN	NN	Case=Dat|Gender=Neut|Number=Sing	3	compound	_	_
-2	letzten	letzter	ADJ	ADJA	Case=Gen|Gender=Neut|Number=Sing	3	amod	_	_
-3	Jahres	Jahr	NOUN	NN	Case=Gen|Gender=Neut|Number=Sing	4	obl	_	_
-4	kommen	kommen	VERB	VVFIN	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	0	root	_	_
-5	täglich	täglich	ADV	ADJD	_	4	advmod	_	_
-6	eine	ein	DET	ART	Case=Nom|Definite=Ind|Gender=Fem|Number=Sing|PronType=Art	7	det	_	_
-7	Handvoll	Handvoll	NOUN	NN	Case=Nom|Gender=Fem|Number=Sing	8	compound	_	_
-8	Ermittler	Ermittler	NOUN	NN	Case=Gen|Gender=Masc|Number=Plur	4	nsubj	_	_
-9	des	der	DET	ART	Case=Gen|Definite=Def|Gender=Neut|Number=Sing|PronType=Art	11	det	_	_
-10	niedersächsischen	niedersächsisch	ADJ	ADJA	Case=Gen|Gender=Neut|Number=Sing	11	amod	_	_
-11	Landeskriminalamtes	Landeskriminalamt	NOUN	NE	Case=Gen|Gender=Neut|Number=Sing	8	nmod	_	_
-12	(	(	PUNCT	$(	_	13	punct	_	SpaceAfter=No
-13	LKA	LKA	PROPN	NE	Case=Gen|Gender=Neut|Number=Sing	11	appos	_	SpaceAfter=No
-14	)	)	PUNCT	$(	_	13	punct	_	_
-15	aus	aus	ADP	APPR	_	16	case	_	_
-16	Hannover	Hannover	PROPN	NE	Case=Dat|Gender=Neut|Number=Sing	4	obl	_	_
-17	nach	nach	ADP	APPR	_	18	case	_	_
-18	Göttingen	Göttingen	PROPN	NE	Case=Dat|Gender=Neut|Number=Sing	4	obl	_	SpaceAfter=No
-19	,	,	PUNCT	$,	_	4	punct	_	_
-20	um	um	ADP	KOUI	_	41	aux	_	_
-21	die	der	DET	ART	Case=Acc|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	23	det	_	_
-22	autonome	autonom	ADJ	ADJA	Case=Acc|Gender=Fem|Number=Sing	23	amod	_	_
-23	Szene	Szene	NOUN	NN	Case=Acc|Gender=Fem|Number=Sing	41	obj	_	_
-24	wegen	wegen	ADP	APPR	_	26	case	_	_
-25	des	der	DET	ART	Case=Gen|Definite=Def|Gender=Masc|Number=Sing|PronType=Art	26	det	_	_
-26	Verdachts	Verdacht	NOUN	NN	Case=Gen|Gender=Masc|Number=Sing	41	obl	_	_
-27	der	der	DET	ART	Case=Gen|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	28	det	_	_
-28	Gründung	Gründung	NOUN	NN	Case=Gen|Gender=Fem|Number=Sing	26	nmod	_	SpaceAfter=No
-29	,	,	PUNCT	$,	_	30	punct	_	_
-30	Mitgliedschaft	Mitgliedschaft	NOUN	NN	Case=Gen|Gender=Fem|Number=Sing	28	conj	_	_
-31	oder	oder	CCONJ	KON	_	32	cc	_	_
-32	Unterstützung	Unterstützung	NOUN	NN	Case=Gen|Gender=Fem|Number=Sing	28	conj	_	_
-33	einer	ein	DET	ART	Case=Gen|Definite=Ind|Gender=Fem|Number=Sing|PronType=Art	35	det	_	_
-34	terroristischen	terroristisch	ADJ	ADJA	Case=Gen|Gender=Fem|Number=Sing	35	amod	_	_
-35	Vereinigung	Vereinigung	NOUN	NN	Case=Gen|Gender=Fem|Number=Sing	28	nmod	_	_
-36	nach	nach	ADP	APPR	_	37	case	_	_
-37	Paragraph	Paragraph	NOUN	NN	Case=Dat|Gender=Masc|Number=Sing	26	nmod	_	_
-38	129	129	NUM	CARD	NumType=Card	37	nummod	_	_
-39	a	a	X	XY	_	38	dep	_	_
-40	Strafgesetzbuch	Strafgesetzbuch	NOUN	NN	Case=Nom|Gender=Neut|Number=Sing	37	compound	_	_
-41	auszuforschen	ausforschen	VERB	VVIZU	VerbForm=Inf	4	advcl	_	SpaceAfter=No
-42	.	.	PUNCT	$.	_	4	punct	_	_
+# text = Seit Ende letzten Jahres kommen täglich eine Handvoll Ermittler des niedersächsischen Landeskriminalamtes (LKA) aus Hannover nach Göttingen, um die autonome Szene wegen des Verdachts der Gründung, Mitgliedschaft oder Unterstützung einer terroristischen Vereinigung nach Paragraph 129 a Strafgesetzbuch auszuforschen.
+1	Seit	seit	ADP	APPR	_	2	dep	_	FixTigerDep=Yes
+2	Ende	Ende	NOUN	NN	Case=Dat|Gender=Neut|Number=Sing	4	compound	_	_
+3	letzten	letzter	ADJ	ADJA	Case=Gen|Gender=Neut|Number=Sing	4	amod	_	_
+4	Jahres	Jahr	NOUN	NN	Case=Gen|Gender=Neut|Number=Sing	5	obl	_	_
+5	kommen	kommen	VERB	VVFIN	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	0	root	_	_
+6	täglich	täglich	ADV	ADJD	_	5	advmod	_	_
+7	eine	ein	DET	ART	Case=Nom|Definite=Ind|Gender=Fem|Number=Sing|PronType=Art	8	det	_	_
+8	Handvoll	Handvoll	NOUN	NN	Case=Nom|Gender=Fem|Number=Sing	9	compound	_	_
+9	Ermittler	Ermittler	NOUN	NN	Case=Gen|Gender=Masc|Number=Plur	5	nsubj	_	_
+10	des	der	DET	ART	Case=Gen|Definite=Def|Gender=Neut|Number=Sing|PronType=Art	12	det	_	_
+11	niedersächsischen	niedersächsisch	ADJ	ADJA	Case=Gen|Gender=Neut|Number=Sing	12	amod	_	_
+12	Landeskriminalamtes	Landeskriminalamt	NOUN	NE	Case=Gen|Gender=Neut|Number=Sing	9	nmod	_	_
+13	(	(	PUNCT	$(	_	14	punct	_	SpaceAfter=No
+14	LKA	LKA	PROPN	NE	Case=Gen|Gender=Neut|Number=Sing	12	appos	_	SpaceAfter=No
+15	)	)	PUNCT	$(	_	14	punct	_	_
+16	aus	aus	ADP	APPR	_	17	case	_	_
+17	Hannover	Hannover	PROPN	NE	Case=Dat|Gender=Neut|Number=Sing	5	obl	_	_
+18	nach	nach	ADP	APPR	_	19	case	_	_
+19	Göttingen	Göttingen	PROPN	NE	Case=Dat|Gender=Neut|Number=Sing	5	obl	_	SpaceAfter=No
+20	,	,	PUNCT	$,	_	5	punct	_	_
+21	um	um	ADP	KOUI	_	42	aux	_	_
+22	die	der	DET	ART	Case=Acc|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	24	det	_	_
+23	autonome	autonom	ADJ	ADJA	Case=Acc|Gender=Fem|Number=Sing	24	amod	_	_
+24	Szene	Szene	NOUN	NN	Case=Acc|Gender=Fem|Number=Sing	42	obj	_	_
+25	wegen	wegen	ADP	APPR	_	27	case	_	_
+26	des	der	DET	ART	Case=Gen|Definite=Def|Gender=Masc|Number=Sing|PronType=Art	27	det	_	_
+27	Verdachts	Verdacht	NOUN	NN	Case=Gen|Gender=Masc|Number=Sing	42	obl	_	_
+28	der	der	DET	ART	Case=Gen|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	29	det	_	_
+29	Gründung	Gründung	NOUN	NN	Case=Gen|Gender=Fem|Number=Sing	27	nmod	_	SpaceAfter=No
+30	,	,	PUNCT	$,	_	31	punct	_	_
+31	Mitgliedschaft	Mitgliedschaft	NOUN	NN	Case=Gen|Gender=Fem|Number=Sing	29	conj	_	_
+32	oder	oder	CCONJ	KON	_	33	cc	_	_
+33	Unterstützung	Unterstützung	NOUN	NN	Case=Gen|Gender=Fem|Number=Sing	29	conj	_	_
+34	einer	ein	DET	ART	Case=Gen|Definite=Ind|Gender=Fem|Number=Sing|PronType=Art	36	det	_	_
+35	terroristischen	terroristisch	ADJ	ADJA	Case=Gen|Gender=Fem|Number=Sing	36	amod	_	_
+36	Vereinigung	Vereinigung	NOUN	NN	Case=Gen|Gender=Fem|Number=Sing	29	nmod	_	_
+37	nach	nach	ADP	APPR	_	38	case	_	_
+38	Paragraph	Paragraph	NOUN	NN	Case=Dat|Gender=Masc|Number=Sing	27	nmod	_	_
+39	129	129	NUM	CARD	NumType=Card	38	nummod	_	_
+40	a	a	X	XY	_	39	dep	_	_
+41	Strafgesetzbuch	Strafgesetzbuch	NOUN	NN	Case=Nom|Gender=Neut|Number=Sing	38	compound	_	_
+42	auszuforschen	ausforschen	VERB	VVIZU	VerbForm=Inf	5	advcl	_	SpaceAfter=No
+43	.	.	PUNCT	$.	_	5	punct	_	_
 
 # sent_id = dev-s645
 # text = Die Bauern laufen Sturm, wenn sie solche Sätze hören.
@@ -11501,38 +11557,39 @@
 11	.	.	PUNCT	$.	_	3	punct	_	_
 
 # sent_id = dev-s646
-# text = Es herrscht Bewegung, doch gibt es keine sich bewegenden Objekte, es gibt Aktivität, jedoch keine Handelnden, es gibt keine Tänzer, sondern nur den Tanz.''
-1	Es	es	PRON	PPER	Case=Nom|Gender=Neut|Number=Sing|Person=3|PronType=Prs	2	expl	_	_
-2	herrscht	herrschen	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	0	root	_	_
-3	Bewegung	Bewegung	NOUN	NN	Case=Nom|Gender=Fem|Number=Sing	2	nsubj	_	SpaceAfter=No
-4	,	,	PUNCT	$,	_	6	punct	_	_
-5	doch	doch	CCONJ	KON	_	6	cc	_	_
-6	gibt	geben	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	2	conj	_	_
-7	es	es	PRON	PPER	Case=Nom|Gender=Neut|Number=Sing|Person=3|PronType=Prs	6	nsubj	_	_
-8	keine	kein	PRON	PIAT	Case=Acc|Definite=Ind|Gender=Neut|Number=Plur|Polarity=Neg|PronType=Neg	11	advmod	_	_
-9	sich	er|es|sie	PRON	PRF	Case=Acc|Number=Plur|Person=3|PronType=Prs|Reflex=Yes	10	obj	_	_
-10	bewegenden	bewegend	ADJ	ADJA	Case=Acc|Gender=Neut|Number=Plur	11	amod	_	_
-11	Objekte	Objekt	NOUN	NN	Case=Acc|Gender=Neut|Number=Plur	6	obj	_	SpaceAfter=No
-12	,	,	PUNCT	$,	_	14	punct	_	_
-13	es	es	PRON	PPER	Case=Nom|Gender=Neut|Number=Sing|Person=3|PronType=Prs	14	nsubj	_	_
-14	gibt	geben	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	2	conj	_	_
-15	Aktivität	Aktivität	NOUN	NN	Case=Acc|Gender=Fem|Number=Sing	14	obj	_	SpaceAfter=No
-16	,	,	PUNCT	$,	_	15	punct	_	_
-17	jedoch	jedoch	CCONJ	KON	_	15	cc	_	_
-18	keine	kein	PRON	PIAT	Case=Acc|Definite=Ind|Number=Plur|Polarity=Neg|PronType=Neg	19	advmod	_	_
-19	Handelnden	Handelnd	NOUN	NN	Case=Acc|Number=Plur	15	obj	_	SpaceAfter=No
-20	,	,	PUNCT	$,	_	22	punct	_	_
-21	es	es	PRON	PPER	Case=Nom|Gender=Neut|Number=Sing|Person=3|PronType=Prs	22	nsubj	_	_
-22	gibt	geben	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	2	conj	_	_
-23	keine	kein	PRON	PIAT	Case=Acc|Definite=Ind|Gender=Masc|Number=Plur|Polarity=Neg|PronType=Neg	24	advmod	_	_
-24	Tänzer	Tänzer	NOUN	NN	Case=Acc|Gender=Masc|Number=Plur	22	obj	_	SpaceAfter=No
-25	,	,	PUNCT	$,	_	29	punct	_	_
-26	sondern	sondern	CCONJ	KON	_	29	cc	_	_
-27	nur	nur	ADV	ADV	_	29	advmod	_	_
-28	den	der	DET	ART	Case=Acc|Definite=Def|Gender=Masc|Number=Sing|PronType=Art	29	det	_	_
-29	Tanz	Tanz	NOUN	NN	Case=Acc|Gender=Masc|Number=Sing	24	conj	_	SpaceAfter=No
-30	.	.	PUNCT	$.	_	2	punct	_	SpaceAfter=No
-31	''	''	PUNCT	$(	_	2	punct	_	_
+# text = ``Es herrscht Bewegung, doch gibt es keine sich bewegenden Objekte, es gibt Aktivität, jedoch keine Handelnden, es gibt keine Tänzer, sondern nur den Tanz.''
+1	``	``	PUNCT	$(	_	2	punct	_	FixTigerDep=Yes|SpaceAfter=No
+2	Es	es	PRON	PPER	Case=Nom|Gender=Neut|Number=Sing|Person=3|PronType=Prs	3	expl	_	_
+3	herrscht	herrschen	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	0	root	_	_
+4	Bewegung	Bewegung	NOUN	NN	Case=Nom|Gender=Fem|Number=Sing	3	nsubj	_	SpaceAfter=No
+5	,	,	PUNCT	$,	_	7	punct	_	_
+6	doch	doch	CCONJ	KON	_	7	cc	_	_
+7	gibt	geben	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	3	conj	_	_
+8	es	es	PRON	PPER	Case=Nom|Gender=Neut|Number=Sing|Person=3|PronType=Prs	7	nsubj	_	_
+9	keine	kein	PRON	PIAT	Case=Acc|Definite=Ind|Gender=Neut|Number=Plur|Polarity=Neg|PronType=Neg	12	advmod	_	_
+10	sich	er|es|sie	PRON	PRF	Case=Acc|Number=Plur|Person=3|PronType=Prs|Reflex=Yes	11	obj	_	_
+11	bewegenden	bewegend	ADJ	ADJA	Case=Acc|Gender=Neut|Number=Plur	12	amod	_	_
+12	Objekte	Objekt	NOUN	NN	Case=Acc|Gender=Neut|Number=Plur	7	obj	_	SpaceAfter=No
+13	,	,	PUNCT	$,	_	15	punct	_	_
+14	es	es	PRON	PPER	Case=Nom|Gender=Neut|Number=Sing|Person=3|PronType=Prs	15	nsubj	_	_
+15	gibt	geben	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	3	conj	_	_
+16	Aktivität	Aktivität	NOUN	NN	Case=Acc|Gender=Fem|Number=Sing	15	obj	_	SpaceAfter=No
+17	,	,	PUNCT	$,	_	16	punct	_	_
+18	jedoch	jedoch	CCONJ	KON	_	16	cc	_	_
+19	keine	kein	PRON	PIAT	Case=Acc|Definite=Ind|Number=Plur|Polarity=Neg|PronType=Neg	20	advmod	_	_
+20	Handelnden	Handelnd	NOUN	NN	Case=Acc|Number=Plur	16	obj	_	SpaceAfter=No
+21	,	,	PUNCT	$,	_	23	punct	_	_
+22	es	es	PRON	PPER	Case=Nom|Gender=Neut|Number=Sing|Person=3|PronType=Prs	23	nsubj	_	_
+23	gibt	geben	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	3	conj	_	_
+24	keine	kein	PRON	PIAT	Case=Acc|Definite=Ind|Gender=Masc|Number=Plur|Polarity=Neg|PronType=Neg	25	advmod	_	_
+25	Tänzer	Tänzer	NOUN	NN	Case=Acc|Gender=Masc|Number=Plur	23	obj	_	SpaceAfter=No
+26	,	,	PUNCT	$,	_	30	punct	_	_
+27	sondern	sondern	CCONJ	KON	_	30	cc	_	_
+28	nur	nur	ADV	ADV	_	30	advmod	_	_
+29	den	der	DET	ART	Case=Acc|Definite=Def|Gender=Masc|Number=Sing|PronType=Art	30	det	_	_
+30	Tanz	Tanz	NOUN	NN	Case=Acc|Gender=Masc|Number=Sing	25	conj	_	SpaceAfter=No
+31	.	.	PUNCT	$.	_	3	punct	_	SpaceAfter=No
+32	''	''	PUNCT	$(	_	3	punct	_	_
 
 # sent_id = dev-s647
 # text = Vor kurzem hatte er auch Militäraktionen zum Schutz von Russen für möglich erklärt.
@@ -11626,33 +11683,34 @@
 28	.	.	PUNCT	$.	_	3	punct	_	_
 
 # sent_id = dev-s651
-# text = Ziel sei eine Umwandlung des Zahlungsaufschubs für Rußland in eine reguläre Umschuldung, ähnlich wie bei anderen Schuldnerländern, hieß es in den deutschen Regierungskreisen.
-1	Ziel	Ziel	NOUN	NN	Case=Nom|Gender=Neut|Number=Sing	20	ccomp	_	_
-2	sei	sein	AUX	VAFIN	Mood=Sub|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	1	cop	_	_
-3	eine	ein	DET	ART	Case=Nom|Definite=Ind|Gender=Fem|Number=Sing|PronType=Art	4	det	_	_
-4	Umwandlung	Umwandlung	NOUN	NN	Case=Nom|Gender=Fem|Number=Sing	1	nsubj	_	_
-5	des	der	DET	ART	Case=Gen|Definite=Def|Gender=Masc|Number=Sing|PronType=Art	6	det	_	_
-6	Zahlungsaufschubs	Zahlungsaufschub	NOUN	NN	Case=Gen|Gender=Masc|Number=Sing	4	nmod	_	_
-7	für	für	ADP	APPR	_	8	case	_	_
-8	Rußland	Rußland	PROPN	NE	Case=Acc|Gender=Neut|Number=Sing	6	nmod	_	_
-9	in	in	ADP	APPR	_	12	case	_	_
-10	eine	ein	DET	ART	Case=Acc|Definite=Ind|Gender=Fem|Number=Sing|PronType=Art	12	det	_	_
-11	reguläre	regulär	ADJ	ADJA	Case=Acc|Gender=Fem|Number=Sing	12	amod	_	_
-12	Umschuldung	Umschuldung	NOUN	NN	Case=Acc|Gender=Fem|Number=Sing	4	nmod	_	SpaceAfter=No
-13	,	,	PUNCT	$,	_	20	punct	_	_
-14	ähnlich	ähnlich	ADV	ADJD	_	15	advmod	_	_
-15	wie	wie	CCONJ	KOKOM	_	4	dep	_	_
-16	bei	bei	ADP	APPR	_	18	case	_	_
-17	anderen	anderer	ADJ	ADJA	Case=Dat|Gender=Neut|Number=Plur	18	amod	_	_
-18	Schuldnerländern	Schuldnerland	NOUN	NN	Case=Dat|Gender=Neut|Number=Plur	15	nmod	_	SpaceAfter=No
-19	,	,	PUNCT	$,	_	20	punct	_	_
-20	hieß	heißen	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	0	root	_	_
-21	es	es	PRON	PPER	Case=Nom|Gender=Neut|Number=Sing|Person=3|PronType=Prs	20	nsubj	_	_
-22	in	in	ADP	APPR	_	25	case	_	_
-23	den	der	DET	ART	Case=Dat|Definite=Def|Gender=Masc|Number=Plur|PronType=Art	25	det	_	_
-24	deutschen	deutsch	ADJ	ADJA	Case=Dat|Gender=Masc|Number=Plur	25	amod	_	_
-25	Regierungskreisen	Regierungskreis	NOUN	NN	Case=Dat|Gender=Masc|Number=Plur	20	obl	_	SpaceAfter=No
-26	.	.	PUNCT	$.	_	20	punct	_	_
+# text = Langfristiges Ziel sei eine Umwandlung des Zahlungsaufschubs für Rußland in eine reguläre Umschuldung, ähnlich wie bei anderen Schuldnerländern, hieß es in den deutschen Regierungskreisen.
+1	Langfristiges	langfristig	ADJ	ADJA	Case=Nom|Gender=Neut|Number=Sing	2	dep	_	FixTigerDep=Yes
+2	Ziel	Ziel	NOUN	NN	Case=Nom|Gender=Neut|Number=Sing	21	ccomp	_	_
+3	sei	sein	AUX	VAFIN	Mood=Sub|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	2	cop	_	_
+4	eine	ein	DET	ART	Case=Nom|Definite=Ind|Gender=Fem|Number=Sing|PronType=Art	5	det	_	_
+5	Umwandlung	Umwandlung	NOUN	NN	Case=Nom|Gender=Fem|Number=Sing	2	nsubj	_	_
+6	des	der	DET	ART	Case=Gen|Definite=Def|Gender=Masc|Number=Sing|PronType=Art	7	det	_	_
+7	Zahlungsaufschubs	Zahlungsaufschub	NOUN	NN	Case=Gen|Gender=Masc|Number=Sing	5	nmod	_	_
+8	für	für	ADP	APPR	_	9	case	_	_
+9	Rußland	Rußland	PROPN	NE	Case=Acc|Gender=Neut|Number=Sing	7	nmod	_	_
+10	in	in	ADP	APPR	_	13	case	_	_
+11	eine	ein	DET	ART	Case=Acc|Definite=Ind|Gender=Fem|Number=Sing|PronType=Art	13	det	_	_
+12	reguläre	regulär	ADJ	ADJA	Case=Acc|Gender=Fem|Number=Sing	13	amod	_	_
+13	Umschuldung	Umschuldung	NOUN	NN	Case=Acc|Gender=Fem|Number=Sing	5	nmod	_	SpaceAfter=No
+14	,	,	PUNCT	$,	_	21	punct	_	_
+15	ähnlich	ähnlich	ADV	ADJD	_	16	advmod	_	_
+16	wie	wie	CCONJ	KOKOM	_	5	dep	_	_
+17	bei	bei	ADP	APPR	_	19	case	_	_
+18	anderen	anderer	ADJ	ADJA	Case=Dat|Gender=Neut|Number=Plur	19	amod	_	_
+19	Schuldnerländern	Schuldnerland	NOUN	NN	Case=Dat|Gender=Neut|Number=Plur	16	nmod	_	SpaceAfter=No
+20	,	,	PUNCT	$,	_	21	punct	_	_
+21	hieß	heißen	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	0	root	_	_
+22	es	es	PRON	PPER	Case=Nom|Gender=Neut|Number=Sing|Person=3|PronType=Prs	21	nsubj	_	_
+23	in	in	ADP	APPR	_	26	case	_	_
+24	den	der	DET	ART	Case=Dat|Definite=Def|Gender=Masc|Number=Plur|PronType=Art	26	det	_	_
+25	deutschen	deutsch	ADJ	ADJA	Case=Dat|Gender=Masc|Number=Plur	26	amod	_	_
+26	Regierungskreisen	Regierungskreis	NOUN	NN	Case=Dat|Gender=Masc|Number=Plur	21	obl	_	SpaceAfter=No
+27	.	.	PUNCT	$.	_	21	punct	_	_
 
 # sent_id = dev-s652
 # text = Der US-Bürger Milan Panic, 62 Jahre alt, bis vorige Woche noch Chef der kalifornischen ICN Pharmaceuticals Inc, ist im Laufe seiner sprichwörtlichen Schuhputzerkarriere mehrfach mit ``Wachhunden'' der Wall Street, Aktionären, Buchprüfern und Wissenschaftlern in Konflikt gekommen.
@@ -11706,19 +11764,20 @@
 47	.	.	PUNCT	$.	_	46	punct	_	_
 
 # sent_id = dev-s653
-# text = Mitterrand und der sie begleitende französische Gesundheitsminister Bernard Kouchner blieben unverletzt.
-1	Mitterrand	Mitterrand	PROPN	NE	Case=Nom|Gender=Fem|Number=Sing	10	nsubj	_	_
-2	und	und	CCONJ	KON	_	7	cc	_	_
-3	der	der	DET	ART	Case=Nom|Definite=Def|Gender=Masc|Number=Sing|PronType=Art	7	det	_	_
-4	sie	sie	PRON	PPER	Case=Acc|Gender=Fem|Number=Sing|Person=3|PronType=Prs	5	obj	_	_
-5	begleitende	begleitend	ADJ	ADJA	Case=Nom|Gender=Masc|Number=Sing	7	amod	_	_
-6	französische	französisch	ADJ	ADJA	Case=Nom|Gender=Masc|Number=Sing	7	amod	_	_
-7	Gesundheitsminister	Gesundheitsminister	NOUN	NN	Case=Nom|Gender=Masc|Number=Sing	1	conj	_	_
-8	Bernard	Bernard	PROPN	NE	Case=Nom|Gender=Masc|Number=Sing	7	appos	_	_
-9	Kouchner	Kouchner	PROPN	NE	Case=Nom|Gender=Masc|Number=Sing	8	flat	_	_
-10	blieben	bleiben	VERB	VVFIN	Mood=Ind|Number=Plur|Person=3|Tense=Past|VerbForm=Fin	0	root	_	_
-11	unverletzt	unverletzt	ADJ	ADJD	_	10	xcomp	_	SpaceAfter=No
-12	.	.	PUNCT	$.	_	10	punct	_	_
+# text = Frau Mitterrand und der sie begleitende französische Gesundheitsminister Bernard Kouchner blieben unverletzt.
+1	Frau	Frau	NOUN	NN	Case=Nom|Gender=Fem|Number=Sing	2	dep	_	FixTigerDep=Yes
+2	Mitterrand	Mitterrand	PROPN	NE	Case=Nom|Gender=Fem|Number=Sing	11	nsubj	_	_
+3	und	und	CCONJ	KON	_	8	cc	_	_
+4	der	der	DET	ART	Case=Nom|Definite=Def|Gender=Masc|Number=Sing|PronType=Art	8	det	_	_
+5	sie	sie	PRON	PPER	Case=Acc|Gender=Fem|Number=Sing|Person=3|PronType=Prs	6	obj	_	_
+6	begleitende	begleitend	ADJ	ADJA	Case=Nom|Gender=Masc|Number=Sing	8	amod	_	_
+7	französische	französisch	ADJ	ADJA	Case=Nom|Gender=Masc|Number=Sing	8	amod	_	_
+8	Gesundheitsminister	Gesundheitsminister	NOUN	NN	Case=Nom|Gender=Masc|Number=Sing	2	conj	_	_
+9	Bernard	Bernard	PROPN	NE	Case=Nom|Gender=Masc|Number=Sing	8	appos	_	_
+10	Kouchner	Kouchner	PROPN	NE	Case=Nom|Gender=Masc|Number=Sing	9	flat	_	_
+11	blieben	bleiben	VERB	VVFIN	Mood=Ind|Number=Plur|Person=3|Tense=Past|VerbForm=Fin	0	root	_	_
+12	unverletzt	unverletzt	ADJ	ADJD	_	11	xcomp	_	SpaceAfter=No
+13	.	.	PUNCT	$.	_	11	punct	_	_
 
 # sent_id = dev-s654
 # text = Bürgermeister Christian Ude (SPD,) Bayerns Jusos, die Grünen und Gipfelgegner kritisierten das Polizeivorgehen und den ``Münchner Kessel'' als ``völlig unangemessen'' und zum Teil ``brutal''.
@@ -11733,7 +11792,7 @@
 9	Jusos	Juso	PROPN	NE	Case=Nom|Gender=Masc|Number=Plur	1	conj	_	SpaceAfter=No
 10	,	,	PUNCT	$,	_	12	punct	_	_
 11	die	der	DET	ART	Case=Nom|Definite=Def|Number=Plur|PronType=Art	12	det	_	_
-12	Grünen	Grüne	PROPN	NN	Case=Nom|Number=Plur	1	conj	_	_
+12	Grünen	grüne	PROPN	NN	Case=Nom|Number=Plur	1	conj	_	_
 13	und	und	CCONJ	KON	_	14	cc	_	_
 14	Gipfelgegner	Gipfelgegner	NOUN	NN	Case=Nom|Gender=Masc|Number=Plur	1	conj	_	_
 15	kritisierten	kritisieren	VERB	VVFIN	Mood=Ind|Number=Plur|Person=3|Tense=Past|VerbForm=Fin	0	root	_	_
@@ -11781,78 +11840,81 @@
 17	.	.	PUNCT	$.	_	16	punct	_	_
 
 # sent_id = dev-s656
-# text = Lech Walesa teilte am Samstag über einen Sprecher mit, er habe ``keine Einwände'' gegen die Kandidatur.
-1	Lech	Lech	PROPN	NE	Case=Nom|Gender=Masc|Number=Sing	3	nsubj	_	_
-2	Walesa	Walesa	PROPN	NE	Case=Nom|Gender=Masc|Number=Sing	1	flat	_	_
-3	teilte	teilen	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	0	root	_	_
-4-5	am	_	_	_	_	_	_	_	_
-4	an	an	ADP	APPR	_	6	case	_	_
-5	dem	der	DET	ART	Case=Dat|Definite=Def|Gender=Masc|Number=Sing|PronType=Art	6	det	_	_
-6	Samstag	Samstag	PROPN	NN	Case=Dat|Gender=Masc|Number=Sing	3	obl	_	_
-7	über	über	ADP	APPR	_	9	case	_	_
-8	einen	ein	DET	ART	Case=Acc|Definite=Ind|Gender=Masc|Number=Sing|PronType=Art	9	det	_	_
-9	Sprecher	Sprecher	NOUN	NN	Case=Acc|Gender=Masc|Number=Sing	3	obl	_	_
-10	mit	mit	ADP	PTKVZ	_	3	compound:prt	_	SpaceAfter=No
-11	,	,	PUNCT	$,	_	3	punct	_	_
-12	er	er	PRON	PPER	Case=Nom|Gender=Masc|Number=Sing|Person=3|PronType=Prs	13	nsubj	_	_
-13	habe	haben	VERB	VAFIN	Mood=Sub|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	3	ccomp	_	_
-14	``	``	PUNCT	$(	_	16	punct	_	SpaceAfter=No
-15	keine	kein	PRON	PIAT	Case=Acc|Definite=Ind|Gender=Masc|Number=Plur|Polarity=Neg|PronType=Neg	16	advmod	_	_
-16	Einwände	Einwand	NOUN	NN	Case=Acc|Gender=Masc|Number=Plur	13	obj	_	SpaceAfter=No
-17	''	''	PUNCT	$(	_	16	punct	_	_
-18	gegen	gegen	ADP	APPR	_	20	case	_	_
-19	die	der	DET	ART	Case=Acc|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	20	det	_	_
-20	Kandidatur	Kandidatur	NOUN	NN	Case=Acc|Gender=Fem|Number=Sing	16	nmod	_	SpaceAfter=No
-21	.	.	PUNCT	$.	_	3	punct	_	_
+# text = Staatspräsident Lech Walesa teilte am Samstag über einen Sprecher mit, er habe ``keine Einwände'' gegen die Kandidatur.
+1	Staatspräsident	Staatspräsident	NOUN	NN	Case=Nom|Gender=Masc|Number=Sing	2	dep	_	FixTigerDep=Yes
+2	Lech	Lech	PROPN	NE	Case=Nom|Gender=Masc|Number=Sing	4	nsubj	_	_
+3	Walesa	Walesa	PROPN	NE	Case=Nom|Gender=Masc|Number=Sing	2	flat	_	_
+4	teilte	teilen	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	0	root	_	_
+5-6	am	_	_	_	_	_	_	_	_
+5	an	an	ADP	APPR	_	7	case	_	_
+6	dem	der	DET	ART	Case=Dat|Definite=Def|Gender=Masc|Number=Sing|PronType=Art	7	det	_	_
+7	Samstag	Samstag	PROPN	NN	Case=Dat|Gender=Masc|Number=Sing	4	obl	_	_
+8	über	über	ADP	APPR	_	10	case	_	_
+9	einen	ein	DET	ART	Case=Acc|Definite=Ind|Gender=Masc|Number=Sing|PronType=Art	10	det	_	_
+10	Sprecher	Sprecher	NOUN	NN	Case=Acc|Gender=Masc|Number=Sing	4	obl	_	_
+11	mit	mit	ADP	PTKVZ	_	4	compound:prt	_	SpaceAfter=No
+12	,	,	PUNCT	$,	_	4	punct	_	_
+13	er	er	PRON	PPER	Case=Nom|Gender=Masc|Number=Sing|Person=3|PronType=Prs	14	nsubj	_	_
+14	habe	haben	VERB	VAFIN	Mood=Sub|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	4	ccomp	_	_
+15	``	``	PUNCT	$(	_	17	punct	_	SpaceAfter=No
+16	keine	kein	PRON	PIAT	Case=Acc|Definite=Ind|Gender=Masc|Number=Plur|Polarity=Neg|PronType=Neg	17	advmod	_	_
+17	Einwände	Einwand	NOUN	NN	Case=Acc|Gender=Masc|Number=Plur	14	obj	_	SpaceAfter=No
+18	''	''	PUNCT	$(	_	17	punct	_	_
+19	gegen	gegen	ADP	APPR	_	21	case	_	_
+20	die	der	DET	ART	Case=Acc|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	21	det	_	_
+21	Kandidatur	Kandidatur	NOUN	NN	Case=Acc|Gender=Fem|Number=Sing	17	nmod	_	SpaceAfter=No
+22	.	.	PUNCT	$.	_	4	punct	_	_
 
 # sent_id = dev-s657
-# text = Tausende saßen zum Teil über zwölf Stunden fest und mußten in überfüllten Bahnhöfen kampieren oder auf freier Strecke ausharren.
-1	Tausende	Tausend	NOUN	NN	Case=Nom|Gender=Neut|Number=Plur	2	nsubj	_	_
-2	saßen	sitzen	VERB	VVFIN	Mood=Ind|Number=Plur|Person=3|Tense=Past|VerbForm=Fin	0	root	_	_
-3-4	zum	_	_	_	_	_	_	_	_
-3	zu	zu	ADP	APPR	_	5	case	_	_
-4	dem	der	DET	ART	Case=Dat|Definite=Def|Gender=Masc|Number=Sing|PronType=Art	5	det	_	_
-5	Teil	Teil	NOUN	NN	Case=Dat|Gender=Masc|Number=Sing	8	nmod	_	_
-6	über	über	ADP	ADV	_	8	case	_	_
-7	zwölf	zwölf	NUM	CARD	NumType=Card	8	nummod	_	_
-8	Stunden	Stunde	NOUN	NN	Case=Acc|Gender=Fem|Number=Plur	2	obl	_	_
-9	fest	fest	ADV	PTKVZ	_	2	compound:prt	_	_
-10	und	und	CCONJ	KON	_	15	cc	_	_
-11	mußten	müssen	AUX	VMFIN	Mood=Ind|Number=Plur|Person=3|Tense=Past|VerbForm=Fin	15	aux	_	_
-12	in	in	ADP	APPR	_	14	case	_	_
-13	überfüllten	überfüllt	ADJ	ADJA	Case=Dat|Gender=Masc|Number=Plur	14	amod	_	_
-14	Bahnhöfen	Bahnhof	NOUN	NN	Case=Dat|Gender=Masc|Number=Plur	15	obl	_	_
-15	kampieren	kampieren	VERB	VVINF	VerbForm=Inf	2	conj	_	_
-16	oder	oder	CCONJ	KON	_	20	cc	_	_
-17	auf	auf	ADP	APPR	_	19	case	_	_
-18	freier	frei	ADJ	ADJA	Case=Dat|Gender=Fem|Number=Sing	19	amod	_	_
-19	Strecke	Strecke	NOUN	NN	Case=Dat|Gender=Fem|Number=Sing	20	obl	_	_
-20	ausharren	ausharren	VERB	VVINF	VerbForm=Inf	15	conj	_	SpaceAfter=No
-21	.	.	PUNCT	$.	_	2	punct	_	_
+# text = Mehrere Tausende saßen zum Teil über zwölf Stunden fest und mußten in überfüllten Bahnhöfen kampieren oder auf freier Strecke ausharren.
+1	Mehrere	mehrere	DET	PIAT	Case=Nom|Definite=Ind|Gender=Neut|Number=Plur|PronType=Ind	2	dep	_	FixTigerDep=Yes
+2	Tausende	Tausend	NOUN	NN	Case=Nom|Gender=Neut|Number=Plur	3	nsubj	_	_
+3	saßen	sitzen	VERB	VVFIN	Mood=Ind|Number=Plur|Person=3|Tense=Past|VerbForm=Fin	0	root	_	_
+4-5	zum	_	_	_	_	_	_	_	_
+4	zu	zu	ADP	APPR	_	6	case	_	_
+5	dem	der	DET	ART	Case=Dat|Definite=Def|Gender=Masc|Number=Sing|PronType=Art	6	det	_	_
+6	Teil	Teil	NOUN	NN	Case=Dat|Gender=Masc|Number=Sing	9	nmod	_	_
+7	über	über	ADP	ADV	_	9	case	_	_
+8	zwölf	zwölf	NUM	CARD	NumType=Card	9	nummod	_	_
+9	Stunden	Stunde	NOUN	NN	Case=Acc|Gender=Fem|Number=Plur	3	obl	_	_
+10	fest	fest	ADV	PTKVZ	_	3	compound:prt	_	_
+11	und	und	CCONJ	KON	_	16	cc	_	_
+12	mußten	müssen	AUX	VMFIN	Mood=Ind|Number=Plur|Person=3|Tense=Past|VerbForm=Fin	16	aux	_	_
+13	in	in	ADP	APPR	_	15	case	_	_
+14	überfüllten	überfüllt	ADJ	ADJA	Case=Dat|Gender=Masc|Number=Plur	15	amod	_	_
+15	Bahnhöfen	Bahnhof	NOUN	NN	Case=Dat|Gender=Masc|Number=Plur	16	obl	_	_
+16	kampieren	kampieren	VERB	VVINF	VerbForm=Inf	3	conj	_	_
+17	oder	oder	CCONJ	KON	_	21	cc	_	_
+18	auf	auf	ADP	APPR	_	20	case	_	_
+19	freier	frei	ADJ	ADJA	Case=Dat|Gender=Fem|Number=Sing	20	amod	_	_
+20	Strecke	Strecke	NOUN	NN	Case=Dat|Gender=Fem|Number=Sing	21	obl	_	_
+21	ausharren	ausharren	VERB	VVINF	VerbForm=Inf	16	conj	_	SpaceAfter=No
+22	.	.	PUNCT	$.	_	3	punct	_	_
 
 # sent_id = dev-s658
-# text = Das ist nicht unsere Sache'', sagte Konzernchef Cor Herkströter in einem Gespräch mit der Amsterdamer Tageszeitung De Volkskrant.
-1	Das	der	PRON	PDS	Case=Nom|Gender=Neut|Number=Sing|PronType=Dem	8	ccomp	_	_
-2	ist	sein	AUX	VAFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	1	cop	_	_
-3	nicht	nicht	PART	PTKNEG	Polarity=Neg	2	advmod	_	_
-4	unsere	unser	PRON	PPOSAT	Case=Nom|Gender=Fem|Number=Sing|Poss=Yes	5	det:poss	_	_
-5	Sache	Sache	NOUN	NN	Case=Nom|Gender=Fem|Number=Sing	1	nsubj	_	SpaceAfter=No
-6	''	''	PUNCT	$(	_	8	punct	_	SpaceAfter=No
-7	,	,	PUNCT	$,	_	8	punct	_	_
-8	sagte	sagen	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	0	root	_	_
-9	Konzernchef	Konzernchef	NOUN	NN	Case=Nom|Gender=Masc|Number=Sing	8	nsubj	_	_
-10	Cor	Cor	PROPN	NE	Case=Nom|Gender=Masc|Number=Sing	9	appos	_	_
-11	Herkströter	Herkströter	PROPN	NE	Case=Nom|Gender=Masc|Number=Sing	10	flat	_	_
-12	in	in	ADP	APPR	_	14	case	_	_
-13	einem	ein	DET	ART	Case=Dat|Definite=Ind|Gender=Neut|Number=Sing|PronType=Art	14	det	_	_
-14	Gespräch	Gespräch	NOUN	NN	Case=Dat|Gender=Neut|Number=Sing	8	obl	_	_
-15	mit	mit	ADP	APPR	_	18	case	_	_
-16	der	der	DET	ART	Case=Dat|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	18	det	_	_
-17	Amsterdamer	Amsterdamer	ADJ	ADJA	_	18	amod	_	_
-18	Tageszeitung	Tageszeitung	NOUN	NN	Case=Dat|Gender=Fem|Number=Sing	14	nmod	_	_
-19	De	De	PROPN	NE	_	18	appos	_	_
-20	Volkskrant	Volkskrant	PROPN	NE	Case=Nom	19	flat	_	SpaceAfter=No
-21	.	.	PUNCT	$.	_	8	punct	_	_
+# text = ``Das ist nicht unsere Sache'', sagte Konzernchef Cor Herkströter in einem Gespräch mit der Amsterdamer Tageszeitung De Volkskrant.
+1	``	``	PUNCT	$(	_	2	punct	_	FixTigerDep=Yes|SpaceAfter=No
+2	Das	der	PRON	PDS	Case=Nom|Gender=Neut|Number=Sing|PronType=Dem	9	ccomp	_	_
+3	ist	sein	AUX	VAFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	2	cop	_	_
+4	nicht	nicht	PART	PTKNEG	Polarity=Neg	3	advmod	_	_
+5	unsere	unser	PRON	PPOSAT	Case=Nom|Gender=Fem|Number=Sing|Poss=Yes	6	det:poss	_	_
+6	Sache	Sache	NOUN	NN	Case=Nom|Gender=Fem|Number=Sing	2	nsubj	_	SpaceAfter=No
+7	''	''	PUNCT	$(	_	9	punct	_	SpaceAfter=No
+8	,	,	PUNCT	$,	_	9	punct	_	_
+9	sagte	sagen	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	0	root	_	_
+10	Konzernchef	Konzernchef	NOUN	NN	Case=Nom|Gender=Masc|Number=Sing	9	nsubj	_	_
+11	Cor	Cor	PROPN	NE	Case=Nom|Gender=Masc|Number=Sing	10	appos	_	_
+12	Herkströter	Herkströter	PROPN	NE	Case=Nom|Gender=Masc|Number=Sing	11	flat	_	_
+13	in	in	ADP	APPR	_	15	case	_	_
+14	einem	ein	DET	ART	Case=Dat|Definite=Ind|Gender=Neut|Number=Sing|PronType=Art	15	det	_	_
+15	Gespräch	Gespräch	NOUN	NN	Case=Dat|Gender=Neut|Number=Sing	9	obl	_	_
+16	mit	mit	ADP	APPR	_	19	case	_	_
+17	der	der	DET	ART	Case=Dat|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	19	det	_	_
+18	Amsterdamer	Amsterdamer	ADJ	ADJA	_	19	amod	_	_
+19	Tageszeitung	Tageszeitung	NOUN	NN	Case=Dat|Gender=Fem|Number=Sing	15	nmod	_	_
+20	De	De	PROPN	NE	_	19	appos	_	_
+21	Volkskrant	Volkskrant	PROPN	NE	Case=Nom	20	flat	_	SpaceAfter=No
+22	.	.	PUNCT	$.	_	9	punct	_	_
 
 # sent_id = dev-s659
 # text = Die Verweigerung der Verlängerung von Pachtverträgen ist Teil der Protestaktion der Bevölkerung Okinawas, die nach dem Vergewaltigungsfall zumindest eine deutliche Reduzierung der dort stationierten rund 30 000 US-Soldaten fordert.
@@ -11868,7 +11930,7 @@
 10	Protestaktion	Protestaktion	NOUN	NN	Case=Gen|Gender=Fem|Number=Sing	8	nmod	_	_
 11	der	der	DET	ART	Case=Gen|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	12	det	_	_
 12	Bevölkerung	Bevölkerung	NOUN	NN	Case=Gen|Gender=Fem|Number=Sing	10	nmod	_	_
-13	Okinawas	Okinawas	PROPN	NE	Case=Gen|Number=Sing	12	nmod	_	SpaceAfter=No
+13	Okinawas	Okinawa	PROPN	NE	Case=Gen|Number=Sing	12	nmod	_	SpaceAfter=No
 14	,	,	PUNCT	$,	_	8	punct	_	_
 15	die	der	PRON	PRELS	Case=Nom|Gender=Fem|Number=Sing|PronType=Rel	32	nsubj	_	_
 16	nach	nach	ADP	APPR	_	18	case	_	_
@@ -11891,250 +11953,260 @@
 33	.	.	PUNCT	$.	_	8	punct	_	_
 
 # sent_id = dev-s660
-# text = Die Leute haben nichts gegen die Evangelen'', meint der 32jährige, ``aber sie sollen ihren Glauben anderswo pflegen.
-1	Die	der	DET	ART	Case=Nom|Definite=Def|Number=Plur|PronType=Art	2	det	_	_
-2	Leute	Leute	NOUN	NN	Case=Nom|Number=Plur	3	nsubj	_	_
-3	haben	haben	VERB	VAFIN	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	0	root	_	_
-4	nichts	nichts	PRON	PIS	Definite=Ind|Gender=Neut|PronType=Ind	3	obj	_	_
-5	gegen	gegen	ADP	APPR	_	7	case	_	_
-6	die	der	DET	ART	Case=Acc|Definite=Def|Gender=Masc|Number=Plur|PronType=Art	7	det	_	_
-7	Evangelen	Evangelen	PROPN	NN	Case=Acc|Gender=Masc|Number=Plur	3	obl	_	SpaceAfter=No
-8	''	''	PUNCT	$(	_	21	punct	_	SpaceAfter=No
-9	,	,	PUNCT	$,	_	21	punct	_	_
-10	meint	meinen	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	3	parataxis	_	_
-11	der	der	DET	ART	Case=Nom|Definite=Def|Gender=Masc|Number=Sing|PronType=Art	12	det	_	_
-12	32jährige	32jährige	NOUN	NN	Case=Nom|Gender=Masc|Number=Sing	10	nsubj	_	SpaceAfter=No
-13	,	,	PUNCT	$,	_	21	punct	_	_
-14	``	``	PUNCT	$(	_	10	punct	_	SpaceAfter=No
-15	aber	aber	CCONJ	KON	_	21	cc	_	_
-16	sie	sie	PRON	PPER	Case=Nom|Number=Plur|Person=3|PronType=Prs	21	nsubj	_	_
-17	sollen	sollen	AUX	VMFIN	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	21	aux	_	_
-18	ihren	ihr	PRON	PPOSAT	Case=Acc|Gender=Masc|Number=Sing|Poss=Yes	19	det:poss	_	_
-19	Glauben	Glauben	NOUN	NN	Case=Acc|Gender=Masc|Number=Sing	21	obj	_	_
-20	anderswo	anderswo	ADV	ADV	_	21	advmod	_	_
-21	pflegen	pflegen	VERB	VVINF	VerbForm=Inf	3	conj	_	SpaceAfter=No
-22	.	.	PUNCT	$.	_	3	punct	_	_
+# text = ``Die Leute haben nichts gegen die Evangelen'', meint der 32jährige, ``aber sie sollen ihren Glauben anderswo pflegen.
+1	``	``	PUNCT	$(	_	2	punct	_	FixTigerDep=Yes|SpaceAfter=No
+2	Die	der	DET	ART	Case=Nom|Definite=Def|Number=Plur|PronType=Art	3	det	_	_
+3	Leute	Leute	NOUN	NN	Case=Nom|Number=Plur	4	nsubj	_	_
+4	haben	haben	VERB	VAFIN	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	0	root	_	_
+5	nichts	nichts	PRON	PIS	Definite=Ind|Gender=Neut|PronType=Ind	4	obj	_	_
+6	gegen	gegen	ADP	APPR	_	8	case	_	_
+7	die	der	DET	ART	Case=Acc|Definite=Def|Gender=Masc|Number=Plur|PronType=Art	8	det	_	_
+8	Evangelen	Evangele	PROPN	NN	Case=Acc|Gender=Masc|Number=Plur	4	obl	_	SpaceAfter=No
+9	''	''	PUNCT	$(	_	22	punct	_	SpaceAfter=No
+10	,	,	PUNCT	$,	_	22	punct	_	_
+11	meint	meinen	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	4	parataxis	_	_
+12	der	der	DET	ART	Case=Nom|Definite=Def|Gender=Masc|Number=Sing|PronType=Art	13	det	_	_
+13	32jährige	32jährige	NOUN	NN	Case=Nom|Gender=Masc|Number=Sing	11	nsubj	_	SpaceAfter=No
+14	,	,	PUNCT	$,	_	22	punct	_	_
+15	``	``	PUNCT	$(	_	11	punct	_	SpaceAfter=No
+16	aber	aber	CCONJ	KON	_	22	cc	_	_
+17	sie	sie	PRON	PPER	Case=Nom|Number=Plur|Person=3|PronType=Prs	22	nsubj	_	_
+18	sollen	sollen	AUX	VMFIN	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	22	aux	_	_
+19	ihren	ihr	PRON	PPOSAT	Case=Acc|Gender=Masc|Number=Sing|Poss=Yes	20	det:poss	_	_
+20	Glauben	Glauben	NOUN	NN	Case=Acc|Gender=Masc|Number=Sing	22	obj	_	_
+21	anderswo	anderswo	ADV	ADV	_	22	advmod	_	_
+22	pflegen	pflegen	VERB	VVINF	VerbForm=Inf	4	conj	_	SpaceAfter=No
+23	.	.	PUNCT	$.	_	4	punct	_	_
 
 # sent_id = dev-s661
-# text = Ein junger Mann mit Anti-Friedens-Buttons am T-Shirt meinte, dieses Ende sei ``unvermeidbar'' gewesen:
-1	Ein	ein	DET	ART	Case=Nom|Definite=Ind|Gender=Masc|Number=Sing|PronType=Art	3	det	_	_
-2	junger	jung	ADJ	ADJA	Case=Nom|Gender=Masc|Number=Sing	3	amod	_	_
-3	Mann	Mann	NOUN	NN	Case=Nom|Gender=Masc|Number=Sing	15	nsubj	_	_
-4	mit	mit	ADP	APPR	_	9	case	_	_
-5	Anti	Anti	ADJ	NN	Case=Dat|Gender=Masc|Number=Plur	7	compound	_	SpaceAfter=No
-6	-	-	PUNCT	$(	_	5	punct	_	SpaceAfter=No
-7	Friedens	Frieden	NOUN	NN	Case=Dat|Gender=Masc|Number=Plur	9	compound	_	SpaceAfter=No
-8	-	-	PUNCT	$(	_	7	punct	_	SpaceAfter=No
-9	Buttons	Button	NOUN	NN	Case=Dat|Gender=Masc|Number=Plur	3	nmod	_	_
-10-11	am	_	_	_	_	_	_	_	_
-10	an	an	ADP	APPR	_	14	case	_	_
-11	dem	der	DET	ART	Case=Dat|Definite=Def|Gender=Neut|Number=Sing|PronType=Art	14	det	_	_
-12	T	T	NOUN	NN	Case=Dat|Gender=Neut|Number=Sing	14	compound	_	SpaceAfter=No
-13	-	-	PUNCT	$(	_	12	punct	_	SpaceAfter=No
-14	Shirt	Shirt	NOUN	NN	Case=Dat|Gender=Neut|Number=Sing	9	nmod	_	_
-15	meinte	meinen	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	0	root	_	SpaceAfter=No
-16	,	,	PUNCT	$,	_	15	punct	_	_
-17	dieses	dies	PRON	PDAT	Case=Nom|Gender=Neut|Number=Sing|PronType=Dem	18	det	_	_
-18	Ende	Ende	NOUN	NN	Case=Nom|Gender=Neut|Number=Sing	21	nsubj	_	_
-19	sei	sein	AUX	VAFIN	Mood=Sub|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	23	aux	_	_
-20	``	``	PUNCT	$(	_	21	punct	_	SpaceAfter=No
-21	unvermeidbar	unvermeidbar	ADJ	ADJD	_	15	ccomp	_	SpaceAfter=No
-22	''	''	PUNCT	$(	_	21	punct	_	_
-23	gewesen	sein	AUX	VAPP	VerbForm=Part	21	cop	_	SpaceAfter=No
-24	:	:	PUNCT	$.	_	15	punct	_	_
+# text = ''Ein junger Mann mit Anti-Friedens-Buttons am T-Shirt meinte, dieses Ende sei ``unvermeidbar'' gewesen:
+1	''	''	PUNCT	$(	_	2	punct	_	FixTigerDep=Yes|SpaceAfter=No
+2	Ein	ein	DET	ART	Case=Nom|Definite=Ind|Gender=Masc|Number=Sing|PronType=Art	4	det	_	_
+3	junger	jung	ADJ	ADJA	Case=Nom|Gender=Masc|Number=Sing	4	amod	_	_
+4	Mann	Mann	NOUN	NN	Case=Nom|Gender=Masc|Number=Sing	16	nsubj	_	_
+5	mit	mit	ADP	APPR	_	10	case	_	_
+6	Anti	Anti	ADJ	NN	Case=Dat|Gender=Masc|Number=Plur	8	compound	_	SpaceAfter=No
+7	-	-	PUNCT	$(	_	6	punct	_	SpaceAfter=No
+8	Friedens	Frieden	NOUN	NN	Case=Dat|Gender=Masc|Number=Plur	10	compound	_	SpaceAfter=No
+9	-	-	PUNCT	$(	_	8	punct	_	SpaceAfter=No
+10	Buttons	Button	NOUN	NN	Case=Dat|Gender=Masc|Number=Plur	4	nmod	_	_
+11-12	am	_	_	_	_	_	_	_	_
+11	an	an	ADP	APPR	_	15	case	_	_
+12	dem	der	DET	ART	Case=Dat|Definite=Def|Gender=Neut|Number=Sing|PronType=Art	15	det	_	_
+13	T	T	NOUN	NN	Case=Dat|Gender=Neut|Number=Sing	15	compound	_	SpaceAfter=No
+14	-	-	PUNCT	$(	_	13	punct	_	SpaceAfter=No
+15	Shirt	Shirt	NOUN	NN	Case=Dat|Gender=Neut|Number=Sing	10	nmod	_	_
+16	meinte	meinen	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	0	root	_	SpaceAfter=No
+17	,	,	PUNCT	$,	_	16	punct	_	_
+18	dieses	dies	PRON	PDAT	Case=Nom|Gender=Neut|Number=Sing|PronType=Dem	19	det	_	_
+19	Ende	Ende	NOUN	NN	Case=Nom|Gender=Neut|Number=Sing	22	nsubj	_	_
+20	sei	sein	AUX	VAFIN	Mood=Sub|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	24	aux	_	_
+21	``	``	PUNCT	$(	_	22	punct	_	SpaceAfter=No
+22	unvermeidbar	unvermeidbar	ADJ	ADJD	_	16	ccomp	_	SpaceAfter=No
+23	''	''	PUNCT	$(	_	22	punct	_	_
+24	gewesen	sein	AUX	VAPP	VerbForm=Part	22	cop	_	SpaceAfter=No
+25	:	:	PUNCT	$.	_	16	punct	_	_
 
 # sent_id = dev-s662
-# text = Wir haben genug aufwieglerische Worte von der Rechten zu hören bekommen'', versuchte Uri Dromi eine Erklärung.
-1	Wir	wir	PRON	PPER	Case=Nom|Number=Plur|Person=1|PronType=Prs	11	nsubj	_	_
-2	haben	haben	AUX	VAFIN	Mood=Ind|Number=Plur|Person=1|Tense=Pres|VerbForm=Fin	11	aux	_	_
-3	genug	genug	ADV	PIAT	Definite=Ind|PronType=Ind	4	advmod	_	_
-4	aufwieglerische	aufwieglerisch	ADJ	ADJA	Case=Acc|Gender=Neut|Number=Plur	5	amod	_	_
-5	Worte	Worte	NOUN	NN	Case=Acc|Gender=Neut|Number=Plur	11	obj	_	_
-6	von	von	ADP	APPR	_	8	case	_	_
-7	der	der	DET	ART	Case=Dat|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	8	det	_	_
-8	Rechten	Rechte	NOUN	NN	Case=Dat|Gender=Fem|Number=Sing	11	obl	_	_
-9	zu	zu	PART	PTKZU	_	10	mark	_	_
-10	hören	hören	VERB	VVINF	VerbForm=Inf	11	xcomp	_	_
-11	bekommen	bekommen	VERB	VVINF	VerbForm=Inf	14	ccomp	_	SpaceAfter=No
-12	''	''	PUNCT	$(	_	14	punct	_	SpaceAfter=No
-13	,	,	PUNCT	$,	_	14	punct	_	_
-14	versuchte	versuchen	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	0	root	_	_
-15	Uri	Uri	PROPN	NE	Case=Nom|Gender=Masc|Number=Sing	14	nsubj	_	_
-16	Dromi	Dromi	PROPN	NE	Case=Nom|Gender=Masc|Number=Sing	15	flat	_	_
-17	eine	ein	DET	ART	Case=Acc|Definite=Ind|Gender=Fem|Number=Sing|PronType=Art	18	det	_	_
-18	Erklärung	Erklärung	NOUN	NN	Case=Acc|Gender=Fem|Number=Sing	14	obj	_	SpaceAfter=No
-19	.	.	PUNCT	$.	_	14	punct	_	_
+# text = ``Wir haben genug aufwieglerische Worte von der Rechten zu hören bekommen'', versuchte Uri Dromi eine Erklärung.
+1	``	``	PUNCT	$(	_	2	punct	_	FixTigerDep=Yes|SpaceAfter=No
+2	Wir	wir	PRON	PPER	Case=Nom|Number=Plur|Person=1|PronType=Prs	12	nsubj	_	_
+3	haben	haben	AUX	VAFIN	Mood=Ind|Number=Plur|Person=1|Tense=Pres|VerbForm=Fin	12	aux	_	_
+4	genug	genug	ADV	PIAT	Definite=Ind|PronType=Ind	5	advmod	_	_
+5	aufwieglerische	aufwieglerisch	ADJ	ADJA	Case=Acc|Gender=Neut|Number=Plur	6	amod	_	_
+6	Worte	Worte	NOUN	NN	Case=Acc|Gender=Neut|Number=Plur	12	obj	_	_
+7	von	von	ADP	APPR	_	9	case	_	_
+8	der	der	DET	ART	Case=Dat|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	9	det	_	_
+9	Rechten	Rechte	NOUN	NN	Case=Dat|Gender=Fem|Number=Sing	12	obl	_	_
+10	zu	zu	PART	PTKZU	_	11	mark	_	_
+11	hören	hören	VERB	VVINF	VerbForm=Inf	12	xcomp	_	_
+12	bekommen	bekommen	VERB	VVINF	VerbForm=Inf	15	ccomp	_	SpaceAfter=No
+13	''	''	PUNCT	$(	_	15	punct	_	SpaceAfter=No
+14	,	,	PUNCT	$,	_	15	punct	_	_
+15	versuchte	versuchen	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	0	root	_	_
+16	Uri	Uri	PROPN	NE	Case=Nom|Gender=Masc|Number=Sing	15	nsubj	_	_
+17	Dromi	Dromi	PROPN	NE	Case=Nom|Gender=Masc|Number=Sing	16	flat	_	_
+18	eine	ein	DET	ART	Case=Acc|Definite=Ind|Gender=Fem|Number=Sing|PronType=Art	19	det	_	_
+19	Erklärung	Erklärung	NOUN	NN	Case=Acc|Gender=Fem|Number=Sing	15	obj	_	SpaceAfter=No
+20	.	.	PUNCT	$.	_	15	punct	_	_
 
 # sent_id = dev-s663
-# text = Ich traf ihn vor kurzem auf einer Demo in Jerusalem.
-1	Ich	ich	PRON	PPER	Case=Nom|Number=Sing|Person=1|PronType=Prs	2	nsubj	_	_
-2	traf	treffen	VERB	VVFIN	Mood=Ind|Number=Sing|Person=1|Tense=Past|VerbForm=Fin	0	root	_	_
-3	ihn	er	PRON	PPER	Case=Acc|Gender=Masc|Number=Sing|Person=3|PronType=Prs	2	obj	_	_
-4	vor	vor	ADP	APPR	_	5	case	_	_
-5	kurzem	Kurz	NOUN	ADJA	Case=Dat|Gender=Neut|Number=Sing	2	obl	_	_
-6	auf	auf	ADP	APPR	_	8	case	_	_
-7	einer	ein	DET	ART	Case=Dat|Definite=Ind|Gender=Fem|Number=Sing|PronType=Art	8	det	_	_
-8	Demo	Demo	NOUN	NN	Case=Dat|Gender=Fem|Number=Sing	2	obl	_	_
-9	in	in	ADP	APPR	_	10	case	_	_
-10	Jerusalem	Jerusalem	PROPN	NE	Case=Dat|Gender=Neut|Number=Sing	2	obl	_	SpaceAfter=No
-11	.	.	PUNCT	$.	_	2	punct	_	_
+# text = ``Ich traf ihn vor kurzem auf einer Demo in Jerusalem.
+1	``	``	PUNCT	$(	_	2	punct	_	FixTigerDep=Yes|SpaceAfter=No
+2	Ich	ich	PRON	PPER	Case=Nom|Number=Sing|Person=1|PronType=Prs	3	nsubj	_	_
+3	traf	treffen	VERB	VVFIN	Mood=Ind|Number=Sing|Person=1|Tense=Past|VerbForm=Fin	0	root	_	_
+4	ihn	er	PRON	PPER	Case=Acc|Gender=Masc|Number=Sing|Person=3|PronType=Prs	3	obj	_	_
+5	vor	vor	ADP	APPR	_	6	case	_	_
+6	kurzem	Kurz	NOUN	ADJA	Case=Dat|Gender=Neut|Number=Sing	3	obl	_	_
+7	auf	auf	ADP	APPR	_	9	case	_	_
+8	einer	ein	DET	ART	Case=Dat|Definite=Ind|Gender=Fem|Number=Sing|PronType=Art	9	det	_	_
+9	Demo	Demo	NOUN	NN	Case=Dat|Gender=Fem|Number=Sing	3	obl	_	_
+10	in	in	ADP	APPR	_	11	case	_	_
+11	Jerusalem	Jerusalem	PROPN	NE	Case=Dat|Gender=Neut|Number=Sing	3	obl	_	SpaceAfter=No
+12	.	.	PUNCT	$.	_	3	punct	_	_
 
 # sent_id = dev-s664
-# text = Diese Platte war Freddies letzter Wille, danach wird es Queen nicht mehr geben'', versichert Brian May, ``Freddie wollte damals, daß wir jedesmal ins Studio gingen, wenn er sich einigermaßen gut fühlte.
-1	Diese	dies	PRON	PDAT	Case=Nom|Gender=Fem|Number=Sing|PronType=Dem	2	det	_	_
-2	Platte	Platte	NOUN	NN	Case=Nom|Gender=Fem|Number=Sing	6	nsubj	_	_
-3	war	sein	AUX	VAFIN	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	6	cop	_	_
-4	Freddies	Freddies	PROPN	NE	Case=Gen|Gender=Masc|Number=Sing	6	nmod	_	_
-5	letzter	letzter	ADJ	ADJA	Case=Nom|Gender=Masc|Number=Sing	6	amod	_	_
-6	Wille	Wille	NOUN	NN	Case=Nom|Gender=Masc|Number=Sing	17	ccomp	_	SpaceAfter=No
-7	,	,	PUNCT	$,	_	14	punct	_	_
-8	danach	danach	ADV	PAV	_	14	advmod	_	_
-9	wird	werden	AUX	VAFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	14	aux	_	_
-10	es	es	PRON	PPER	Case=Nom|Gender=Neut|Number=Sing|Person=3|PronType=Prs	14	nsubj	_	_
-11	Queen	Queen	PROPN	NE	Case=Acc|Number=Sing	14	obj	_	_
-12	nicht	nicht	PART	PTKNEG	Polarity=Neg	13	advmod	_	_
-13	mehr	mehr	ADV	ADV	_	14	advmod	_	_
-14	geben	geben	VERB	VVINF	VerbForm=Inf	6	conj	_	SpaceAfter=No
-15	''	''	PUNCT	$(	_	17	punct	_	SpaceAfter=No
-16	,	,	PUNCT	$,	_	17	punct	_	_
-17	versichert	versichern	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	0	root	_	_
-18	Brian	Brian	PROPN	NE	Case=Nom|Gender=Masc|Number=Sing	17	nsubj	_	_
-19	May	May	PROPN	NE	Case=Nom|Gender=Masc|Number=Sing	18	flat	_	SpaceAfter=No
-20	,	,	PUNCT	$,	_	17	punct	_	_
-21	``	``	PUNCT	$(	_	17	punct	_	SpaceAfter=No
-22	Freddie	Freddie	PROPN	NE	Case=Nom|Gender=Masc|Number=Sing	23	nsubj	_	_
-23	wollte	wollen	VERB	VMFIN	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	17	ccomp	_	_
-24	damals	damals	ADV	ADV	_	23	advmod	_	SpaceAfter=No
-25	,	,	PUNCT	$,	_	17	punct	_	_
-26	daß	daß	SCONJ	KOUS	_	32	mark	_	_
-27	wir	wir	PRON	PPER	Case=Nom|Number=Plur|Person=1|PronType=Prs	32	nsubj	_	_
-28	jedesmal	jedesmal	ADV	ADV	_	32	advmod	_	_
-29-30	ins	_	_	_	_	_	_	_	_
-29	in	in	ADP	APPR	_	31	case	_	_
-30	das	der	DET	ART	Case=Acc|Definite=Def|Gender=Neut|Number=Sing|PronType=Art	31	det	_	_
-31	Studio	Studio	NOUN	NN	Case=Acc|Gender=Neut|Number=Sing	32	obl	_	_
-32	gingen	gehen	VERB	VVFIN	Mood=Ind|Number=Plur|Person=1|Tense=Past|VerbForm=Fin	23	ccomp	_	SpaceAfter=No
-33	,	,	PUNCT	$,	_	17	punct	_	_
-34	wenn	wenn	SCONJ	KOUS	_	39	mark	_	_
-35	er	er	PRON	PPER	Case=Nom|Gender=Masc|Number=Sing|Person=3|PronType=Prs	39	nsubj	_	_
-36	sich	er|es|sie	PRON	PRF	Case=Acc|Number=Sing|Person=3|PronType=Prs|Reflex=Yes	39	obj	_	_
-37	einigermaßen	einigermaßen	ADV	ADV	_	38	advmod	_	_
-38	gut	gut	ADJ	ADJD	_	39	xcomp	_	_
-39	fühlte	fühlen	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	32	advcl	_	SpaceAfter=No
-40	.	.	PUNCT	$.	_	17	punct	_	_
+# text = ``Diese Platte war Freddies letzter Wille, danach wird es Queen nicht mehr geben'', versichert Brian May, ``Freddie wollte damals, daß wir jedesmal ins Studio gingen, wenn er sich einigermaßen gut fühlte.
+1	``	``	PUNCT	$(	_	2	punct	_	FixTigerDep=Yes|SpaceAfter=No
+2	Diese	dies	PRON	PDAT	Case=Nom|Gender=Fem|Number=Sing|PronType=Dem	3	det	_	_
+3	Platte	Platte	NOUN	NN	Case=Nom|Gender=Fem|Number=Sing	7	nsubj	_	_
+4	war	sein	AUX	VAFIN	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	7	cop	_	_
+5	Freddies	Freddie	PROPN	NE	Case=Gen|Gender=Masc|Number=Sing	7	nmod	_	_
+6	letzter	letzter	ADJ	ADJA	Case=Nom|Gender=Masc|Number=Sing	7	amod	_	_
+7	Wille	Wille	NOUN	NN	Case=Nom|Gender=Masc|Number=Sing	18	ccomp	_	SpaceAfter=No
+8	,	,	PUNCT	$,	_	15	punct	_	_
+9	danach	danach	ADV	PAV	_	15	advmod	_	_
+10	wird	werden	AUX	VAFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	15	aux	_	_
+11	es	es	PRON	PPER	Case=Nom|Gender=Neut|Number=Sing|Person=3|PronType=Prs	15	nsubj	_	_
+12	Queen	Queen	PROPN	NE	Case=Acc|Number=Sing	15	obj	_	_
+13	nicht	nicht	PART	PTKNEG	Polarity=Neg	14	advmod	_	_
+14	mehr	mehr	ADV	ADV	_	15	advmod	_	_
+15	geben	geben	VERB	VVINF	VerbForm=Inf	7	conj	_	SpaceAfter=No
+16	''	''	PUNCT	$(	_	18	punct	_	SpaceAfter=No
+17	,	,	PUNCT	$,	_	18	punct	_	_
+18	versichert	versichern	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	0	root	_	_
+19	Brian	Brian	PROPN	NE	Case=Nom|Gender=Masc|Number=Sing	18	nsubj	_	_
+20	May	May	PROPN	NE	Case=Nom|Gender=Masc|Number=Sing	19	flat	_	SpaceAfter=No
+21	,	,	PUNCT	$,	_	18	punct	_	_
+22	``	``	PUNCT	$(	_	18	punct	_	SpaceAfter=No
+23	Freddie	Freddie	PROPN	NE	Case=Nom|Gender=Masc|Number=Sing	24	nsubj	_	_
+24	wollte	wollen	VERB	VMFIN	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	18	ccomp	_	_
+25	damals	damals	ADV	ADV	_	24	advmod	_	SpaceAfter=No
+26	,	,	PUNCT	$,	_	18	punct	_	_
+27	daß	daß	SCONJ	KOUS	_	33	mark	_	_
+28	wir	wir	PRON	PPER	Case=Nom|Number=Plur|Person=1|PronType=Prs	33	nsubj	_	_
+29	jedesmal	jedesmal	ADV	ADV	_	33	advmod	_	_
+30-31	ins	_	_	_	_	_	_	_	_
+30	in	in	ADP	APPR	_	32	case	_	_
+31	das	der	DET	ART	Case=Acc|Definite=Def|Gender=Neut|Number=Sing|PronType=Art	32	det	_	_
+32	Studio	Studio	NOUN	NN	Case=Acc|Gender=Neut|Number=Sing	33	obl	_	_
+33	gingen	gehen	VERB	VVFIN	Mood=Ind|Number=Plur|Person=1|Tense=Past|VerbForm=Fin	24	ccomp	_	SpaceAfter=No
+34	,	,	PUNCT	$,	_	18	punct	_	_
+35	wenn	wenn	SCONJ	KOUS	_	40	mark	_	_
+36	er	er	PRON	PPER	Case=Nom|Gender=Masc|Number=Sing|Person=3|PronType=Prs	40	nsubj	_	_
+37	sich	er|es|sie	PRON	PRF	Case=Acc|Number=Sing|Person=3|PronType=Prs|Reflex=Yes	40	obj	_	_
+38	einigermaßen	einigermaßen	ADV	ADV	_	39	advmod	_	_
+39	gut	gut	ADJ	ADJD	_	40	xcomp	_	_
+40	fühlte	fühlen	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	33	advcl	_	SpaceAfter=No
+41	.	.	PUNCT	$.	_	18	punct	_	_
 
 # sent_id = dev-s665
-# text = Unter Klimaaspekten gibt dies keinen Anlaß zur Freude'', räumt der ABB-Mann ein.
-1	Unter	unter	ADP	APPR	_	2	case	_	_
-2	Klimaaspekten	Klimaaspekt	NOUN	NN	Case=Dat|Gender=Masc|Number=Plur	3	obl	_	_
-3	gibt	geben	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	12	ccomp	_	_
-4	dies	dies	PRON	PDS	Case=Nom|Gender=Neut|Number=Sing|PronType=Dem	3	nsubj	_	_
-5	keinen	kein	PRON	PIAT	Case=Acc|Definite=Ind|Gender=Masc|Number=Sing|Polarity=Neg|PronType=Neg	6	advmod	_	_
-6	Anlaß	Anlaß	NOUN	NN	Case=Acc|Gender=Masc|Number=Sing	3	obj	_	_
-7-8	zur	_	_	_	_	_	_	_	_
-7	zu	zu	ADP	APPR	_	9	case	_	_
-8	der	der	DET	ART	Case=Dat|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	9	det	_	_
-9	Freude	Freude	NOUN	NN	Case=Dat|Gender=Fem|Number=Sing	6	nmod	_	SpaceAfter=No
-10	''	''	PUNCT	$(	_	12	punct	_	SpaceAfter=No
-11	,	,	PUNCT	$,	_	12	punct	_	_
-12	räumt	räumen	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	0	root	_	_
-13	der	der	DET	ART	Case=Nom|Definite=Def|Gender=Masc|Number=Sing|PronType=Art	14	det	_	_
-14	ABB	ABB	PROPN	NN	Case=Nom|Gender=Masc|Number=Sing	16	compound	_	SpaceAfter=No
-15	-	-	PUNCT	$(	_	14	punct	_	SpaceAfter=No
-16	Mann	Mann	NOUN	NN	Case=Nom|Gender=Masc|Number=Sing	12	nsubj	_	_
-17	ein	ein	ADV	PTKVZ	_	12	compound:prt	_	SpaceAfter=No
-18	.	.	PUNCT	$.	_	12	punct	_	_
+# text = ``Unter Klimaaspekten gibt dies keinen Anlaß zur Freude'', räumt der ABB-Mann ein.
+1	``	``	PUNCT	$(	_	2	punct	_	FixTigerDep=Yes|SpaceAfter=No
+2	Unter	unter	ADP	APPR	_	3	case	_	_
+3	Klimaaspekten	Klimaaspekt	NOUN	NN	Case=Dat|Gender=Masc|Number=Plur	4	obl	_	_
+4	gibt	geben	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	13	ccomp	_	_
+5	dies	dies	PRON	PDS	Case=Nom|Gender=Neut|Number=Sing|PronType=Dem	4	nsubj	_	_
+6	keinen	kein	PRON	PIAT	Case=Acc|Definite=Ind|Gender=Masc|Number=Sing|Polarity=Neg|PronType=Neg	7	advmod	_	_
+7	Anlaß	Anlaß	NOUN	NN	Case=Acc|Gender=Masc|Number=Sing	4	obj	_	_
+8-9	zur	_	_	_	_	_	_	_	_
+8	zu	zu	ADP	APPR	_	10	case	_	_
+9	der	der	DET	ART	Case=Dat|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	10	det	_	_
+10	Freude	Freude	NOUN	NN	Case=Dat|Gender=Fem|Number=Sing	7	nmod	_	SpaceAfter=No
+11	''	''	PUNCT	$(	_	13	punct	_	SpaceAfter=No
+12	,	,	PUNCT	$,	_	13	punct	_	_
+13	räumt	räumen	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	0	root	_	_
+14	der	der	DET	ART	Case=Nom|Definite=Def|Gender=Masc|Number=Sing|PronType=Art	15	det	_	_
+15	ABB	ABB	PROPN	NN	Case=Nom|Gender=Masc|Number=Sing	17	compound	_	SpaceAfter=No
+16	-	-	PUNCT	$(	_	15	punct	_	SpaceAfter=No
+17	Mann	Mann	NOUN	NN	Case=Nom|Gender=Masc|Number=Sing	13	nsubj	_	_
+18	ein	ein	ADV	PTKVZ	_	13	compound:prt	_	SpaceAfter=No
+19	.	.	PUNCT	$.	_	13	punct	_	_
 
 # sent_id = dev-s666
-# text = Mit dem Aufbau der Stadtwerke haben wir nicht gerechnet.''
-1	Mit	mit	ADP	APPR	_	3	case	_	_
-2	dem	der	DET	ART	Case=Dat|Definite=Def|Gender=Masc|Number=Sing|PronType=Art	3	det	_	_
-3	Aufbau	Aufbau	NOUN	NN	Case=Dat|Gender=Masc|Number=Sing	9	obl	_	_
-4	der	der	DET	ART	Case=Gen|Definite=Def|Gender=Neut|Number=Plur|PronType=Art	5	det	_	_
-5	Stadtwerke	Stadtwerk	NOUN	NN	Case=Gen|Gender=Neut|Number=Plur	3	nmod	_	_
-6	haben	haben	AUX	VAFIN	Mood=Ind|Number=Plur|Person=1|Tense=Pres|VerbForm=Fin	9	aux	_	_
-7	wir	wir	PRON	PPER	Case=Nom|Number=Plur|Person=1|PronType=Prs	9	nsubj	_	_
-8	nicht	nicht	PART	PTKNEG	Polarity=Neg	9	advmod	_	_
-9	gerechnet	rechnen	VERB	VVPP	VerbForm=Part	0	root	_	SpaceAfter=No
-10	.	.	PUNCT	$.	_	9	punct	_	SpaceAfter=No
-11	''	''	PUNCT	$(	_	9	punct	_	_
+# text = ``Mit dem Aufbau der Stadtwerke haben wir nicht gerechnet.''
+1	``	``	PUNCT	$(	_	2	punct	_	FixTigerDep=Yes|SpaceAfter=No
+2	Mit	mit	ADP	APPR	_	4	case	_	_
+3	dem	der	DET	ART	Case=Dat|Definite=Def|Gender=Masc|Number=Sing|PronType=Art	4	det	_	_
+4	Aufbau	Aufbau	NOUN	NN	Case=Dat|Gender=Masc|Number=Sing	10	obl	_	_
+5	der	der	DET	ART	Case=Gen|Definite=Def|Gender=Neut|Number=Plur|PronType=Art	6	det	_	_
+6	Stadtwerke	Stadtwerk	NOUN	NN	Case=Gen|Gender=Neut|Number=Plur	4	nmod	_	_
+7	haben	haben	AUX	VAFIN	Mood=Ind|Number=Plur|Person=1|Tense=Pres|VerbForm=Fin	10	aux	_	_
+8	wir	wir	PRON	PPER	Case=Nom|Number=Plur|Person=1|PronType=Prs	10	nsubj	_	_
+9	nicht	nicht	PART	PTKNEG	Polarity=Neg	10	advmod	_	_
+10	gerechnet	rechnen	VERB	VVPP	VerbForm=Part	0	root	_	SpaceAfter=No
+11	.	.	PUNCT	$.	_	10	punct	_	SpaceAfter=No
+12	''	''	PUNCT	$(	_	10	punct	_	_
 
 # sent_id = dev-s667
-# text = Berlin braucht gerade wegen der anstehenden schweren Aufgaben eine handlungsfähige Regierung.
-1	Berlin	Berlin	PROPN	NE	Case=Nom|Gender=Neut|Number=Sing	2	nsubj	_	_
-2	braucht	brauchen	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	0	root	_	_
-3	gerade	gerade	ADV	ADV	_	2	advmod	_	_
-4	wegen	wegen	ADP	APPR	_	8	case	_	_
-5	der	der	DET	ART	Case=Gen|Definite=Def|Gender=Fem|Number=Plur|PronType=Art	8	det	_	_
-6	anstehenden	anstehend	ADJ	ADJA	Case=Gen|Gender=Fem|Number=Plur	8	amod	_	_
-7	schweren	schwer	ADJ	ADJA	Case=Gen|Gender=Fem|Number=Plur	8	amod	_	_
-8	Aufgaben	Aufgabe	NOUN	NN	Case=Gen|Gender=Fem|Number=Plur	2	obl	_	_
-9	eine	ein	DET	ART	Case=Acc|Definite=Ind|Gender=Fem|Number=Sing|PronType=Art	11	det	_	_
-10	handlungsfähige	handlungsfähig	ADJ	ADJA	Case=Acc|Gender=Fem|Number=Sing	11	amod	_	_
-11	Regierung	Regierung	NOUN	NN	Case=Acc|Gender=Fem|Number=Sing	2	obj	_	SpaceAfter=No
-12	.	.	PUNCT	$.	_	2	punct	_	_
+# text = Doch Berlin braucht gerade wegen der anstehenden schweren Aufgaben eine handlungsfähige Regierung.
+1	Doch	doch	CCONJ	KON	_	2	dep	_	FixTigerDep=Yes
+2	Berlin	Berlin	PROPN	NE	Case=Nom|Gender=Neut|Number=Sing	3	nsubj	_	_
+3	braucht	brauchen	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	0	root	_	_
+4	gerade	gerade	ADV	ADV	_	3	advmod	_	_
+5	wegen	wegen	ADP	APPR	_	9	case	_	_
+6	der	der	DET	ART	Case=Gen|Definite=Def|Gender=Fem|Number=Plur|PronType=Art	9	det	_	_
+7	anstehenden	anstehend	ADJ	ADJA	Case=Gen|Gender=Fem|Number=Plur	9	amod	_	_
+8	schweren	schwer	ADJ	ADJA	Case=Gen|Gender=Fem|Number=Plur	9	amod	_	_
+9	Aufgaben	Aufgabe	NOUN	NN	Case=Gen|Gender=Fem|Number=Plur	3	obl	_	_
+10	eine	ein	DET	ART	Case=Acc|Definite=Ind|Gender=Fem|Number=Sing|PronType=Art	12	det	_	_
+11	handlungsfähige	handlungsfähig	ADJ	ADJA	Case=Acc|Gender=Fem|Number=Sing	12	amod	_	_
+12	Regierung	Regierung	NOUN	NN	Case=Acc|Gender=Fem|Number=Sing	3	obj	_	SpaceAfter=No
+13	.	.	PUNCT	$.	_	3	punct	_	_
 
 # sent_id = dev-s668
-# text = 1992 können Ausländer, die seit mindestens fünf Jahren in Holland wohnen, einen Paß bekommen, ohne ihre alte Staatsbürgerschaft aufzugeben.
-1	1992	1992	NUM	CARD	NumType=Card	16	dep	_	_
-2	können	können	AUX	VMFIN	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	16	aux	_	_
-3	Ausländer	Ausländer	NOUN	NN	Case=Nom|Gender=Masc|Number=Plur	16	nsubj	_	SpaceAfter=No
-4	,	,	PUNCT	$,	_	16	punct	_	_
-5	die	der	PRON	PRELS	Case=Nom|Gender=Masc|Number=Plur|PronType=Rel	12	nsubj	_	_
-6	seit	seit	ADP	APPR	_	9	case	_	_
-7	mindestens	mindestens	ADV	ADV	_	8	advmod	_	_
-8	fünf	fünf	NUM	CARD	NumType=Card	9	nummod	_	_
-9	Jahren	Jahr	NOUN	NN	Case=Dat|Gender=Neut|Number=Plur	12	obl	_	_
-10	in	in	ADP	APPR	_	11	case	_	_
-11	Holland	Holland	PROPN	NE	Case=Dat|Gender=Neut|Number=Sing	12	obl	_	_
-12	wohnen	wohnen	VERB	VVFIN	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	3	acl	_	SpaceAfter=No
-13	,	,	PUNCT	$,	_	16	punct	_	_
-14	einen	ein	DET	ART	Case=Acc|Definite=Ind|Gender=Masc|Number=Sing|PronType=Art	15	det	_	_
-15	Paß	Paß	NOUN	NN	Case=Acc|Gender=Masc|Number=Sing	16	obj	_	_
-16	bekommen	bekommen	VERB	VVINF	VerbForm=Inf	0	root	_	SpaceAfter=No
-17	,	,	PUNCT	$,	_	16	punct	_	_
-18	ohne	ohne	CCONJ	KOUI	_	16	cc	_	_
-19	ihre	ihr	PRON	PPOSAT	Case=Acc|Gender=Fem|Number=Sing|Poss=Yes	21	det:poss	_	_
-20	alte	alt	ADJ	ADJA	Case=Acc|Gender=Fem|Number=Sing	21	amod	_	_
-21	Staatsbürgerschaft	Staatsbürgerschaft	NOUN	NN	Case=Acc|Gender=Fem|Number=Sing	22	obj	_	_
-22	aufzugeben	aufgeben	VERB	VVIZU	VerbForm=Inf	16	xcomp	_	SpaceAfter=No
-23	.	.	PUNCT	$.	_	16	punct	_	_
+# text = Seit 1992 können Ausländer, die seit mindestens fünf Jahren in Holland wohnen, einen Paß bekommen, ohne ihre alte Staatsbürgerschaft aufzugeben.
+1	Seit	seit	ADP	APPR	_	2	dep	_	FixTigerDep=Yes
+2	1992	1992	NUM	CARD	NumType=Card	17	dep	_	_
+3	können	können	AUX	VMFIN	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	17	aux	_	_
+4	Ausländer	Ausländer	NOUN	NN	Case=Nom|Gender=Masc|Number=Plur	17	nsubj	_	SpaceAfter=No
+5	,	,	PUNCT	$,	_	17	punct	_	_
+6	die	der	PRON	PRELS	Case=Nom|Gender=Masc|Number=Plur|PronType=Rel	13	nsubj	_	_
+7	seit	seit	ADP	APPR	_	10	case	_	_
+8	mindestens	mindestens	ADV	ADV	_	9	advmod	_	_
+9	fünf	fünf	NUM	CARD	NumType=Card	10	nummod	_	_
+10	Jahren	Jahr	NOUN	NN	Case=Dat|Gender=Neut|Number=Plur	13	obl	_	_
+11	in	in	ADP	APPR	_	12	case	_	_
+12	Holland	Holland	PROPN	NE	Case=Dat|Gender=Neut|Number=Sing	13	obl	_	_
+13	wohnen	wohnen	VERB	VVFIN	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	4	acl	_	SpaceAfter=No
+14	,	,	PUNCT	$,	_	17	punct	_	_
+15	einen	ein	DET	ART	Case=Acc|Definite=Ind|Gender=Masc|Number=Sing|PronType=Art	16	det	_	_
+16	Paß	Paß	NOUN	NN	Case=Acc|Gender=Masc|Number=Sing	17	obj	_	_
+17	bekommen	bekommen	VERB	VVINF	VerbForm=Inf	0	root	_	SpaceAfter=No
+18	,	,	PUNCT	$,	_	17	punct	_	_
+19	ohne	ohne	CCONJ	KOUI	_	17	cc	_	_
+20	ihre	ihr	PRON	PPOSAT	Case=Acc|Gender=Fem|Number=Sing|Poss=Yes	22	det:poss	_	_
+21	alte	alt	ADJ	ADJA	Case=Acc|Gender=Fem|Number=Sing	22	amod	_	_
+22	Staatsbürgerschaft	Staatsbürgerschaft	NOUN	NN	Case=Acc|Gender=Fem|Number=Sing	23	obj	_	_
+23	aufzugeben	aufgeben	VERB	VVIZU	VerbForm=Inf	17	xcomp	_	SpaceAfter=No
+24	.	.	PUNCT	$.	_	17	punct	_	_
 
 # sent_id = dev-s669
-# text = Christen dürften sich nicht darauf beschränken, ethische Grundsätze zu formulieren, sondern ``müssen die Last der politischen Verantwortung übernehmen'', verlangte Günter Brakelmann, Sozialethiker an der Universität Bochum.
-1	Christen	Christ	NOUN	NN	Case=Nom|Gender=Masc|Number=Plur	6	nsubj	_	_
-2	dürften	dürfen	AUX	VMFIN	Mood=Sub|Number=Plur|Person=3|Tense=Past|VerbForm=Fin	6	aux	_	_
-3	sich	er|es|sie	PRON	PRF	Case=Acc|Number=Plur|Person=3|PronType=Prs|Reflex=Yes	6	obj	_	_
-4	nicht	nicht	PART	PTKNEG	Polarity=Neg	6	advmod	_	_
-5	darauf	darauf	ADV	PAV	_	6	advmod	_	_
-6	beschränken	beschränken	VERB	VVINF	VerbForm=Inf	24	ccomp	_	SpaceAfter=No
-7	,	,	PUNCT	$,	_	24	punct	_	_
-8	ethische	ethisch	ADJ	ADJA	Case=Acc|Gender=Masc|Number=Plur	9	amod	_	_
-9	Grundsätze	Grundsatz	NOUN	NN	Case=Acc|Gender=Masc|Number=Plur	11	obj	_	_
-10	zu	zu	PART	PTKZU	_	11	mark	_	_
-11	formulieren	formulieren	VERB	VVINF	VerbForm=Inf	6	xcomp	_	SpaceAfter=No
-12	,	,	PUNCT	$,	_	24	punct	_	_
-13	sondern	sondern	CCONJ	KON	_	21	cc	_	_
-14	``	``	PUNCT	$(	_	24	punct	_	SpaceAfter=No
-15	müssen	müssen	AUX	VMFIN	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	21	aux	_	_
-16	die	der	DET	ART	Case=Acc|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	17	det	_	_
-17	Last	Last	NOUN	NN	Case=Acc|Gender=Fem|Number=Sing	21	obj	_	_
-18	der	der	DET	ART	Case=Gen|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	20	det	_	_
-19	politischen	politisch	ADJ	ADJA	Case=Gen|Gender=Fem|Number=Sing	20	amod	_	_
-20	Verantwortung	Verantwortung	NOUN	NN	Case=Gen|Gender=Fem|Number=Sing	17	nmod	_	_
-21	übernehmen	übernehmen	VERB	VVINF	VerbForm=Inf	6	conj	_	SpaceAfter=No
-22	''	''	PUNCT	$(	_	24	punct	_	SpaceAfter=No
-23	,	,	PUNCT	$,	_	24	punct	_	_
-24	verlangte	verlangen	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	0	root	_	_
-25	Günter	Günter	PROPN	NE	Case=Nom|Gender=Masc|Number=Sing	24	nsubj	_	_
-26	Brakelmann	Brakelmann	PROPN	NE	Case=Nom|Gender=Masc|Number=Sing	25	flat	_	SpaceAfter=No
-27	,	,	PUNCT	$,	_	24	punct	_	_
-28	Sozialethiker	Sozialethiker	NOUN	NN	Case=Nom|Gender=Masc|Number=Sing	25	appos	_	_
-29	an	an	ADP	APPR	_	31	case	_	_
-30	der	der	DET	ART	Case=Dat|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	31	det	_	_
-31	Universität	Universität	PROPN	NN	Case=Dat|Gender=Fem|Number=Sing	28	nmod	_	_
-32	Bochum	Bochum	PROPN	NE	Case=Nom|Gender=Neut|Number=Sing	31	flat	_	SpaceAfter=No
-33	.	.	PUNCT	$.	_	24	punct	_	_
+# text = Die Christen dürften sich nicht darauf beschränken, ethische Grundsätze zu formulieren, sondern ``müssen die Last der politischen Verantwortung übernehmen'', verlangte Günter Brakelmann, Sozialethiker an der Universität Bochum.
+1	Die	der	DET	ART	Case=Nom|Definite=Def|Gender=Masc|Number=Plur|PronType=Art	2	dep	_	FixTigerDep=Yes
+2	Christen	Christ	NOUN	NN	Case=Nom|Gender=Masc|Number=Plur	7	nsubj	_	_
+3	dürften	dürfen	AUX	VMFIN	Mood=Sub|Number=Plur|Person=3|Tense=Past|VerbForm=Fin	7	aux	_	_
+4	sich	er|es|sie	PRON	PRF	Case=Acc|Number=Plur|Person=3|PronType=Prs|Reflex=Yes	7	obj	_	_
+5	nicht	nicht	PART	PTKNEG	Polarity=Neg	7	advmod	_	_
+6	darauf	darauf	ADV	PAV	_	7	advmod	_	_
+7	beschränken	beschränken	VERB	VVINF	VerbForm=Inf	25	ccomp	_	SpaceAfter=No
+8	,	,	PUNCT	$,	_	25	punct	_	_
+9	ethische	ethisch	ADJ	ADJA	Case=Acc|Gender=Masc|Number=Plur	10	amod	_	_
+10	Grundsätze	Grundsatz	NOUN	NN	Case=Acc|Gender=Masc|Number=Plur	12	obj	_	_
+11	zu	zu	PART	PTKZU	_	12	mark	_	_
+12	formulieren	formulieren	VERB	VVINF	VerbForm=Inf	7	xcomp	_	SpaceAfter=No
+13	,	,	PUNCT	$,	_	25	punct	_	_
+14	sondern	sondern	CCONJ	KON	_	22	cc	_	_
+15	``	``	PUNCT	$(	_	25	punct	_	SpaceAfter=No
+16	müssen	müssen	AUX	VMFIN	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	22	aux	_	_
+17	die	der	DET	ART	Case=Acc|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	18	det	_	_
+18	Last	Last	NOUN	NN	Case=Acc|Gender=Fem|Number=Sing	22	obj	_	_
+19	der	der	DET	ART	Case=Gen|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	21	det	_	_
+20	politischen	politisch	ADJ	ADJA	Case=Gen|Gender=Fem|Number=Sing	21	amod	_	_
+21	Verantwortung	Verantwortung	NOUN	NN	Case=Gen|Gender=Fem|Number=Sing	18	nmod	_	_
+22	übernehmen	übernehmen	VERB	VVINF	VerbForm=Inf	7	conj	_	SpaceAfter=No
+23	''	''	PUNCT	$(	_	25	punct	_	SpaceAfter=No
+24	,	,	PUNCT	$,	_	25	punct	_	_
+25	verlangte	verlangen	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	0	root	_	_
+26	Günter	Günter	PROPN	NE	Case=Nom|Gender=Masc|Number=Sing	25	nsubj	_	_
+27	Brakelmann	Brakelmann	PROPN	NE	Case=Nom|Gender=Masc|Number=Sing	26	flat	_	SpaceAfter=No
+28	,	,	PUNCT	$,	_	25	punct	_	_
+29	Sozialethiker	Sozialethiker	NOUN	NN	Case=Nom|Gender=Masc|Number=Sing	26	appos	_	_
+30	an	an	ADP	APPR	_	32	case	_	_
+31	der	der	DET	ART	Case=Dat|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	32	det	_	_
+32	Universität	Universität	PROPN	NN	Case=Dat|Gender=Fem|Number=Sing	29	nmod	_	_
+33	Bochum	Bochum	PROPN	NE	Case=Nom|Gender=Neut|Number=Sing	32	flat	_	SpaceAfter=No
+34	.	.	PUNCT	$.	_	25	punct	_	_
 
 # sent_id = dev-s670
 # text = Laßt nie zu, daß solches euch passiert.
@@ -12182,13 +12254,14 @@
 29	.	.	PUNCT	$.	_	11	punct	_	_
 
 # sent_id = dev-s672
-# text = Merkel sieht sich als Pionier.
-1	Merkel	Merkel	PROPN	NE	Case=Nom|Gender=Masc|Number=Sing	2	nsubj	_	_
-2	sieht	sehen	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	0	root	_	_
-3	sich	er|es|sie	PRON	PRF	Case=Acc|Number=Sing|Person=3|PronType=Prs|Reflex=Yes	2	obj	_	_
-4	als	als	ADP	APPR	_	5	case	_	_
-5	Pionier	Pionier	NOUN	NN	Case=Acc|Gender=Masc|Number=Sing	2	obl	_	SpaceAfter=No
-6	.	.	PUNCT	$.	_	2	punct	_	_
+# text = Willi Merkel sieht sich als Pionier.
+1	Willi	Willi	PROPN	NE	Case=Nom|Gender=Masc|Number=Sing	2	dep	_	FixTigerDep=Yes
+2	Merkel	Merkel	PROPN	NE	Case=Nom|Gender=Masc|Number=Sing	3	nsubj	_	_
+3	sieht	sehen	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	0	root	_	_
+4	sich	er|es|sie	PRON	PRF	Case=Acc|Number=Sing|Person=3|PronType=Prs|Reflex=Yes	3	obj	_	_
+5	als	als	ADP	APPR	_	6	case	_	_
+6	Pionier	Pionier	NOUN	NN	Case=Acc|Gender=Masc|Number=Sing	3	obl	_	SpaceAfter=No
+7	.	.	PUNCT	$.	_	3	punct	_	_
 
 # sent_id = dev-s673
 # text = Wir Gewerkschaften sind bereit, über fast alles zu reden, auch über Lohn- und Nebenkosten und über Tarifstrukturen.
@@ -12215,15 +12288,16 @@
 21	.	.	PUNCT	$.	_	4	punct	_	_
 
 # sent_id = dev-s674
-# text = Es gab bereits ähnliche Fälle in Afrika.
-1	Es	es	PRON	PPER	Case=Nom|Gender=Neut|Number=Sing|Person=3|PronType=Prs	2	nsubj	_	_
-2	gab	geben	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	0	root	_	_
-3	bereits	bereits	ADV	ADV	_	2	advmod	_	_
-4	ähnliche	ähnlich	ADJ	ADJA	Case=Acc|Gender=Masc|Number=Plur	5	amod	_	_
-5	Fälle	Fall	NOUN	NN	Case=Acc|Gender=Masc|Number=Plur	2	obj	_	_
-6	in	in	ADP	APPR	_	7	case	_	_
-7	Afrika	Afrika	PROPN	NE	Case=Dat|Gender=Neut|Number=Sing	2	obl	_	SpaceAfter=No
-8	.	.	PUNCT	$.	_	2	punct	_	_
+# text = ``Es gab bereits ähnliche Fälle in Afrika.
+1	``	``	PUNCT	$(	_	2	punct	_	FixTigerDep=Yes|SpaceAfter=No
+2	Es	es	PRON	PPER	Case=Nom|Gender=Neut|Number=Sing|Person=3|PronType=Prs	3	nsubj	_	_
+3	gab	geben	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	0	root	_	_
+4	bereits	bereits	ADV	ADV	_	3	advmod	_	_
+5	ähnliche	ähnlich	ADJ	ADJA	Case=Acc|Gender=Masc|Number=Plur	6	amod	_	_
+6	Fälle	Fall	NOUN	NN	Case=Acc|Gender=Masc|Number=Plur	3	obj	_	_
+7	in	in	ADP	APPR	_	8	case	_	_
+8	Afrika	Afrika	PROPN	NE	Case=Dat|Gender=Neut|Number=Sing	3	obl	_	SpaceAfter=No
+9	.	.	PUNCT	$.	_	3	punct	_	_
 
 # sent_id = dev-s675
 # text = Die Kampfflugzeuge flogen am Dienstag laut UN Aufklärungseinsätze über Ostslawonien.
@@ -12258,21 +12332,22 @@
 13	.	.	PUNCT	$.	_	12	punct	_	_
 
 # sent_id = dev-s677
-# text = Presseberichten zufolge boomt der Flohhandel bereits an Schulen im ganzen Land.
-1	Presseberichten	Pressebericht	NOUN	NN	Case=Dat|Gender=Masc|Number=Plur	3	obl	_	_
-2	zufolge	zufolge	ADP	APPO	Case=Dat	1	case	_	_
-3	boomt	boomen	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	0	root	_	_
-4	der	der	DET	ART	Case=Nom|Definite=Def|Gender=Masc|Number=Sing|PronType=Art	5	det	_	_
-5	Flohhandel	Flohhandel	NOUN	NN	Case=Nom|Gender=Masc|Number=Sing	3	nsubj	_	_
-6	bereits	bereits	ADV	ADV	_	3	advmod	_	_
-7	an	an	ADP	APPR	_	8	case	_	_
-8	Schulen	Schule	NOUN	NN	Case=Dat|Gender=Fem|Number=Plur	3	obl	_	_
-9-10	im	_	_	_	_	_	_	_	_
-9	in	in	ADP	APPR	_	12	case	_	_
-10	dem	der	DET	ART	Case=Dat|Definite=Def|Gender=Neut|Number=Sing|PronType=Art	12	det	_	_
-11	ganzen	ganz	ADJ	ADJA	Case=Dat|Gender=Neut|Number=Sing	12	amod	_	_
-12	Land	Land	NOUN	NN	Case=Dat|Gender=Neut|Number=Sing	8	nmod	_	SpaceAfter=No
-13	.	.	PUNCT	$.	_	3	punct	_	_
+# text = Bulgarischen Presseberichten zufolge boomt der Flohhandel bereits an Schulen im ganzen Land.
+1	Bulgarischen	bulgarisch	ADJ	ADJA	Case=Dat|Gender=Masc|Number=Plur	2	dep	_	FixTigerDep=Yes
+2	Presseberichten	Pressebericht	NOUN	NN	Case=Dat|Gender=Masc|Number=Plur	4	obl	_	_
+3	zufolge	zufolge	ADP	APPO	Case=Dat	2	case	_	_
+4	boomt	boomen	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	0	root	_	_
+5	der	der	DET	ART	Case=Nom|Definite=Def|Gender=Masc|Number=Sing|PronType=Art	6	det	_	_
+6	Flohhandel	Flohhandel	NOUN	NN	Case=Nom|Gender=Masc|Number=Sing	4	nsubj	_	_
+7	bereits	bereits	ADV	ADV	_	4	advmod	_	_
+8	an	an	ADP	APPR	_	9	case	_	_
+9	Schulen	Schule	NOUN	NN	Case=Dat|Gender=Fem|Number=Plur	4	obl	_	_
+10-11	im	_	_	_	_	_	_	_	_
+10	in	in	ADP	APPR	_	13	case	_	_
+11	dem	der	DET	ART	Case=Dat|Definite=Def|Gender=Neut|Number=Sing|PronType=Art	13	det	_	_
+12	ganzen	ganz	ADJ	ADJA	Case=Dat|Gender=Neut|Number=Sing	13	amod	_	_
+13	Land	Land	NOUN	NN	Case=Dat|Gender=Neut|Number=Sing	9	nmod	_	SpaceAfter=No
+14	.	.	PUNCT	$.	_	4	punct	_	_
 
 # sent_id = dev-s678
 # text = Die notwendige Glut haben wir mitgebracht.
@@ -12307,22 +12382,23 @@
 18	.	.	PUNCT	$.	_	6	punct	_	_
 
 # sent_id = dev-s680
-# text = Um die 600 Gulden muß man als Anfänger schon investieren'', sagt Theo.
-1	Um	um	ADV	APPR	_	3	advmod	_	_
-2	die	der	DET	ART	Case=Acc|Definite=Def|Gender=Masc|Number=Plur|PronType=Art	4	det	_	_
-3	600	600	NUM	CARD	NumType=Card	4	nummod	_	_
-4	Gulden	Gulden	PROPN	NN	Case=Acc|Gender=Masc|Number=Plur	10	obj	_	_
-5	muß	müssen	AUX	VMFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	10	aux	_	_
-6	man	man	PRON	PIS	Case=Nom|Definite=Ind|Number=Sing|PronType=Ind	10	nsubj	_	_
-7	als	als	ADP	APPR	_	8	case	_	_
-8	Anfänger	Anfänger	NOUN	NN	Case=Nom|Gender=Masc|Number=Sing	10	obl	_	_
-9	schon	schon	ADV	ADV	_	10	advmod	_	_
-10	investieren	investieren	VERB	VVINF	VerbForm=Inf	13	ccomp	_	SpaceAfter=No
-11	''	''	PUNCT	$(	_	13	punct	_	SpaceAfter=No
-12	,	,	PUNCT	$,	_	13	punct	_	_
-13	sagt	sagen	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	0	root	_	_
-14	Theo	Theo	PROPN	NE	Case=Nom|Gender=Masc|Number=Sing	13	nsubj	_	SpaceAfter=No
-15	.	.	PUNCT	$.	_	13	punct	_	_
+# text = ``Um die 600 Gulden muß man als Anfänger schon investieren'', sagt Theo.
+1	``	``	PUNCT	$(	_	2	punct	_	FixTigerDep=Yes|SpaceAfter=No
+2	Um	um	ADV	APPR	_	4	advmod	_	_
+3	die	der	DET	ART	Case=Acc|Definite=Def|Gender=Masc|Number=Plur|PronType=Art	5	det	_	_
+4	600	600	NUM	CARD	NumType=Card	5	nummod	_	_
+5	Gulden	Gulden	PROPN	NN	Case=Acc|Gender=Masc|Number=Plur	11	obj	_	_
+6	muß	müssen	AUX	VMFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	11	aux	_	_
+7	man	man	PRON	PIS	Case=Nom|Definite=Ind|Number=Sing|PronType=Ind	11	nsubj	_	_
+8	als	als	ADP	APPR	_	9	case	_	_
+9	Anfänger	Anfänger	NOUN	NN	Case=Nom|Gender=Masc|Number=Sing	11	obl	_	_
+10	schon	schon	ADV	ADV	_	11	advmod	_	_
+11	investieren	investieren	VERB	VVINF	VerbForm=Inf	14	ccomp	_	SpaceAfter=No
+12	''	''	PUNCT	$(	_	14	punct	_	SpaceAfter=No
+13	,	,	PUNCT	$,	_	14	punct	_	_
+14	sagt	sagen	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	0	root	_	_
+15	Theo	Theo	PROPN	NE	Case=Nom|Gender=Masc|Number=Sing	14	nsubj	_	SpaceAfter=No
+16	.	.	PUNCT	$.	_	14	punct	_	_
 
 # sent_id = dev-s681
 # text = Der Präsident Nelson Mandela äußerte zurückhaltende Kritik und setzte auf Gespräche mit der Junta in Lagos.
@@ -12379,69 +12455,71 @@
 9	.	.	PUNCT	$.	_	8	punct	_	_
 
 # sent_id = dev-s684
-# text = Günter Rexrodt (FDP) kündigte am Donnerstag im Bundestag ``ein umfassendes Maßnahmenpaket für Wachstum und Beschäftigung'' an, das soziale Kürzungen vorsieht und Anfang 1996 mit dem Jahreswirtschaftsbericht vorgelegt werden soll.
-1	Günter	Günter	PROPN	NE	Case=Nom|Gender=Masc|Number=Sing	6	nsubj	_	_
-2	Rexrodt	Rexrodt	PROPN	NE	Case=Nom|Gender=Masc|Number=Sing	1	flat	_	_
-3	(	(	PUNCT	$(	_	4	punct	_	SpaceAfter=No
-4	FDP	FDP	PROPN	NE	Case=Nom|Gender=Fem|Number=Sing	1	appos	_	SpaceAfter=No
-5	)	)	PUNCT	$(	_	4	punct	_	_
-6	kündigte	kündigen	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	0	root	_	_
-7-8	am	_	_	_	_	_	_	_	_
-7	an	an	ADP	APPR	_	9	case	_	_
-8	dem	der	DET	ART	Case=Dat|Definite=Def|Gender=Masc|Number=Sing|PronType=Art	9	det	_	_
-9	Donnerstag	Donnerstag	PROPN	NN	Case=Dat|Gender=Masc|Number=Sing	6	obl	_	_
-10-11	im	_	_	_	_	_	_	_	_
-10	in	in	ADP	APPR	_	12	case	_	_
-11	dem	der	DET	ART	Case=Dat|Definite=Def|Gender=Masc|Number=Sing|PronType=Art	12	det	_	_
-12	Bundestag	Bundestag	PROPN	NN	Case=Dat|Gender=Masc|Number=Sing	6	obl	_	_
-13	``	``	PUNCT	$(	_	16	punct	_	SpaceAfter=No
-14	ein	ein	DET	ART	Case=Acc|Definite=Ind|Gender=Neut|Number=Sing|PronType=Art	16	det	_	_
-15	umfassendes	umfassend	ADJ	ADJA	Case=Acc|Gender=Neut|Number=Sing	16	amod	_	_
-16	Maßnahmenpaket	Maßnahmenpaket	NOUN	NN	Case=Acc|Gender=Neut|Number=Sing	6	obj	_	_
-17	für	für	ADP	APPR	_	18	case	_	_
-18	Wachstum	Wachstum	NOUN	NN	Case=Acc|Gender=Neut|Number=Sing	16	nmod	_	_
-19	und	und	CCONJ	KON	_	20	cc	_	_
-20	Beschäftigung	Beschäftigung	NOUN	NN	Case=Acc|Gender=Fem|Number=Sing	18	conj	_	SpaceAfter=No
-21	''	''	PUNCT	$(	_	16	punct	_	_
-22	an	an	ADP	PTKVZ	_	6	compound:prt	_	SpaceAfter=No
-23	,	,	PUNCT	$,	_	6	punct	_	_
-24	das	der	PRON	PRELS	Case=Nom|Gender=Neut|Number=Sing|PronType=Rel	27	nsubj	_	_
-25	soziale	sozial	ADJ	ADJA	Case=Acc|Gender=Fem|Number=Plur	26	amod	_	_
-26	Kürzungen	Kürzung	NOUN	NN	Case=Acc|Gender=Fem|Number=Plur	27	obj	_	_
-27	vorsieht	vorsehen	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	16	acl	_	_
-28	und	und	CCONJ	KON	_	34	cc	_	_
-29	Anfang	Anfang	NOUN	NN	Gender=Masc|Number=Sing	30	compound	_	_
-30	1996	1996	NUM	CARD	NumType=Card	34	obl	_	_
-31	mit	mit	ADP	APPR	_	33	case	_	_
-32	dem	der	DET	ART	Case=Dat|Definite=Def|Gender=Masc|Number=Sing|PronType=Art	33	det	_	_
-33	Jahreswirtschaftsbericht	Jahreswirtschaftsbericht	NOUN	NN	Case=Dat|Gender=Masc|Number=Sing	34	obl	_	_
-34	vorgelegt	vorlegen	VERB	VVPP	VerbForm=Part	27	conj	_	_
-35	werden	werden	AUX	VAINF	VerbForm=Inf|Voice=Pass	34	aux:pass	_	_
-36	soll	sollen	AUX	VMFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	34	aux	_	SpaceAfter=No
-37	.	.	PUNCT	$.	_	6	punct	_	_
+# text = Bundeswirtschaftsminister Günter Rexrodt (FDP) kündigte am Donnerstag im Bundestag ``ein umfassendes Maßnahmenpaket für Wachstum und Beschäftigung'' an, das soziale Kürzungen vorsieht und Anfang 1996 mit dem Jahreswirtschaftsbericht vorgelegt werden soll.
+1	Bundeswirtschaftsminister	Bundeswirtschaftsminister	NOUN	NN	Case=Nom|Gender=Masc|Number=Sing	2	dep	_	FixTigerDep=Yes
+2	Günter	Günter	PROPN	NE	Case=Nom|Gender=Masc|Number=Sing	7	nsubj	_	_
+3	Rexrodt	Rexrodt	PROPN	NE	Case=Nom|Gender=Masc|Number=Sing	2	flat	_	_
+4	(	(	PUNCT	$(	_	5	punct	_	SpaceAfter=No
+5	FDP	FDP	PROPN	NE	Case=Nom|Gender=Fem|Number=Sing	2	appos	_	SpaceAfter=No
+6	)	)	PUNCT	$(	_	5	punct	_	_
+7	kündigte	kündigen	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	0	root	_	_
+8-9	am	_	_	_	_	_	_	_	_
+8	an	an	ADP	APPR	_	10	case	_	_
+9	dem	der	DET	ART	Case=Dat|Definite=Def|Gender=Masc|Number=Sing|PronType=Art	10	det	_	_
+10	Donnerstag	Donnerstag	PROPN	NN	Case=Dat|Gender=Masc|Number=Sing	7	obl	_	_
+11-12	im	_	_	_	_	_	_	_	_
+11	in	in	ADP	APPR	_	13	case	_	_
+12	dem	der	DET	ART	Case=Dat|Definite=Def|Gender=Masc|Number=Sing|PronType=Art	13	det	_	_
+13	Bundestag	Bundestag	PROPN	NN	Case=Dat|Gender=Masc|Number=Sing	7	obl	_	_
+14	``	``	PUNCT	$(	_	17	punct	_	SpaceAfter=No
+15	ein	ein	DET	ART	Case=Acc|Definite=Ind|Gender=Neut|Number=Sing|PronType=Art	17	det	_	_
+16	umfassendes	umfassend	ADJ	ADJA	Case=Acc|Gender=Neut|Number=Sing	17	amod	_	_
+17	Maßnahmenpaket	Maßnahmenpaket	NOUN	NN	Case=Acc|Gender=Neut|Number=Sing	7	obj	_	_
+18	für	für	ADP	APPR	_	19	case	_	_
+19	Wachstum	Wachstum	NOUN	NN	Case=Acc|Gender=Neut|Number=Sing	17	nmod	_	_
+20	und	und	CCONJ	KON	_	21	cc	_	_
+21	Beschäftigung	Beschäftigung	NOUN	NN	Case=Acc|Gender=Fem|Number=Sing	19	conj	_	SpaceAfter=No
+22	''	''	PUNCT	$(	_	17	punct	_	_
+23	an	an	ADP	PTKVZ	_	7	compound:prt	_	SpaceAfter=No
+24	,	,	PUNCT	$,	_	7	punct	_	_
+25	das	der	PRON	PRELS	Case=Nom|Gender=Neut|Number=Sing|PronType=Rel	28	nsubj	_	_
+26	soziale	sozial	ADJ	ADJA	Case=Acc|Gender=Fem|Number=Plur	27	amod	_	_
+27	Kürzungen	Kürzung	NOUN	NN	Case=Acc|Gender=Fem|Number=Plur	28	obj	_	_
+28	vorsieht	vorsehen	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	17	acl	_	_
+29	und	und	CCONJ	KON	_	35	cc	_	_
+30	Anfang	Anfang	NOUN	NN	Gender=Masc|Number=Sing	31	compound	_	_
+31	1996	1996	NUM	CARD	NumType=Card	35	obl	_	_
+32	mit	mit	ADP	APPR	_	34	case	_	_
+33	dem	der	DET	ART	Case=Dat|Definite=Def|Gender=Masc|Number=Sing|PronType=Art	34	det	_	_
+34	Jahreswirtschaftsbericht	Jahreswirtschaftsbericht	NOUN	NN	Case=Dat|Gender=Masc|Number=Sing	35	obl	_	_
+35	vorgelegt	vorlegen	VERB	VVPP	VerbForm=Part	28	conj	_	_
+36	werden	werden	AUX	VAINF	VerbForm=Inf|Voice=Pass	35	aux:pass	_	_
+37	soll	sollen	AUX	VMFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	35	aux	_	SpaceAfter=No
+38	.	.	PUNCT	$.	_	7	punct	_	_
 
 # sent_id = dev-s685
-# text = Greenpeace Deutschland würde gerne für seine Rettung mitstreiten, sucht aber noch nach einem tragenden Bild für eine Kampagne.
-1	Greenpeace	Greenpeace	PROPN	NE	Case=Nom|Number=Sing	8	nsubj	_	_
-2	Deutschland	Deutschland	PROPN	NE	Case=Nom|Gender=Neut|Number=Sing	1	flat	_	_
-3	würde	werden	AUX	VAFIN	Mood=Sub|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	8	aux	_	_
-4	gerne	gerne	ADV	ADV	_	8	advmod	_	_
-5	für	für	ADP	APPR	_	7	case	_	_
-6	seine	sein	PRON	PPOSAT	Case=Acc|Gender=Fem|Number=Sing|Poss=Yes	7	det:poss	_	_
-7	Rettung	Rettung	NOUN	NN	Case=Acc|Gender=Fem|Number=Sing	8	obl	_	_
-8	mitstreiten	mitstreiten	VERB	VVINF	VerbForm=Inf	0	root	_	SpaceAfter=No
-9	,	,	PUNCT	$,	_	10	punct	_	_
-10	sucht	suchen	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	8	conj	_	_
-11	aber	aber	CCONJ	ADV	_	10	cc	_	_
-12	noch	noch	ADV	ADV	_	10	advmod	_	_
-13	nach	nach	ADP	APPR	_	16	case	_	_
-14	einem	ein	DET	ART	Case=Dat|Definite=Ind|Gender=Neut|Number=Sing|PronType=Art	16	det	_	_
-15	tragenden	tragend	ADJ	ADJA	Case=Dat|Gender=Neut|Number=Sing	16	amod	_	_
-16	Bild	Bild	NOUN	NN	Case=Dat|Gender=Neut|Number=Sing	10	obl	_	_
-17	für	für	ADP	APPR	_	19	case	_	_
-18	eine	ein	DET	ART	Case=Acc|Definite=Ind|Gender=Fem|Number=Sing|PronType=Art	19	det	_	_
-19	Kampagne	Kampagne	NOUN	NN	Case=Acc|Gender=Fem|Number=Sing	16	nmod	_	SpaceAfter=No
-20	.	.	PUNCT	$.	_	8	punct	_	_
+# text = Auch Greenpeace Deutschland würde gerne für seine Rettung mitstreiten, sucht aber noch nach einem tragenden Bild für eine Kampagne.
+1	Auch	auch	ADV	ADV	_	2	dep	_	FixTigerDep=Yes
+2	Greenpeace	Greenpeace	PROPN	NE	Case=Nom|Number=Sing	9	nsubj	_	_
+3	Deutschland	Deutschland	PROPN	NE	Case=Nom|Gender=Neut|Number=Sing	2	flat	_	_
+4	würde	werden	AUX	VAFIN	Mood=Sub|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	9	aux	_	_
+5	gerne	gerne	ADV	ADV	_	9	advmod	_	_
+6	für	für	ADP	APPR	_	8	case	_	_
+7	seine	sein	PRON	PPOSAT	Case=Acc|Gender=Fem|Number=Sing|Poss=Yes	8	det:poss	_	_
+8	Rettung	Rettung	NOUN	NN	Case=Acc|Gender=Fem|Number=Sing	9	obl	_	_
+9	mitstreiten	mitstreiten	VERB	VVINF	VerbForm=Inf	0	root	_	SpaceAfter=No
+10	,	,	PUNCT	$,	_	11	punct	_	_
+11	sucht	suchen	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	9	conj	_	_
+12	aber	aber	CCONJ	ADV	_	11	cc	_	_
+13	noch	noch	ADV	ADV	_	11	advmod	_	_
+14	nach	nach	ADP	APPR	_	17	case	_	_
+15	einem	ein	DET	ART	Case=Dat|Definite=Ind|Gender=Neut|Number=Sing|PronType=Art	17	det	_	_
+16	tragenden	tragend	ADJ	ADJA	Case=Dat|Gender=Neut|Number=Sing	17	amod	_	_
+17	Bild	Bild	NOUN	NN	Case=Dat|Gender=Neut|Number=Sing	11	obl	_	_
+18	für	für	ADP	APPR	_	20	case	_	_
+19	eine	ein	DET	ART	Case=Acc|Definite=Ind|Gender=Fem|Number=Sing|PronType=Art	20	det	_	_
+20	Kampagne	Kampagne	NOUN	NN	Case=Acc|Gender=Fem|Number=Sing	17	nmod	_	SpaceAfter=No
+21	.	.	PUNCT	$.	_	9	punct	_	_
 
 # sent_id = dev-s686
 # text = Die Entschädigungen für die Familienangehörigen belaufen sich auf umgerechnet zwischen etwa 150 000 und 225 000 Mark.
@@ -12465,93 +12543,97 @@
 18	.	.	PUNCT	$.	_	6	punct	_	_
 
 # sent_id = dev-s687
-# text = Wir wissen immer noch nichts über die Herkunft des Virus''', gibt Murray zu.
-1	Wir	wir	PRON	PPER	Case=Nom|Number=Plur|Person=1|PronType=Prs	2	nsubj	_	_
-2	wissen	wissen	VERB	VVFIN	Mood=Ind|Number=Plur|Person=1|Tense=Pres|VerbForm=Fin	13	ccomp	_	_
-3	immer	immer	ADV	ADV	_	4	advmod	_	_
-4	noch	noch	ADV	ADV	_	2	advmod	_	_
-5	nichts	nichts	PRON	PIS	Definite=Ind|Gender=Neut|PronType=Ind	2	obj	_	_
-6	über	über	ADP	APPR	_	8	case	_	_
-7	die	der	DET	ART	Case=Acc|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	8	det	_	_
-8	Herkunft	Herkunft	NOUN	NN	Case=Acc|Gender=Fem|Number=Sing	2	obl	_	_
-9	des	der	DET	ART	Case=Gen|Definite=Def|Gender=Neut|Number=Sing|PronType=Art	10	det	_	_
-10	Virus'	Virus	NOUN	NN	Case=Gen|Gender=Neut|Number=Sing	8	nmod	_	SpaceAfter=No
-11	''	''	PUNCT	$(	_	13	punct	_	SpaceAfter=No
-12	,	,	PUNCT	$,	_	13	punct	_	_
-13	gibt	geben	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	0	root	_	_
-14	Murray	Murray	PROPN	NE	Case=Nom|Number=Sing	13	nsubj	_	_
-15	zu	zu	ADP	PTKVZ	_	13	compound:prt	_	SpaceAfter=No
-16	.	.	PUNCT	$.	_	13	punct	_	_
+# text = ``Wir wissen immer noch nichts über die Herkunft des Virus''', gibt Murray zu.
+1	``	``	PUNCT	$(	_	2	punct	_	FixTigerDep=Yes|SpaceAfter=No
+2	Wir	wir	PRON	PPER	Case=Nom|Number=Plur|Person=1|PronType=Prs	3	nsubj	_	_
+3	wissen	wissen	VERB	VVFIN	Mood=Ind|Number=Plur|Person=1|Tense=Pres|VerbForm=Fin	14	ccomp	_	_
+4	immer	immer	ADV	ADV	_	5	advmod	_	_
+5	noch	noch	ADV	ADV	_	3	advmod	_	_
+6	nichts	nichts	PRON	PIS	Definite=Ind|Gender=Neut|PronType=Ind	3	obj	_	_
+7	über	über	ADP	APPR	_	9	case	_	_
+8	die	der	DET	ART	Case=Acc|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	9	det	_	_
+9	Herkunft	Herkunft	NOUN	NN	Case=Acc|Gender=Fem|Number=Sing	3	obl	_	_
+10	des	der	DET	ART	Case=Gen|Definite=Def|Gender=Neut|Number=Sing|PronType=Art	11	det	_	_
+11	Virus'	Virus	NOUN	NN	Case=Gen|Gender=Neut|Number=Sing	9	nmod	_	SpaceAfter=No
+12	''	''	PUNCT	$(	_	14	punct	_	SpaceAfter=No
+13	,	,	PUNCT	$,	_	14	punct	_	_
+14	gibt	geben	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	0	root	_	_
+15	Murray	Murray	PROPN	NE	Case=Nom|Number=Sing	14	nsubj	_	_
+16	zu	zu	ADP	PTKVZ	_	14	compound:prt	_	SpaceAfter=No
+17	.	.	PUNCT	$.	_	14	punct	_	_
 
 # sent_id = dev-s688
-# text = ``Wie läßt sich die ausgeprägte Furcht von Innovationen sowohl im deutschen Management wie auch bei vielen Arbeitnehmerinnen und Arbeitnehmern überwinden?''
-1	``	``	PUNCT	$(	_	3	punct	_	SpaceAfter=No
-2	Wie	wie	ADV	PWAV	PronType=Int	3	advmod	_	_
-3	läßt	lassen	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	0	root	_	_
-4	sich	er|es|sie	PRON	PRF	Case=Acc|Number=Sing|Person=3|PronType=Prs|Reflex=Yes	3	obj	_	_
-5	die	der	DET	ART	Case=Nom|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	7	det	_	_
-6	ausgeprägte	ausgeprägt	ADJ	ADJA	Case=Nom|Gender=Fem|Number=Sing	7	amod	_	_
-7	Furcht	Furcht	NOUN	NN	Case=Nom|Gender=Fem|Number=Sing	3	nsubj	_	_
-8	von	von	ADP	APPR	_	9	case	_	_
-9	Innovationen	Innovation	NOUN	NN	Case=Dat|Gender=Fem|Number=Plur	7	nmod	_	_
-10	sowohl	sowohl	CCONJ	KON	_	14	cc	_	_
-11-12	im	_	_	_	_	_	_	_	_
-11	in	in	ADP	APPR	_	14	case	_	_
-12	dem	der	DET	ART	Case=Dat|Definite=Def|Gender=Neut|Number=Sing|PronType=Art	14	det	_	_
-13	deutschen	deutsch	ADJ	ADJA	Case=Dat|Gender=Neut|Number=Sing	14	amod	_	_
-14	Management	Management	NOUN	NN	Case=Dat|Gender=Neut|Number=Sing	22	obl	_	_
-15	wie	wie	CCONJ	KON	_	19	cc	_	_
-16	auch	auch	ADV	ADV	_	19	advmod	_	_
-17	bei	bei	ADP	APPR	_	19	case	_	_
-18	vielen	vieler	ADJ	PIAT	Case=Dat|Definite=Ind|Number=Plur|PronType=Ind	19	amod	_	_
-19	Arbeitnehmerinnen	Arbeitnehmerin	NOUN	NN	Case=Dat|Gender=Fem|Number=Plur	14	conj	_	_
-20	und	und	CCONJ	KON	_	21	cc	_	_
-21	Arbeitnehmern	Arbeitnehmer	NOUN	NN	Case=Dat|Gender=Masc|Number=Plur	19	conj	_	_
-22	überwinden	überwinden	VERB	VVINF	VerbForm=Inf	3	xcomp	_	SpaceAfter=No
-23	?	?	PUNCT	$.	_	3	punct	_	SpaceAfter=No
-24	''	''	PUNCT	$(	_	3	punct	_	_
+# text = -``Wie läßt sich die ausgeprägte Furcht von Innovationen sowohl im deutschen Management wie auch bei vielen Arbeitnehmerinnen und Arbeitnehmern überwinden?''
+1	-	-	PUNCT	$(	_	2	punct	_	FixTigerDep=Yes|SpaceAfter=No
+2	``	``	PUNCT	$(	_	4	punct	_	SpaceAfter=No
+3	Wie	wie	ADV	PWAV	PronType=Int	4	advmod	_	_
+4	läßt	lassen	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	0	root	_	_
+5	sich	er|es|sie	PRON	PRF	Case=Acc|Number=Sing|Person=3|PronType=Prs|Reflex=Yes	4	obj	_	_
+6	die	der	DET	ART	Case=Nom|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	8	det	_	_
+7	ausgeprägte	ausgeprägt	ADJ	ADJA	Case=Nom|Gender=Fem|Number=Sing	8	amod	_	_
+8	Furcht	Furcht	NOUN	NN	Case=Nom|Gender=Fem|Number=Sing	4	nsubj	_	_
+9	von	von	ADP	APPR	_	10	case	_	_
+10	Innovationen	Innovation	NOUN	NN	Case=Dat|Gender=Fem|Number=Plur	8	nmod	_	_
+11	sowohl	sowohl	CCONJ	KON	_	15	cc	_	_
+12-13	im	_	_	_	_	_	_	_	_
+12	in	in	ADP	APPR	_	15	case	_	_
+13	dem	der	DET	ART	Case=Dat|Definite=Def|Gender=Neut|Number=Sing|PronType=Art	15	det	_	_
+14	deutschen	deutsch	ADJ	ADJA	Case=Dat|Gender=Neut|Number=Sing	15	amod	_	_
+15	Management	Management	NOUN	NN	Case=Dat|Gender=Neut|Number=Sing	23	obl	_	_
+16	wie	wie	CCONJ	KON	_	20	cc	_	_
+17	auch	auch	ADV	ADV	_	20	advmod	_	_
+18	bei	bei	ADP	APPR	_	20	case	_	_
+19	vielen	vieler	ADJ	PIAT	Case=Dat|Definite=Ind|Number=Plur|PronType=Ind	20	amod	_	_
+20	Arbeitnehmerinnen	Arbeitnehmerin	NOUN	NN	Case=Dat|Gender=Fem|Number=Plur	15	conj	_	_
+21	und	und	CCONJ	KON	_	22	cc	_	_
+22	Arbeitnehmern	Arbeitnehmer	NOUN	NN	Case=Dat|Gender=Masc|Number=Plur	20	conj	_	_
+23	überwinden	überwinden	VERB	VVINF	VerbForm=Inf	4	xcomp	_	SpaceAfter=No
+24	?	?	PUNCT	$.	_	4	punct	_	SpaceAfter=No
+25	''	''	PUNCT	$(	_	4	punct	_	_
 
 # sent_id = dev-s689
-# text = Schleußer (SPD) ist seit 1988 Finanzminister in Nordhein-Westfalen.
-1	Schleußer	Schleußer	PROPN	NE	Case=Nom|Gender=Masc|Number=Sing	8	nsubj	_	_
-2	(	(	PUNCT	$(	_	3	punct	_	SpaceAfter=No
-3	SPD	SPD	PROPN	NE	Case=Nom|Gender=Fem|Number=Sing	1	appos	_	SpaceAfter=No
-4	)	)	PUNCT	$(	_	3	punct	_	_
-5	ist	sein	AUX	VAFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	8	cop	_	_
-6	seit	seit	ADP	APPR	_	7	case	_	_
-7	1988	1988	NUM	CARD	NumType=Card	8	nmod	_	_
-8	Finanzminister	Finanzminister	NOUN	NN	Case=Nom|Gender=Masc|Number=Sing	0	root	_	_
-9	in	in	ADP	APPR	_	10	case	_	_
-10	Nordhein	Nordhein	PROPN	NE	Case=Dat|Gender=Neut|Number=Sing	8	nmod	_	SpaceAfter=No
-11	-	-	PUNCT	$(	_	10	punct	_	SpaceAfter=No
-12	Westfalen	Westfalen	PROPN	NE	Case=Dat|Gender=Neut|Number=Sing	10	flat	_	SpaceAfter=No
-13	.	.	PUNCT	$.	_	8	punct	_	_
+# text = Heinz Schleußer (SPD) ist seit 1988 Finanzminister in Nordhein-Westfalen.
+1	Heinz	Heinz	PROPN	NE	Case=Nom|Gender=Masc|Number=Sing	2	dep	_	FixTigerDep=Yes
+2	Schleußer	Schleußer	PROPN	NE	Case=Nom|Gender=Masc|Number=Sing	9	nsubj	_	_
+3	(	(	PUNCT	$(	_	4	punct	_	SpaceAfter=No
+4	SPD	SPD	PROPN	NE	Case=Nom|Gender=Fem|Number=Sing	2	appos	_	SpaceAfter=No
+5	)	)	PUNCT	$(	_	4	punct	_	_
+6	ist	sein	AUX	VAFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	9	cop	_	_
+7	seit	seit	ADP	APPR	_	8	case	_	_
+8	1988	1988	NUM	CARD	NumType=Card	9	nmod	_	_
+9	Finanzminister	Finanzminister	NOUN	NN	Case=Nom|Gender=Masc|Number=Sing	0	root	_	_
+10	in	in	ADP	APPR	_	11	case	_	_
+11	Nordhein	Nordhein	PROPN	NE	Case=Dat|Gender=Neut|Number=Sing	9	nmod	_	SpaceAfter=No
+12	-	-	PUNCT	$(	_	11	punct	_	SpaceAfter=No
+13	Westfalen	Westfalen	PROPN	NE	Case=Dat|Gender=Neut|Number=Sing	11	flat	_	SpaceAfter=No
+14	.	.	PUNCT	$.	_	9	punct	_	_
 
 # sent_id = dev-s690
-# text = 1988 und 1990 war Peres Finanzminister in Schamirs neuer Regierung, kündigte dann jedoch die Koalition auf und ging in die Opposition.
-1	1988	1988	NUM	CARD	NumType=Card	6	nmod	_	_
-2	und	und	CCONJ	KON	_	3	cc	_	_
-3	1990	1990	NUM	CARD	NumType=Card	1	conj	_	_
-4	war	sein	AUX	VAFIN	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	6	cop	_	_
-5	Peres	Peres	PROPN	NE	Case=Nom|Number=Sing	6	nsubj	_	_
-6	Finanzminister	Finanzminister	NOUN	NN	Case=Nom|Gender=Masc|Number=Sing	0	root	_	_
-7	in	in	ADP	APPR	_	10	case	_	_
-8	Schamirs	Schamir	PROPN	NE	Case=Gen|Number=Sing	10	nmod	_	_
-9	neuer	neu	ADJ	ADJA	Case=Dat|Gender=Fem|Number=Sing	10	amod	_	_
-10	Regierung	Regierung	NOUN	NN	Case=Dat|Gender=Fem|Number=Sing	6	nmod	_	SpaceAfter=No
-11	,	,	PUNCT	$,	_	12	punct	_	_
-12	kündigte	kündigen	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	6	conj	_	_
-13	dann	dann	ADV	ADV	_	12	advmod	_	_
-14	jedoch	jedoch	CCONJ	ADV	_	19	cc	_	_
-15	die	der	DET	ART	Case=Acc|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	16	det	_	_
-16	Koalition	Koalition	NOUN	NN	Case=Acc|Gender=Fem|Number=Sing	12	obj	_	_
-17	auf	auf	ADP	PTKVZ	_	12	compound:prt	_	_
-18	und	und	CCONJ	KON	_	19	cc	_	_
-19	ging	gehen	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	12	conj	_	_
-20	in	in	ADP	APPR	_	22	case	_	_
-21	die	der	DET	ART	Case=Acc|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	22	det	_	_
-22	Opposition	Opposition	NOUN	NN	Case=Acc|Gender=Fem|Number=Sing	19	obl	_	SpaceAfter=No
-23	.	.	PUNCT	$.	_	6	punct	_	_
+# text = Zwischen 1988 und 1990 war Peres Finanzminister in Schamirs neuer Regierung, kündigte dann jedoch die Koalition auf und ging in die Opposition.
+1	Zwischen	zwischen	ADP	APPR	_	2	dep	_	FixTigerDep=Yes
+2	1988	1988	NUM	CARD	NumType=Card	7	nmod	_	_
+3	und	und	CCONJ	KON	_	4	cc	_	_
+4	1990	1990	NUM	CARD	NumType=Card	2	conj	_	_
+5	war	sein	AUX	VAFIN	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	7	cop	_	_
+6	Peres	Peres	PROPN	NE	Case=Nom|Number=Sing	7	nsubj	_	_
+7	Finanzminister	Finanzminister	NOUN	NN	Case=Nom|Gender=Masc|Number=Sing	0	root	_	_
+8	in	in	ADP	APPR	_	11	case	_	_
+9	Schamirs	Schamir	PROPN	NE	Case=Gen|Number=Sing	11	nmod	_	_
+10	neuer	neu	ADJ	ADJA	Case=Dat|Gender=Fem|Number=Sing	11	amod	_	_
+11	Regierung	Regierung	NOUN	NN	Case=Dat|Gender=Fem|Number=Sing	7	nmod	_	SpaceAfter=No
+12	,	,	PUNCT	$,	_	13	punct	_	_
+13	kündigte	kündigen	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	7	conj	_	_
+14	dann	dann	ADV	ADV	_	13	advmod	_	_
+15	jedoch	jedoch	CCONJ	ADV	_	20	cc	_	_
+16	die	der	DET	ART	Case=Acc|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	17	det	_	_
+17	Koalition	Koalition	NOUN	NN	Case=Acc|Gender=Fem|Number=Sing	13	obj	_	_
+18	auf	auf	ADP	PTKVZ	_	13	compound:prt	_	_
+19	und	und	CCONJ	KON	_	20	cc	_	_
+20	ging	gehen	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	13	conj	_	_
+21	in	in	ADP	APPR	_	23	case	_	_
+22	die	der	DET	ART	Case=Acc|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	23	det	_	_
+23	Opposition	Opposition	NOUN	NN	Case=Acc|Gender=Fem|Number=Sing	20	obl	_	SpaceAfter=No
+24	.	.	PUNCT	$.	_	7	punct	_	_
 
 # sent_id = dev-s691
 # text = Die Telekom stellt von sofort an alle ausländischen Ansagedienste wieder auf Handvermittlung um.
@@ -12571,32 +12653,33 @@
 14	.	.	PUNCT	$.	_	3	punct	_	_
 
 # sent_id = dev-s692
-# text = Das größte Problem ist, die US-Zulieferer daran zu gewöhnen, uns BMW-Qualität und nicht US-Qualität zu liefern.
-1	Das	der	DET	ART	Case=Nom|Definite=Def|Gender=Neut|Number=Sing|PronType=Art	3	det	_	_
-2	größte	groß	ADJ	ADJA	Case=Nom|Gender=Neut|Number=Sing	3	amod	_	_
-3	Problem	Problem	NOUN	NN	Case=Nom|Gender=Neut|Number=Sing	4	nsubj	_	_
-4	ist	sein	VERB	VAFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	0	root	_	SpaceAfter=No
-5	,	,	PUNCT	$,	_	4	punct	_	_
-6	die	der	DET	ART	Case=Acc|Definite=Def|Gender=Masc|Number=Plur|PronType=Art	7	det	_	_
-7	US	US	PROPN	NN	Case=Acc|Gender=Masc|Number=Plur	9	compound	_	SpaceAfter=No
-8	-	-	PUNCT	$(	_	7	punct	_	SpaceAfter=No
-9	Zulieferer	Zulieferer	NOUN	NN	Case=Acc|Gender=Masc|Number=Plur	12	obj	_	_
-10	daran	daran	ADV	PAV	_	12	advmod	_	_
-11	zu	zu	PART	PTKZU	_	12	mark	_	_
-12	gewöhnen	gewöhnen	VERB	VVINF	VerbForm=Inf	4	xcomp	_	SpaceAfter=No
-13	,	,	PUNCT	$,	_	4	punct	_	_
-14	uns	wir	PRON	PPER	Case=Dat|Number=Plur|Person=1|PronType=Prs	24	iobj	_	_
-15	BMW	BMW	PROPN	NN	Case=Acc|Gender=Fem|Number=Sing	17	compound	_	SpaceAfter=No
-16	-	-	PUNCT	$(	_	15	punct	_	SpaceAfter=No
-17	Qualität	Qualität	NOUN	NN	Case=Acc|Gender=Fem|Number=Sing	24	obj	_	_
-18	und	und	CCONJ	KON	_	20	cc	_	_
-19	nicht	nicht	PART	PTKNEG	Polarity=Neg	20	advmod	_	_
-20	US	US	PROPN	NN	Case=Acc|Gender=Fem|Number=Sing	22	compound	_	SpaceAfter=No
-21	-	-	PUNCT	$(	_	20	punct	_	SpaceAfter=No
-22	Qualität	Qualität	NOUN	NN	Case=Acc|Gender=Fem|Number=Sing	15	conj	_	_
-23	zu	zu	PART	PTKZU	_	24	mark	_	_
-24	liefern	liefern	VERB	VVINF	VerbForm=Inf	12	xcomp	_	SpaceAfter=No
-25	.	.	PUNCT	$.	_	4	punct	_	_
+# text = ``Das größte Problem ist, die US-Zulieferer daran zu gewöhnen, uns BMW-Qualität und nicht US-Qualität zu liefern.
+1	``	``	PUNCT	$(	_	2	punct	_	FixTigerDep=Yes|SpaceAfter=No
+2	Das	der	DET	ART	Case=Nom|Definite=Def|Gender=Neut|Number=Sing|PronType=Art	4	det	_	_
+3	größte	groß	ADJ	ADJA	Case=Nom|Gender=Neut|Number=Sing	4	amod	_	_
+4	Problem	Problem	NOUN	NN	Case=Nom|Gender=Neut|Number=Sing	5	nsubj	_	_
+5	ist	sein	VERB	VAFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	0	root	_	SpaceAfter=No
+6	,	,	PUNCT	$,	_	5	punct	_	_
+7	die	der	DET	ART	Case=Acc|Definite=Def|Gender=Masc|Number=Plur|PronType=Art	8	det	_	_
+8	US	US	PROPN	NN	Case=Acc|Gender=Masc|Number=Plur	10	compound	_	SpaceAfter=No
+9	-	-	PUNCT	$(	_	8	punct	_	SpaceAfter=No
+10	Zulieferer	Zulieferer	NOUN	NN	Case=Acc|Gender=Masc|Number=Plur	13	obj	_	_
+11	daran	daran	ADV	PAV	_	13	advmod	_	_
+12	zu	zu	PART	PTKZU	_	13	mark	_	_
+13	gewöhnen	gewöhnen	VERB	VVINF	VerbForm=Inf	5	xcomp	_	SpaceAfter=No
+14	,	,	PUNCT	$,	_	5	punct	_	_
+15	uns	wir	PRON	PPER	Case=Dat|Number=Plur|Person=1|PronType=Prs	25	iobj	_	_
+16	BMW	BMW	PROPN	NN	Case=Acc|Gender=Fem|Number=Sing	18	compound	_	SpaceAfter=No
+17	-	-	PUNCT	$(	_	16	punct	_	SpaceAfter=No
+18	Qualität	Qualität	NOUN	NN	Case=Acc|Gender=Fem|Number=Sing	25	obj	_	_
+19	und	und	CCONJ	KON	_	21	cc	_	_
+20	nicht	nicht	PART	PTKNEG	Polarity=Neg	21	advmod	_	_
+21	US	US	PROPN	NN	Case=Acc|Gender=Fem|Number=Sing	23	compound	_	SpaceAfter=No
+22	-	-	PUNCT	$(	_	21	punct	_	SpaceAfter=No
+23	Qualität	Qualität	NOUN	NN	Case=Acc|Gender=Fem|Number=Sing	16	conj	_	_
+24	zu	zu	PART	PTKZU	_	25	mark	_	_
+25	liefern	liefern	VERB	VVINF	VerbForm=Inf	13	xcomp	_	SpaceAfter=No
+26	.	.	PUNCT	$.	_	5	punct	_	_
 
 # sent_id = dev-s693
 # text = Die Stimmabgabe wurde für die Sicherheitskräfte vorverlegt, damit sie am Wahltag selbst im Einsatz sein können.
@@ -12624,16 +12707,17 @@
 20	.	.	PUNCT	$.	_	7	punct	_	_
 
 # sent_id = dev-s694
-# text = 800 000 Bedienstete werden voraussichtlich in Zwangsurlaub geschickt.
-1	800	800	NUM	CARD	NumType=Card	2	nummod	_	_
-2	000	000	NUM	CARD	NumType=Card	3	nummod	_	_
-3	Bedienstete	Bediensteter	NOUN	NN	Case=Nom|Number=Plur	8	nsubj:pass	_	_
-4	werden	werden	AUX	VAFIN	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin|Voice=Pass	8	aux:pass	_	_
-5	voraussichtlich	voraussichtlich	ADV	ADJD	_	8	advmod	_	_
-6	in	in	ADP	APPR	_	7	case	_	_
-7	Zwangsurlaub	Zwangsurlaub	NOUN	NN	Case=Acc|Gender=Masc|Number=Sing	8	obl	_	_
-8	geschickt	schicken	VERB	VVPP	VerbForm=Part	0	root	_	SpaceAfter=No
-9	.	.	PUNCT	$.	_	8	punct	_	_
+# text = Rund 800 000 Bedienstete werden voraussichtlich in Zwangsurlaub geschickt.
+1	Rund	rund	ADJ	ADJD	_	2	dep	_	FixTigerDep=Yes
+2	800	800	NUM	CARD	NumType=Card	3	nummod	_	_
+3	000	000	NUM	CARD	NumType=Card	4	nummod	_	_
+4	Bedienstete	Bediensteter	NOUN	NN	Case=Nom|Number=Plur	9	nsubj:pass	_	_
+5	werden	werden	AUX	VAFIN	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin|Voice=Pass	9	aux:pass	_	_
+6	voraussichtlich	voraussichtlich	ADV	ADJD	_	9	advmod	_	_
+7	in	in	ADP	APPR	_	8	case	_	_
+8	Zwangsurlaub	Zwangsurlaub	NOUN	NN	Case=Acc|Gender=Masc|Number=Sing	9	obl	_	_
+9	geschickt	schicken	VERB	VVPP	VerbForm=Part	0	root	_	SpaceAfter=No
+10	.	.	PUNCT	$.	_	9	punct	_	_
 
 # sent_id = dev-s695
 # text = Die Stromwirtschaft und die Atomindustrie Deutschlands und Frankreichs haben am Montag in Straßburg ihr gemeinsames Projekt für einen Europäischen Druckwasserreaktor (EPR) offiziell vorgestellt.
@@ -12667,47 +12751,49 @@
 27	.	.	PUNCT	$.	_	26	punct	_	_
 
 # sent_id = dev-s696
-# text = Bischof soll aufgefordert worden sein, entsprechende Klöster in seiner Diözese zu überprüfen und festzustellen, ob die jungen Inderinnen wirklich Ordensschwestern werden wollten.
-1	Bischof	Bischof	NOUN	NN	Case=Nom|Gender=Masc|Number=Sing	3	nsubj:pass	_	_
-2	soll	sollen	AUX	VMFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	3	aux	_	_
-3	aufgefordert	auffordern	VERB	VVPP	VerbForm=Part	0	root	_	_
-4	worden	werden	AUX	VAPP	VerbForm=Part|Voice=Pass	3	aux:pass	_	_
-5	sein	sein	AUX	VAINF	VerbForm=Inf	3	aux	_	SpaceAfter=No
-6	,	,	PUNCT	$,	_	3	punct	_	_
-7	entsprechende	entsprechend	ADJ	ADJA	Case=Acc|Gender=Neut|Number=Plur	8	amod	_	_
-8	Klöster	Kloster	NOUN	NN	Case=Acc|Gender=Neut|Number=Plur	13	obj	_	_
-9	in	in	ADP	APPR	_	11	case	_	_
-10	seiner	sein	PRON	PPOSAT	Case=Dat|Gender=Fem|Number=Sing|Poss=Yes	11	det:poss	_	_
-11	Diözese	Diözese	NOUN	NN	Case=Dat|Gender=Fem|Number=Sing	8	nmod	_	_
-12	zu	zu	PART	PTKZU	_	13	mark	_	_
-13	überprüfen	überprüfen	VERB	VVINF	VerbForm=Inf	3	xcomp	_	_
-14	und	und	CCONJ	KON	_	15	cc	_	_
-15	festzustellen	feststellen	VERB	VVIZU	VerbForm=Inf	13	conj	_	SpaceAfter=No
-16	,	,	PUNCT	$,	_	3	punct	_	_
-17	ob	ob	SCONJ	KOUS	_	22	mark	_	_
-18	die	der	DET	ART	Case=Nom|Definite=Def|Gender=Fem|Number=Plur|PronType=Art	20	det	_	_
-19	jungen	jung	ADJ	ADJA	Case=Nom|Gender=Fem|Number=Plur	20	amod	_	_
-20	Inderinnen	Inderin	NOUN	NN	Case=Nom|Gender=Fem|Number=Plur	22	nsubj	_	_
-21	wirklich	wirklich	ADV	ADJD	_	22	advmod	_	_
-22	Ordensschwestern	Ordensbruder	NOUN	NN	Case=Nom|Gender=Fem|Number=Plur	15	advcl	_	_
-23	werden	werden	AUX	VAINF	VerbForm=Inf	22	cop	_	_
-24	wollten	wollen	AUX	VMFIN	Mood=Ind|Number=Plur|Person=3|Tense=Past|VerbForm=Fin	23	aux	_	SpaceAfter=No
-25	.	.	PUNCT	$.	_	3	punct	_	_
+# text = Jeder Bischof soll aufgefordert worden sein, entsprechende Klöster in seiner Diözese zu überprüfen und festzustellen, ob die jungen Inderinnen wirklich Ordensschwestern werden wollten.
+1	Jeder	jeder	DET	PIAT	Case=Nom|Definite=Ind|Gender=Masc|Number=Sing|PronType=Ind	2	dep	_	FixTigerDep=Yes
+2	Bischof	Bischof	NOUN	NN	Case=Nom|Gender=Masc|Number=Sing	4	nsubj:pass	_	_
+3	soll	sollen	AUX	VMFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	4	aux	_	_
+4	aufgefordert	auffordern	VERB	VVPP	VerbForm=Part	0	root	_	_
+5	worden	werden	AUX	VAPP	VerbForm=Part|Voice=Pass	4	aux:pass	_	_
+6	sein	sein	AUX	VAINF	VerbForm=Inf	4	aux	_	SpaceAfter=No
+7	,	,	PUNCT	$,	_	4	punct	_	_
+8	entsprechende	entsprechend	ADJ	ADJA	Case=Acc|Gender=Neut|Number=Plur	9	amod	_	_
+9	Klöster	Kloster	NOUN	NN	Case=Acc|Gender=Neut|Number=Plur	14	obj	_	_
+10	in	in	ADP	APPR	_	12	case	_	_
+11	seiner	sein	PRON	PPOSAT	Case=Dat|Gender=Fem|Number=Sing|Poss=Yes	12	det:poss	_	_
+12	Diözese	Diözese	NOUN	NN	Case=Dat|Gender=Fem|Number=Sing	9	nmod	_	_
+13	zu	zu	PART	PTKZU	_	14	mark	_	_
+14	überprüfen	überprüfen	VERB	VVINF	VerbForm=Inf	4	xcomp	_	_
+15	und	und	CCONJ	KON	_	16	cc	_	_
+16	festzustellen	feststellen	VERB	VVIZU	VerbForm=Inf	14	conj	_	SpaceAfter=No
+17	,	,	PUNCT	$,	_	4	punct	_	_
+18	ob	ob	SCONJ	KOUS	_	23	mark	_	_
+19	die	der	DET	ART	Case=Nom|Definite=Def|Gender=Fem|Number=Plur|PronType=Art	21	det	_	_
+20	jungen	jung	ADJ	ADJA	Case=Nom|Gender=Fem|Number=Plur	21	amod	_	_
+21	Inderinnen	Inderin	NOUN	NN	Case=Nom|Gender=Fem|Number=Plur	23	nsubj	_	_
+22	wirklich	wirklich	ADV	ADJD	_	23	advmod	_	_
+23	Ordensschwestern	Ordensbruder	NOUN	NN	Case=Nom|Gender=Fem|Number=Plur	16	advcl	_	_
+24	werden	werden	AUX	VAINF	VerbForm=Inf	23	cop	_	_
+25	wollten	wollen	AUX	VMFIN	Mood=Ind|Number=Plur|Person=3|Tense=Past|VerbForm=Fin	24	aux	_	SpaceAfter=No
+26	.	.	PUNCT	$.	_	4	punct	_	_
 
 # sent_id = dev-s697
-# text = Auwald ist also ein Wasserwald, sein Herz ist der Fluß.
-1	Auwald	Auwald	PROPN	NN	Case=Nom|Gender=Masc|Number=Sing	5	nsubj	_	_
-2	ist	sein	AUX	VAFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	5	cop	_	_
-3	also	also	ADV	ADV	_	5	advmod	_	_
-4	ein	ein	DET	ART	Case=Nom|Definite=Ind|Gender=Masc|Number=Sing|PronType=Art	5	det	_	_
-5	Wasserwald	Wasserwald	NOUN	NN	Case=Nom|Gender=Masc|Number=Sing	0	root	_	SpaceAfter=No
-6	,	,	PUNCT	$,	_	8	punct	_	_
-7	sein	sein	PRON	PPOSAT	Case=Nom|Gender=Neut|Number=Sing|Poss=Yes	8	det:poss	_	_
-8	Herz	Herz	NOUN	NN	Case=Nom|Gender=Neut|Number=Sing	5	conj	_	_
-9	ist	sein	AUX	VAFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	8	cop	_	_
-10	der	der	DET	ART	Case=Nom|Definite=Def|Gender=Masc|Number=Sing|PronType=Art	11	det	_	_
-11	Fluß	Fluß	NOUN	NN	Case=Nom|Gender=Masc|Number=Sing	8	nsubj	_	SpaceAfter=No
-12	.	.	PUNCT	$.	_	5	punct	_	_
+# text = Ein Auwald ist also ein Wasserwald, sein Herz ist der Fluß.
+1	Ein	ein	DET	ART	Case=Nom|Definite=Ind|Gender=Masc|Number=Sing|PronType=Art	2	dep	_	FixTigerDep=Yes
+2	Auwald	Auwald	PROPN	NN	Case=Nom|Gender=Masc|Number=Sing	6	nsubj	_	_
+3	ist	sein	AUX	VAFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	6	cop	_	_
+4	also	also	ADV	ADV	_	6	advmod	_	_
+5	ein	ein	DET	ART	Case=Nom|Definite=Ind|Gender=Masc|Number=Sing|PronType=Art	6	det	_	_
+6	Wasserwald	Wasserwald	NOUN	NN	Case=Nom|Gender=Masc|Number=Sing	0	root	_	SpaceAfter=No
+7	,	,	PUNCT	$,	_	9	punct	_	_
+8	sein	sein	PRON	PPOSAT	Case=Nom|Gender=Neut|Number=Sing|Poss=Yes	9	det:poss	_	_
+9	Herz	Herz	NOUN	NN	Case=Nom|Gender=Neut|Number=Sing	6	conj	_	_
+10	ist	sein	AUX	VAFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	9	cop	_	_
+11	der	der	DET	ART	Case=Nom|Definite=Def|Gender=Masc|Number=Sing|PronType=Art	12	det	_	_
+12	Fluß	Fluß	NOUN	NN	Case=Nom|Gender=Masc|Number=Sing	9	nsubj	_	SpaceAfter=No
+13	.	.	PUNCT	$.	_	6	punct	_	_
 
 # sent_id = dev-s698
 # text = Die Zeit geht vor allem Kindern verloren, denn jede Stunde mehr vor dem TV bedeutet eine Stunde weniger mit Freunden oder der Familie, mit möglicherweise negativen Folgen für die individuelle und soziale Entwicklung.
@@ -12766,33 +12852,34 @@
 14	.	.	PUNCT	$.	_	8	punct	_	_
 
 # sent_id = dev-s700
-# text = 45 Prozent der marktweiten Aufwendungen entfielen 1994 auf adressierte und unadressierte Postsendungen, zwölf Prozent auf Telefonaktivitäten und gut ein Drittel auf Anzeigen und Beilagen.
-1	45	45	NUM	CARD	NumType=Card	2	nummod	_	_
-2	Prozent	Prozent	NOUN	NN	Gender=Neut	6	nsubj	_	_
-3	der	der	DET	ART	Case=Gen|Definite=Def|Gender=Fem|Number=Plur|PronType=Art	5	det	_	_
-4	marktweiten	marktweit	ADJ	ADJA	Case=Gen|Gender=Fem|Number=Plur	5	amod	_	_
-5	Aufwendungen	Aufwendung	NOUN	NN	Case=Gen|Gender=Fem|Number=Plur	2	nmod	_	_
-6	entfielen	entfallen	VERB	VVFIN	Mood=Ind|Number=Plur|Person=3|Tense=Past|VerbForm=Fin	0	root	_	_
-7	1994	1994	NUM	CARD	NumType=Card	6	obl	_	_
-8	auf	auf	ADP	APPR	_	12	case	_	_
-9	adressierte	adressiert	ADJ	ADJA	Case=Acc|Gender=Fem|Number=Plur	12	amod	_	_
-10	und	und	CCONJ	KON	_	11	cc	_	_
-11	unadressierte	unadressiert	ADJ	ADJA	Case=Acc|Gender=Fem|Number=Plur	9	conj	_	_
-12	Postsendungen	Postsendung	NOUN	NN	Case=Acc|Gender=Fem|Number=Plur	6	obl	_	SpaceAfter=No
-13	,	,	PUNCT	$,	_	6	punct	_	_
-14	zwölf	zwölf	NUM	CARD	NumType=Card	15	nummod	_	_
-15	Prozent	Prozent	NOUN	NN	Gender=Neut	6	appos	_	_
-16	auf	auf	ADP	APPR	_	17	case	_	_
-17	Telefonaktivitäten	Telefonaktivität	NOUN	NN	Case=Acc|Gender=Fem|Number=Plur	15	nmod	_	_
-18	und	und	CCONJ	KON	_	21	cc	_	_
-19	gut	gut	ADV	ADJD	_	20	advmod	_	_
-20	ein	ein	DET	ART	Case=Nom|Definite=Ind|Gender=Neut|Number=Sing|PronType=Art	21	det	_	_
-21	Drittel	Drittel	NOUN	NN	Case=Nom|Gender=Neut|Number=Sing	15	conj	_	_
-22	auf	auf	ADP	APPR	_	23	case	_	_
-23	Anzeigen	Anzeige	NOUN	NN	Case=Acc|Gender=Fem|Number=Plur	21	nmod	_	_
-24	und	und	CCONJ	KON	_	25	cc	_	_
-25	Beilagen	Beilage	NOUN	NN	Case=Acc|Gender=Fem|Number=Plur	23	conj	_	SpaceAfter=No
-26	.	.	PUNCT	$.	_	6	punct	_	_
+# text = Knapp 45 Prozent der marktweiten Aufwendungen entfielen 1994 auf adressierte und unadressierte Postsendungen, zwölf Prozent auf Telefonaktivitäten und gut ein Drittel auf Anzeigen und Beilagen.
+1	Knapp	knapp	ADV	ADV	_	2	dep	_	FixTigerDep=Yes
+2	45	45	NUM	CARD	NumType=Card	3	nummod	_	_
+3	Prozent	Prozent	NOUN	NN	Gender=Neut	7	nsubj	_	_
+4	der	der	DET	ART	Case=Gen|Definite=Def|Gender=Fem|Number=Plur|PronType=Art	6	det	_	_
+5	marktweiten	marktweit	ADJ	ADJA	Case=Gen|Gender=Fem|Number=Plur	6	amod	_	_
+6	Aufwendungen	Aufwendung	NOUN	NN	Case=Gen|Gender=Fem|Number=Plur	3	nmod	_	_
+7	entfielen	entfallen	VERB	VVFIN	Mood=Ind|Number=Plur|Person=3|Tense=Past|VerbForm=Fin	0	root	_	_
+8	1994	1994	NUM	CARD	NumType=Card	7	obl	_	_
+9	auf	auf	ADP	APPR	_	13	case	_	_
+10	adressierte	adressiert	ADJ	ADJA	Case=Acc|Gender=Fem|Number=Plur	13	amod	_	_
+11	und	und	CCONJ	KON	_	12	cc	_	_
+12	unadressierte	unadressiert	ADJ	ADJA	Case=Acc|Gender=Fem|Number=Plur	10	conj	_	_
+13	Postsendungen	Postsendung	NOUN	NN	Case=Acc|Gender=Fem|Number=Plur	7	obl	_	SpaceAfter=No
+14	,	,	PUNCT	$,	_	7	punct	_	_
+15	zwölf	zwölf	NUM	CARD	NumType=Card	16	nummod	_	_
+16	Prozent	Prozent	NOUN	NN	Gender=Neut	7	appos	_	_
+17	auf	auf	ADP	APPR	_	18	case	_	_
+18	Telefonaktivitäten	Telefonaktivität	NOUN	NN	Case=Acc|Gender=Fem|Number=Plur	16	nmod	_	_
+19	und	und	CCONJ	KON	_	22	cc	_	_
+20	gut	gut	ADV	ADJD	_	21	advmod	_	_
+21	ein	ein	DET	ART	Case=Nom|Definite=Ind|Gender=Neut|Number=Sing|PronType=Art	22	det	_	_
+22	Drittel	Drittel	NOUN	NN	Case=Nom|Gender=Neut|Number=Sing	16	conj	_	_
+23	auf	auf	ADP	APPR	_	24	case	_	_
+24	Anzeigen	Anzeige	NOUN	NN	Case=Acc|Gender=Fem|Number=Plur	22	nmod	_	_
+25	und	und	CCONJ	KON	_	26	cc	_	_
+26	Beilagen	Beilage	NOUN	NN	Case=Acc|Gender=Fem|Number=Plur	24	conj	_	SpaceAfter=No
+27	.	.	PUNCT	$.	_	7	punct	_	_
 
 # sent_id = dev-s701
 # text = Die Kasseler Richter haben damit dem Bundesverwaltungsgericht die Gefolgschaft verweigert.
@@ -12823,214 +12910,222 @@
 11	.	.	PUNCT	$.	_	3	punct	_	_
 
 # sent_id = dev-s703
-# text = Es muß zu denken geben, daß die deutsche Wirtschaft selbst vor dem Wind einer kräftigen Exportkonjunktur nicht zu mehr Eigendynamik findet'', stellt das Gutachten fest.
-1	Es	es	PRON	PPER	Case=Nom|Gender=Neut|Number=Sing|Person=3|PronType=Prs	5	nsubj	_	_
-2	muß	müssen	AUX	VMFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	5	aux	_	_
-3	zu	zu	PART	PTKZU	_	4	mark	_	_
-4	denken	denken	VERB	VVINF	VerbForm=Inf	5	acl	_	_
-5	geben	geben	VERB	VVINF	VerbForm=Inf	25	ccomp	_	SpaceAfter=No
-6	,	,	PUNCT	$,	_	25	punct	_	_
-7	daß	daß	CCONJ	KOUS	_	22	cc	_	_
-8	die	der	DET	ART	Case=Nom|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	10	det	_	_
-9	deutsche	deutsch	ADJ	ADJA	Case=Nom|Gender=Fem|Number=Sing	10	amod	_	_
-10	Wirtschaft	Wirtschaft	NOUN	NN	Case=Nom|Gender=Fem|Number=Sing	22	nsubj	_	_
-11	selbst	selbst	ADV	ADV	_	22	advmod	_	_
-12	vor	vor	ADP	APPR	_	14	case	_	_
-13	dem	der	DET	ART	Case=Dat|Definite=Def|Gender=Masc|Number=Sing|PronType=Art	14	det	_	_
-14	Wind	Wind	NOUN	NN	Case=Dat|Gender=Masc|Number=Sing	22	obl	_	_
-15	einer	ein	DET	ART	Case=Gen|Definite=Ind|Gender=Fem|Number=Sing|PronType=Art	17	det	_	_
-16	kräftigen	kräftig	ADJ	ADJA	Case=Gen|Gender=Fem|Number=Sing	17	amod	_	_
-17	Exportkonjunktur	Exportkonjunktur	NOUN	NN	Case=Gen|Gender=Fem|Number=Sing	14	nmod	_	_
-18	nicht	nicht	PART	PTKNEG	Polarity=Neg	22	advmod	_	_
-19	zu	zu	ADP	APPR	_	21	case	_	_
-20	mehr	mehr	PRON	PIAT	Definite=Ind|PronType=Ind	21	det	_	_
-21	Eigendynamik	Eigendynamik	NOUN	NN	Case=Dat|Gender=Fem|Number=Sing	22	obl	_	_
-22	findet	finden	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	5	ccomp	_	SpaceAfter=No
-23	''	''	PUNCT	$(	_	25	punct	_	SpaceAfter=No
-24	,	,	PUNCT	$,	_	25	punct	_	_
-25	stellt	stellen	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	0	root	_	_
-26	das	der	DET	ART	Case=Nom|Definite=Def|Gender=Neut|Number=Sing|PronType=Art	27	det	_	_
-27	Gutachten	Gutachten	NOUN	NN	Case=Nom|Gender=Neut|Number=Sing	25	nsubj	_	_
-28	fest	fest	ADV	PTKVZ	_	25	compound:prt	_	SpaceAfter=No
-29	.	.	PUNCT	$.	_	25	punct	_	_
+# text = ``Es muß zu denken geben, daß die deutsche Wirtschaft selbst vor dem Wind einer kräftigen Exportkonjunktur nicht zu mehr Eigendynamik findet'', stellt das Gutachten fest.
+1	``	``	PUNCT	$(	_	2	punct	_	FixTigerDep=Yes|SpaceAfter=No
+2	Es	es	PRON	PPER	Case=Nom|Gender=Neut|Number=Sing|Person=3|PronType=Prs	6	nsubj	_	_
+3	muß	müssen	AUX	VMFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	6	aux	_	_
+4	zu	zu	PART	PTKZU	_	5	mark	_	_
+5	denken	denken	VERB	VVINF	VerbForm=Inf	6	acl	_	_
+6	geben	geben	VERB	VVINF	VerbForm=Inf	26	ccomp	_	SpaceAfter=No
+7	,	,	PUNCT	$,	_	26	punct	_	_
+8	daß	daß	CCONJ	KOUS	_	23	cc	_	_
+9	die	der	DET	ART	Case=Nom|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	11	det	_	_
+10	deutsche	deutsch	ADJ	ADJA	Case=Nom|Gender=Fem|Number=Sing	11	amod	_	_
+11	Wirtschaft	Wirtschaft	NOUN	NN	Case=Nom|Gender=Fem|Number=Sing	23	nsubj	_	_
+12	selbst	selbst	ADV	ADV	_	23	advmod	_	_
+13	vor	vor	ADP	APPR	_	15	case	_	_
+14	dem	der	DET	ART	Case=Dat|Definite=Def|Gender=Masc|Number=Sing|PronType=Art	15	det	_	_
+15	Wind	Wind	NOUN	NN	Case=Dat|Gender=Masc|Number=Sing	23	obl	_	_
+16	einer	ein	DET	ART	Case=Gen|Definite=Ind|Gender=Fem|Number=Sing|PronType=Art	18	det	_	_
+17	kräftigen	kräftig	ADJ	ADJA	Case=Gen|Gender=Fem|Number=Sing	18	amod	_	_
+18	Exportkonjunktur	Exportkonjunktur	NOUN	NN	Case=Gen|Gender=Fem|Number=Sing	15	nmod	_	_
+19	nicht	nicht	PART	PTKNEG	Polarity=Neg	23	advmod	_	_
+20	zu	zu	ADP	APPR	_	22	case	_	_
+21	mehr	mehr	PRON	PIAT	Definite=Ind|PronType=Ind	22	det	_	_
+22	Eigendynamik	Eigendynamik	NOUN	NN	Case=Dat|Gender=Fem|Number=Sing	23	obl	_	_
+23	findet	finden	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	6	ccomp	_	SpaceAfter=No
+24	''	''	PUNCT	$(	_	26	punct	_	SpaceAfter=No
+25	,	,	PUNCT	$,	_	26	punct	_	_
+26	stellt	stellen	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	0	root	_	_
+27	das	der	DET	ART	Case=Nom|Definite=Def|Gender=Neut|Number=Sing|PronType=Art	28	det	_	_
+28	Gutachten	Gutachten	NOUN	NN	Case=Nom|Gender=Neut|Number=Sing	26	nsubj	_	_
+29	fest	fest	ADV	PTKVZ	_	26	compound:prt	_	SpaceAfter=No
+30	.	.	PUNCT	$.	_	26	punct	_	_
 
 # sent_id = dev-s704
-# text = Kohl bewegt sich derweil schon im Marschschritt auf die zivile Seite der Division zu.
-1	Kohl	Kohl	PROPN	NE	Case=Nom|Gender=Masc|Number=Sing	2	nsubj	_	_
-2	bewegt	bewegen	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	0	root	_	_
-3	sich	er|es|sie	PRON	PRF	Case=Acc|Number=Sing|Person=3|PronType=Prs|Reflex=Yes	2	obj	_	_
-4	derweil	derweil	ADV	ADV	_	2	advmod	_	_
-5	schon	schon	ADV	ADV	_	2	advmod	_	_
-6-7	im	_	_	_	_	_	_	_	_
-6	in	in	ADP	APPR	_	8	case	_	_
-7	dem	der	DET	ART	Case=Dat|Definite=Def|Gender=Masc|Number=Sing|PronType=Art	8	det	_	_
-8	Marschschritt	Marschschritt	NOUN	NN	Case=Dat|Gender=Masc|Number=Sing	2	obl	_	_
-9	auf	auf	ADP	APPR	_	12	case	_	_
-10	die	der	DET	ART	Case=Acc|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	12	det	_	_
-11	zivile	zivil	ADJ	ADJA	Case=Acc|Gender=Fem|Number=Sing	12	amod	_	_
-12	Seite	Seite	NOUN	NN	Case=Acc|Gender=Fem|Number=Sing	2	obl	_	_
-13	der	der	DET	ART	Case=Gen|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	14	det	_	_
-14	Division	Division	NOUN	NN	Case=Gen|Gender=Fem|Number=Sing	12	nmod	_	_
-15	zu	zu	ADP	PTKVZ	_	2	compound:prt	_	SpaceAfter=No
-16	.	.	PUNCT	$.	_	2	punct	_	_
+# text = Helmut Kohl bewegt sich derweil schon im Marschschritt auf die zivile Seite der Division zu.
+1	Helmut	Helmut	PROPN	NE	Case=Nom|Gender=Masc|Number=Sing	2	dep	_	FixTigerDep=Yes
+2	Kohl	Kohl	PROPN	NE	Case=Nom|Gender=Masc|Number=Sing	3	nsubj	_	_
+3	bewegt	bewegen	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	0	root	_	_
+4	sich	er|es|sie	PRON	PRF	Case=Acc|Number=Sing|Person=3|PronType=Prs|Reflex=Yes	3	obj	_	_
+5	derweil	derweil	ADV	ADV	_	3	advmod	_	_
+6	schon	schon	ADV	ADV	_	3	advmod	_	_
+7-8	im	_	_	_	_	_	_	_	_
+7	in	in	ADP	APPR	_	9	case	_	_
+8	dem	der	DET	ART	Case=Dat|Definite=Def|Gender=Masc|Number=Sing|PronType=Art	9	det	_	_
+9	Marschschritt	Marschschritt	NOUN	NN	Case=Dat|Gender=Masc|Number=Sing	3	obl	_	_
+10	auf	auf	ADP	APPR	_	13	case	_	_
+11	die	der	DET	ART	Case=Acc|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	13	det	_	_
+12	zivile	zivil	ADJ	ADJA	Case=Acc|Gender=Fem|Number=Sing	13	amod	_	_
+13	Seite	Seite	NOUN	NN	Case=Acc|Gender=Fem|Number=Sing	3	obl	_	_
+14	der	der	DET	ART	Case=Gen|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	15	det	_	_
+15	Division	Division	NOUN	NN	Case=Gen|Gender=Fem|Number=Sing	13	nmod	_	_
+16	zu	zu	ADP	PTKVZ	_	3	compound:prt	_	SpaceAfter=No
+17	.	.	PUNCT	$.	_	3	punct	_	_
 
 # sent_id = dev-s705
-# text = Wer an deutschen Universitäten abgewiesen wird, wendet sich möglicherweise an eine dieser in Deutschland nicht anerkannten Hochschulen, die auch keinen anerkannten Abschluß verleihen kann'', befürchtet Werner Becker, HRK-Informationsreferent.
-1	Wer	wer	PRON	PWS	Case=Nom|Gender=Masc|Number=Sing|PronType=Int	5	nsubj:pass	_	_
-2	an	an	ADP	APPR	_	4	case	_	_
-3	deutschen	deutsch	ADJ	ADJA	Case=Dat|Gender=Fem|Number=Plur	4	amod	_	_
-4	Universitäten	Universität	NOUN	NN	Case=Dat|Gender=Fem|Number=Plur	5	obl	_	_
-5	abgewiesen	abweisen	VERB	VVPP	VerbForm=Part	8	csubj	_	_
-6	wird	werden	AUX	VAFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin|Voice=Pass	5	aux:pass	_	SpaceAfter=No
-7	,	,	PUNCT	$,	_	29	punct	_	_
-8	wendet	wenden	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	29	ccomp	_	_
-9	sich	er|es|sie	PRON	PRF	Case=Acc|Number=Sing|Person=3|PronType=Prs|Reflex=Yes	8	obj	_	_
-10	möglicherweise	möglicherweise	ADV	ADV	_	8	advmod	_	_
-11	an	an	ADP	APPR	_	12	case	_	_
-12	eine	ein	PRON	PIS	Case=Acc|Definite=Ind|Gender=Fem|Number=Sing|PronType=Ind	8	obl	_	_
-13	dieser	dies	PRON	PDAT	Case=Gen|Gender=Fem|Number=Plur|PronType=Dem	18	det	_	_
-14	in	in	ADP	APPR	_	15	case	_	_
-15	Deutschland	Deutschland	PROPN	NE	Case=Dat|Gender=Neut|Number=Sing	17	nmod	_	_
-16	nicht	nicht	PART	PTKNEG	Polarity=Neg	17	advmod	_	_
-17	anerkannten	anerkannt	ADJ	ADJA	Case=Gen|Gender=Fem|Number=Plur	18	amod	_	_
-18	Hochschulen	Hochschule	NOUN	NN	Case=Gen|Gender=Fem|Number=Plur	12	nmod	_	SpaceAfter=No
-19	,	,	PUNCT	$,	_	29	punct	_	_
-20	die	der	PRON	PRELS	Case=Nom|Gender=Fem|Number=Sing|PronType=Rel	25	nsubj	_	_
-21	auch	auch	ADV	ADV	_	25	advmod	_	_
-22	keinen	kein	PRON	PIAT	Case=Acc|Definite=Ind|Gender=Masc|Number=Sing|Polarity=Neg|PronType=Neg	24	advmod	_	_
-23	anerkannten	anerkannt	ADJ	ADJA	Case=Acc|Gender=Masc|Number=Sing	24	amod	_	_
-24	Abschluß	Abschluß	NOUN	NN	Case=Acc|Gender=Masc|Number=Sing	25	obj	_	_
-25	verleihen	verleihen	VERB	VVINF	VerbForm=Inf	18	acl	_	_
-26	kann	können	AUX	VMFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	25	aux	_	SpaceAfter=No
-27	''	''	PUNCT	$(	_	29	punct	_	SpaceAfter=No
-28	,	,	PUNCT	$,	_	29	punct	_	_
-29	befürchtet	befürchten	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	0	root	_	_
-30	Werner	Werner	PROPN	NE	Case=Nom|Gender=Masc|Number=Sing	29	nsubj	_	_
-31	Becker	Becker	PROPN	NE	Case=Nom|Gender=Masc|Number=Sing	30	flat	_	SpaceAfter=No
-32	,	,	PUNCT	$,	_	29	punct	_	_
-33	HRK	HRK	PROPN	NN	Case=Nom|Gender=Masc|Number=Sing	35	compound	_	SpaceAfter=No
-34	-	-	PUNCT	$(	_	33	punct	_	SpaceAfter=No
-35	Informationsreferent	Informationsreferent	NOUN	NN	Case=Nom|Gender=Masc|Number=Sing	30	appos	_	SpaceAfter=No
-36	.	.	PUNCT	$.	_	29	punct	_	_
+# text = ``Wer an deutschen Universitäten abgewiesen wird, wendet sich möglicherweise an eine dieser in Deutschland nicht anerkannten Hochschulen, die auch keinen anerkannten Abschluß verleihen kann'', befürchtet Werner Becker, HRK-Informationsreferent.
+1	``	``	PUNCT	$(	_	2	punct	_	FixTigerDep=Yes|SpaceAfter=No
+2	Wer	wer	PRON	PWS	Case=Nom|Gender=Masc|Number=Sing|PronType=Int	6	nsubj:pass	_	_
+3	an	an	ADP	APPR	_	5	case	_	_
+4	deutschen	deutsch	ADJ	ADJA	Case=Dat|Gender=Fem|Number=Plur	5	amod	_	_
+5	Universitäten	Universität	NOUN	NN	Case=Dat|Gender=Fem|Number=Plur	6	obl	_	_
+6	abgewiesen	abweisen	VERB	VVPP	VerbForm=Part	9	csubj	_	_
+7	wird	werden	AUX	VAFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin|Voice=Pass	6	aux:pass	_	SpaceAfter=No
+8	,	,	PUNCT	$,	_	30	punct	_	_
+9	wendet	wenden	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	30	ccomp	_	_
+10	sich	er|es|sie	PRON	PRF	Case=Acc|Number=Sing|Person=3|PronType=Prs|Reflex=Yes	9	obj	_	_
+11	möglicherweise	möglicherweise	ADV	ADV	_	9	advmod	_	_
+12	an	an	ADP	APPR	_	13	case	_	_
+13	eine	ein	PRON	PIS	Case=Acc|Definite=Ind|Gender=Fem|Number=Sing|PronType=Ind	9	obl	_	_
+14	dieser	dies	PRON	PDAT	Case=Gen|Gender=Fem|Number=Plur|PronType=Dem	19	det	_	_
+15	in	in	ADP	APPR	_	16	case	_	_
+16	Deutschland	Deutschland	PROPN	NE	Case=Dat|Gender=Neut|Number=Sing	18	nmod	_	_
+17	nicht	nicht	PART	PTKNEG	Polarity=Neg	18	advmod	_	_
+18	anerkannten	anerkannt	ADJ	ADJA	Case=Gen|Gender=Fem|Number=Plur	19	amod	_	_
+19	Hochschulen	Hochschule	NOUN	NN	Case=Gen|Gender=Fem|Number=Plur	13	nmod	_	SpaceAfter=No
+20	,	,	PUNCT	$,	_	30	punct	_	_
+21	die	der	PRON	PRELS	Case=Nom|Gender=Fem|Number=Sing|PronType=Rel	26	nsubj	_	_
+22	auch	auch	ADV	ADV	_	26	advmod	_	_
+23	keinen	kein	PRON	PIAT	Case=Acc|Definite=Ind|Gender=Masc|Number=Sing|Polarity=Neg|PronType=Neg	25	advmod	_	_
+24	anerkannten	anerkannt	ADJ	ADJA	Case=Acc|Gender=Masc|Number=Sing	25	amod	_	_
+25	Abschluß	Abschluß	NOUN	NN	Case=Acc|Gender=Masc|Number=Sing	26	obj	_	_
+26	verleihen	verleihen	VERB	VVINF	VerbForm=Inf	19	acl	_	_
+27	kann	können	AUX	VMFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	26	aux	_	SpaceAfter=No
+28	''	''	PUNCT	$(	_	30	punct	_	SpaceAfter=No
+29	,	,	PUNCT	$,	_	30	punct	_	_
+30	befürchtet	befürchten	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	0	root	_	_
+31	Werner	Werner	PROPN	NE	Case=Nom|Gender=Masc|Number=Sing	30	nsubj	_	_
+32	Becker	Becker	PROPN	NE	Case=Nom|Gender=Masc|Number=Sing	31	flat	_	SpaceAfter=No
+33	,	,	PUNCT	$,	_	30	punct	_	_
+34	HRK	HRK	PROPN	NN	Case=Nom|Gender=Masc|Number=Sing	36	compound	_	SpaceAfter=No
+35	-	-	PUNCT	$(	_	34	punct	_	SpaceAfter=No
+36	Informationsreferent	Informationsreferent	NOUN	NN	Case=Nom|Gender=Masc|Number=Sing	31	appos	_	SpaceAfter=No
+37	.	.	PUNCT	$.	_	30	punct	_	_
 
 # sent_id = dev-s706
-# text = Ich gebe Arbeit ab und bekomme dafür mehr Freizeit'', sagte Pastor Klaus Onnasch von der Christusgemeinde in Kronshagen bei Kiel.
-1	Ich	ich	PRON	PPER	Case=Nom|Gender=Masc|Number=Sing|Person=1|PronType=Prs	2	nsubj	_	_
-2	gebe	geben	VERB	VVFIN	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	12	ccomp	_	_
-3	Arbeit	Arbeit	NOUN	NN	Case=Acc|Gender=Fem|Number=Sing	2	obj	_	_
-4	ab	ab	ADP	PTKVZ	_	2	compound:prt	_	_
-5	und	und	CCONJ	KON	_	6	cc	_	_
-6	bekomme	bekommen	VERB	VVFIN	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	2	conj	_	_
-7	dafür	dafür	ADV	PAV	_	6	advmod	_	_
-8	mehr	mehr	PRON	PIAT	Definite=Ind|PronType=Ind	9	det	_	_
-9	Freizeit	Freizeit	NOUN	NN	Case=Acc|Gender=Fem|Number=Sing	6	obj	_	SpaceAfter=No
-10	''	''	PUNCT	$(	_	12	punct	_	SpaceAfter=No
-11	,	,	PUNCT	$,	_	12	punct	_	_
-12	sagte	sagen	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	0	root	_	_
-13	Pastor	Pastor	NOUN	NN	Case=Nom|Gender=Masc|Number=Sing	12	nsubj	_	_
-14	Klaus	Klaus	PROPN	NE	Case=Nom|Gender=Masc|Number=Sing	13	appos	_	_
-15	Onnasch	Onnasch	PROPN	NE	Case=Nom|Gender=Masc|Number=Sing	14	flat	_	_
-16	von	von	ADP	APPR	_	18	case	_	_
-17	der	der	DET	ART	Case=Dat|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	18	det	_	_
-18	Christusgemeinde	Christusgemeinde	PROPN	NN	Case=Dat|Gender=Fem|Number=Sing	13	nmod	_	_
-19	in	in	ADP	APPR	_	20	case	_	_
-20	Kronshagen	Kronshagen	PROPN	NE	Case=Dat|Gender=Neut|Number=Sing	18	nmod	_	_
-21	bei	bei	ADP	APPR	_	22	case	_	_
-22	Kiel	Kiel	PROPN	NE	Case=Dat|Gender=Neut|Number=Sing	20	nmod	_	SpaceAfter=No
-23	.	.	PUNCT	$.	_	12	punct	_	_
+# text = ``Ich gebe Arbeit ab und bekomme dafür mehr Freizeit'', sagte Pastor Klaus Onnasch von der Christusgemeinde in Kronshagen bei Kiel.
+1	``	``	PUNCT	$(	_	2	punct	_	FixTigerDep=Yes|SpaceAfter=No
+2	Ich	ich	PRON	PPER	Case=Nom|Gender=Masc|Number=Sing|Person=1|PronType=Prs	3	nsubj	_	_
+3	gebe	geben	VERB	VVFIN	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	13	ccomp	_	_
+4	Arbeit	Arbeit	NOUN	NN	Case=Acc|Gender=Fem|Number=Sing	3	obj	_	_
+5	ab	ab	ADP	PTKVZ	_	3	compound:prt	_	_
+6	und	und	CCONJ	KON	_	7	cc	_	_
+7	bekomme	bekommen	VERB	VVFIN	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	3	conj	_	_
+8	dafür	dafür	ADV	PAV	_	7	advmod	_	_
+9	mehr	mehr	PRON	PIAT	Definite=Ind|PronType=Ind	10	det	_	_
+10	Freizeit	Freizeit	NOUN	NN	Case=Acc|Gender=Fem|Number=Sing	7	obj	_	SpaceAfter=No
+11	''	''	PUNCT	$(	_	13	punct	_	SpaceAfter=No
+12	,	,	PUNCT	$,	_	13	punct	_	_
+13	sagte	sagen	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	0	root	_	_
+14	Pastor	Pastor	NOUN	NN	Case=Nom|Gender=Masc|Number=Sing	13	nsubj	_	_
+15	Klaus	Klaus	PROPN	NE	Case=Nom|Gender=Masc|Number=Sing	14	appos	_	_
+16	Onnasch	Onnasch	PROPN	NE	Case=Nom|Gender=Masc|Number=Sing	15	flat	_	_
+17	von	von	ADP	APPR	_	19	case	_	_
+18	der	der	DET	ART	Case=Dat|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	19	det	_	_
+19	Christusgemeinde	Christusgemeinde	PROPN	NN	Case=Dat|Gender=Fem|Number=Sing	14	nmod	_	_
+20	in	in	ADP	APPR	_	21	case	_	_
+21	Kronshagen	Kronshagen	PROPN	NE	Case=Dat|Gender=Neut|Number=Sing	19	nmod	_	_
+22	bei	bei	ADP	APPR	_	23	case	_	_
+23	Kiel	Kiel	PROPN	NE	Case=Dat|Gender=Neut|Number=Sing	21	nmod	_	SpaceAfter=No
+24	.	.	PUNCT	$.	_	13	punct	_	_
 
 # sent_id = dev-s707
-# text = Roman Herzog hat sich dafür ausgesprochen, die rund 40 000 Deutschstämmigen in der asiatischen Republik Usbekistan durch Hilfen zum Bleiben im Lande zu bewegen.
-1	Roman	Roman	PROPN	NE	Case=Nom|Gender=Masc|Number=Sing	6	nsubj	_	_
-2	Herzog	Herzog	PROPN	NE	Case=Nom|Gender=Masc|Number=Sing	1	flat	_	_
-3	hat	haben	AUX	VAFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	6	aux	_	_
-4	sich	er|es|sie	PRON	PRF	Case=Acc|Number=Sing|Person=3|PronType=Prs|Reflex=Yes	6	obj	_	_
-5	dafür	dafür	ADV	PAV	_	6	advmod	_	_
-6	ausgesprochen	aussprechen	VERB	VVPP	VerbForm=Part	0	root	_	SpaceAfter=No
-7	,	,	PUNCT	$,	_	6	punct	_	_
-8	die	der	DET	ART	Case=Acc|Definite=Def|Number=Plur|PronType=Art	12	det	_	_
-9	rund	rund	ADV	ADJD	_	10	advmod	_	_
-10	40	40	NUM	CARD	NumType=Card	11	nummod	_	_
-11	000	000	NUM	CARD	NumType=Card	12	nummod	_	_
-12	Deutschstämmigen	Deutschstämmige	NOUN	NN	Case=Acc|Gender=Fem|Number=Plur	27	obj	_	_
-13	in	in	ADP	APPR	_	16	case	_	_
-14	der	der	DET	ART	Case=Dat|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	16	det	_	_
-15	asiatischen	asiatisch	ADJ	ADJA	Case=Dat|Gender=Fem|Number=Sing	16	amod	_	_
-16	Republik	Republik	NOUN	NN	Case=Dat|Gender=Fem|Number=Sing	12	nmod	_	_
-17	Usbekistan	Usbekistan	PROPN	NE	Case=Nom|Gender=Neut|Number=Sing	16	flat	_	_
-18	durch	durch	ADP	APPR	_	19	case	_	_
-19	Hilfen	Hilfe	NOUN	NN	Case=Acc|Gender=Fem|Number=Plur	27	obl	_	_
-20-21	zum	_	_	_	_	_	_	_	_
-20	zu	zu	ADP	APPR	_	22	case	_	_
-21	dem	der	DET	ART	Case=Dat|Definite=Def|Gender=Neut|Number=Sing|PronType=Art	22	det	_	_
-22	Bleiben	Bleiben	NOUN	NN	Case=Dat|Gender=Neut|Number=Sing	27	obl	_	_
-23-24	im	_	_	_	_	_	_	_	_
-23	in	in	ADP	APPR	_	25	case	_	_
-24	dem	der	DET	ART	Case=Dat|Definite=Def|Gender=Neut|Number=Sing|PronType=Art	25	det	_	_
-25	Lande	Land	NOUN	NN	Case=Dat|Gender=Neut|Number=Sing	22	nmod	_	_
-26	zu	zu	PART	PTKZU	_	27	mark	_	_
-27	bewegen	bewegen	VERB	VVINF	VerbForm=Inf	6	xcomp	_	SpaceAfter=No
-28	.	.	PUNCT	$.	_	6	punct	_	_
+# text = Bundespräsident Roman Herzog hat sich dafür ausgesprochen, die rund 40 000 Deutschstämmigen in der asiatischen Republik Usbekistan durch Hilfen zum Bleiben im Lande zu bewegen.
+1	Bundespräsident	Bundespräsident	NOUN	NN	Case=Nom|Gender=Masc|Number=Sing	2	dep	_	FixTigerDep=Yes
+2	Roman	Roman	PROPN	NE	Case=Nom|Gender=Masc|Number=Sing	7	nsubj	_	_
+3	Herzog	Herzog	PROPN	NE	Case=Nom|Gender=Masc|Number=Sing	2	flat	_	_
+4	hat	haben	AUX	VAFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	7	aux	_	_
+5	sich	er|es|sie	PRON	PRF	Case=Acc|Number=Sing|Person=3|PronType=Prs|Reflex=Yes	7	obj	_	_
+6	dafür	dafür	ADV	PAV	_	7	advmod	_	_
+7	ausgesprochen	aussprechen	VERB	VVPP	VerbForm=Part	0	root	_	SpaceAfter=No
+8	,	,	PUNCT	$,	_	7	punct	_	_
+9	die	der	DET	ART	Case=Acc|Definite=Def|Number=Plur|PronType=Art	13	det	_	_
+10	rund	rund	ADV	ADJD	_	11	advmod	_	_
+11	40	40	NUM	CARD	NumType=Card	12	nummod	_	_
+12	000	000	NUM	CARD	NumType=Card	13	nummod	_	_
+13	Deutschstämmigen	Deutschstämmige	NOUN	NN	Case=Acc|Gender=Fem|Number=Plur	28	obj	_	_
+14	in	in	ADP	APPR	_	17	case	_	_
+15	der	der	DET	ART	Case=Dat|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	17	det	_	_
+16	asiatischen	asiatisch	ADJ	ADJA	Case=Dat|Gender=Fem|Number=Sing	17	amod	_	_
+17	Republik	Republik	NOUN	NN	Case=Dat|Gender=Fem|Number=Sing	13	nmod	_	_
+18	Usbekistan	Usbekistan	PROPN	NE	Case=Nom|Gender=Neut|Number=Sing	17	flat	_	_
+19	durch	durch	ADP	APPR	_	20	case	_	_
+20	Hilfen	Hilfe	NOUN	NN	Case=Acc|Gender=Fem|Number=Plur	28	obl	_	_
+21-22	zum	_	_	_	_	_	_	_	_
+21	zu	zu	ADP	APPR	_	23	case	_	_
+22	dem	der	DET	ART	Case=Dat|Definite=Def|Gender=Neut|Number=Sing|PronType=Art	23	det	_	_
+23	Bleiben	Bleiben	NOUN	NN	Case=Dat|Gender=Neut|Number=Sing	28	obl	_	_
+24-25	im	_	_	_	_	_	_	_	_
+24	in	in	ADP	APPR	_	26	case	_	_
+25	dem	der	DET	ART	Case=Dat|Definite=Def|Gender=Neut|Number=Sing|PronType=Art	26	det	_	_
+26	Lande	Land	NOUN	NN	Case=Dat|Gender=Neut|Number=Sing	23	nmod	_	_
+27	zu	zu	PART	PTKZU	_	28	mark	_	_
+28	bewegen	bewegen	VERB	VVINF	VerbForm=Inf	7	xcomp	_	SpaceAfter=No
+29	.	.	PUNCT	$.	_	7	punct	_	_
 
 # sent_id = dev-s708
-# text = Dazu will Haider eine politische Kulturrevolution, er ist gegen die Parteien, gegen die Sozialpartner.
-1	Dazu	dazu	ADV	PAV	_	2	advmod	_	_
-2	will	wollen	VERB	VMFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	0	root	_	_
-3	Haider	Haider	PROPN	NE	Case=Nom|Gender=Masc|Number=Sing	2	nsubj	_	_
-4	eine	ein	DET	ART	Case=Acc|Definite=Ind|Gender=Fem|Number=Sing|PronType=Art	6	det	_	_
-5	politische	politisch	ADJ	ADJA	Case=Acc|Gender=Fem|Number=Sing	6	amod	_	_
-6	Kulturrevolution	Kulturrevolution	NOUN	NN	Case=Acc|Gender=Fem|Number=Sing	2	obj	_	SpaceAfter=No
-7	,	,	PUNCT	$,	_	2	punct	_	_
-8	er	er	PRON	PPER	Case=Nom|Gender=Masc|Number=Sing|Person=3|PronType=Prs	9	nsubj	_	_
-9	ist	sein	VERB	VAFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	2	parataxis	_	_
-10	gegen	gegen	ADP	APPR	_	12	case	_	_
-11	die	der	DET	ART	Case=Acc|Definite=Def|Gender=Fem|Number=Plur|PronType=Art	12	det	_	_
-12	Parteien	Partei	NOUN	NN	Case=Acc|Gender=Fem|Number=Plur	9	obl	_	SpaceAfter=No
-13	,	,	PUNCT	$,	_	16	punct	_	_
-14	gegen	gegen	ADP	APPR	_	16	case	_	_
-15	die	der	DET	ART	Case=Acc|Definite=Def|Gender=Masc|Number=Plur|PronType=Art	16	det	_	_
-16	Sozialpartner	Sozialpartner	NOUN	NN	Case=Acc|Gender=Masc|Number=Plur	12	conj	_	SpaceAfter=No
-17	.	.	PUNCT	$.	_	2	punct	_	_
+# text = ``Dazu will Haider eine politische Kulturrevolution, er ist gegen die Parteien, gegen die Sozialpartner.
+1	``	``	PUNCT	$(	_	2	punct	_	FixTigerDep=Yes|SpaceAfter=No
+2	Dazu	dazu	ADV	PAV	_	3	advmod	_	_
+3	will	wollen	VERB	VMFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	0	root	_	_
+4	Haider	Haider	PROPN	NE	Case=Nom|Gender=Masc|Number=Sing	3	nsubj	_	_
+5	eine	ein	DET	ART	Case=Acc|Definite=Ind|Gender=Fem|Number=Sing|PronType=Art	7	det	_	_
+6	politische	politisch	ADJ	ADJA	Case=Acc|Gender=Fem|Number=Sing	7	amod	_	_
+7	Kulturrevolution	Kulturrevolution	NOUN	NN	Case=Acc|Gender=Fem|Number=Sing	3	obj	_	SpaceAfter=No
+8	,	,	PUNCT	$,	_	3	punct	_	_
+9	er	er	PRON	PPER	Case=Nom|Gender=Masc|Number=Sing|Person=3|PronType=Prs	10	nsubj	_	_
+10	ist	sein	VERB	VAFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	3	parataxis	_	_
+11	gegen	gegen	ADP	APPR	_	13	case	_	_
+12	die	der	DET	ART	Case=Acc|Definite=Def|Gender=Fem|Number=Plur|PronType=Art	13	det	_	_
+13	Parteien	Partei	NOUN	NN	Case=Acc|Gender=Fem|Number=Plur	10	obl	_	SpaceAfter=No
+14	,	,	PUNCT	$,	_	17	punct	_	_
+15	gegen	gegen	ADP	APPR	_	17	case	_	_
+16	die	der	DET	ART	Case=Acc|Definite=Def|Gender=Masc|Number=Plur|PronType=Art	17	det	_	_
+17	Sozialpartner	Sozialpartner	NOUN	NN	Case=Acc|Gender=Masc|Number=Plur	13	conj	_	SpaceAfter=No
+18	.	.	PUNCT	$.	_	3	punct	_	_
 
 # sent_id = dev-s709
-# text = Überzeugungsarbeit mußte Küng in Tutzing nicht mehr leisten.
-1	Überzeugungsarbeit	Überzeugungsarbeit	NOUN	NN	Case=Acc|Gender=Fem|Number=Sing	8	obj	_	_
-2	mußte	müssen	AUX	VMFIN	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	8	aux	_	_
-3	Küng	Küng	PROPN	NE	Case=Nom|Number=Sing	8	nsubj	_	_
-4	in	in	ADP	APPR	_	5	case	_	_
-5	Tutzing	Tutzing	PROPN	NE	Case=Dat|Gender=Neut|Number=Sing	8	obl	_	_
-6	nicht	nicht	PART	PTKNEG	Polarity=Neg	7	advmod	_	_
-7	mehr	mehr	ADV	ADV	_	8	advmod	_	_
-8	leisten	leisten	VERB	VVINF	VerbForm=Inf	0	root	_	SpaceAfter=No
-9	.	.	PUNCT	$.	_	8	punct	_	_
+# text = Viel Überzeugungsarbeit mußte Küng in Tutzing nicht mehr leisten.
+1	Viel	viel	DET	PIAT	Definite=Ind|PronType=Ind	2	dep	_	FixTigerDep=Yes
+2	Überzeugungsarbeit	Überzeugungsarbeit	NOUN	NN	Case=Acc|Gender=Fem|Number=Sing	9	obj	_	_
+3	mußte	müssen	AUX	VMFIN	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	9	aux	_	_
+4	Küng	Küng	PROPN	NE	Case=Nom|Number=Sing	9	nsubj	_	_
+5	in	in	ADP	APPR	_	6	case	_	_
+6	Tutzing	Tutzing	PROPN	NE	Case=Dat|Gender=Neut|Number=Sing	9	obl	_	_
+7	nicht	nicht	PART	PTKNEG	Polarity=Neg	8	advmod	_	_
+8	mehr	mehr	ADV	ADV	_	9	advmod	_	_
+9	leisten	leisten	VERB	VVINF	VerbForm=Inf	0	root	_	SpaceAfter=No
+10	.	.	PUNCT	$.	_	9	punct	_	_
 
 # sent_id = dev-s710
-# text = Peymann ist in blendender Verfassung und relativ guter Dinge, das jugendliche Lachen der frühen Zeit ist ihm während seines Wiener Jahrzehnts nicht vergangen.
-1	Peymann	Peymann	PROPN	NE	Case=Nom|Gender=Masc|Number=Sing	9	nsubj	_	_
-2	ist	sein	AUX	VAFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	9	cop	_	_
-3	in	in	ADP	APPR	_	5	case	_	_
-4	blendender	blendend	ADJ	ADJA	Case=Dat|Gender=Fem|Number=Sing	5	amod	_	_
-5	Verfassung	Verfassung	NOUN	NN	Case=Dat|Gender=Fem|Number=Sing	9	nmod	_	_
-6	und	und	CCONJ	KON	_	9	cc	_	_
-7	relativ	relativ	ADV	ADJD	_	8	advmod	_	_
-8	guter	gut	ADJ	ADJA	Case=Gen|Gender=Neut|Number=Plur	9	amod	_	_
-9	Dinge	Ding	NOUN	NN	Case=Gen|Gender=Neut|Number=Plur	0	root	_	SpaceAfter=No
-10	,	,	PUNCT	$,	_	9	punct	_	_
-11	das	der	DET	ART	Case=Nom|Definite=Def|Gender=Neut|Number=Sing|PronType=Art	13	det	_	_
-12	jugendliche	jugendlich	ADJ	ADJA	Case=Nom|Gender=Neut|Number=Sing	13	amod	_	_
-13	Lachen	Lachen	NOUN	NN	Case=Nom|Gender=Neut|Number=Sing	24	nsubj	_	_
-14	der	der	DET	ART	Case=Gen|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	16	det	_	_
-15	frühen	früh	ADJ	ADJA	Case=Gen|Gender=Fem|Number=Sing	16	amod	_	_
-16	Zeit	Zeit	NOUN	NN	Case=Gen|Gender=Fem|Number=Sing	13	nmod	_	_
-17	ist	sein	AUX	VAFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	24	aux	_	_
-18	ihm	er	PRON	PPER	Case=Dat|Gender=Masc|Number=Sing|Person=3|PronType=Prs	24	iobj	_	_
-19	während	während	ADP	APPR	_	22	case	_	_
-20	seines	sein	PRON	PPOSAT	Case=Gen|Gender=Neut|Number=Sing|Poss=Yes	22	det:poss	_	_
-21	Wiener	Wiener	ADJ	ADJA	_	22	amod	_	_
-22	Jahrzehnts	Jahrzehnt	NOUN	NN	Case=Gen|Gender=Neut|Number=Sing	24	obl	_	_
-23	nicht	nicht	PART	PTKNEG	Polarity=Neg	24	advmod	_	_
-24	vergangen	vergehen	VERB	VVPP	VerbForm=Part	9	parataxis	_	SpaceAfter=No
-25	.	.	PUNCT	$.	_	9	punct	_	_
+# text = Claus Peymann ist in blendender Verfassung und relativ guter Dinge, das jugendliche Lachen der frühen Zeit ist ihm während seines Wiener Jahrzehnts nicht vergangen.
+1	Claus	Claus	PROPN	NE	Case=Nom|Gender=Masc|Number=Sing	2	dep	_	FixTigerDep=Yes
+2	Peymann	Peymann	PROPN	NE	Case=Nom|Gender=Masc|Number=Sing	10	nsubj	_	_
+3	ist	sein	AUX	VAFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	10	cop	_	_
+4	in	in	ADP	APPR	_	6	case	_	_
+5	blendender	blendend	ADJ	ADJA	Case=Dat|Gender=Fem|Number=Sing	6	amod	_	_
+6	Verfassung	Verfassung	NOUN	NN	Case=Dat|Gender=Fem|Number=Sing	10	nmod	_	_
+7	und	und	CCONJ	KON	_	10	cc	_	_
+8	relativ	relativ	ADV	ADJD	_	9	advmod	_	_
+9	guter	gut	ADJ	ADJA	Case=Gen|Gender=Neut|Number=Plur	10	amod	_	_
+10	Dinge	Ding	NOUN	NN	Case=Gen|Gender=Neut|Number=Plur	0	root	_	SpaceAfter=No
+11	,	,	PUNCT	$,	_	10	punct	_	_
+12	das	der	DET	ART	Case=Nom|Definite=Def|Gender=Neut|Number=Sing|PronType=Art	14	det	_	_
+13	jugendliche	jugendlich	ADJ	ADJA	Case=Nom|Gender=Neut|Number=Sing	14	amod	_	_
+14	Lachen	Lachen	NOUN	NN	Case=Nom|Gender=Neut|Number=Sing	25	nsubj	_	_
+15	der	der	DET	ART	Case=Gen|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	17	det	_	_
+16	frühen	früh	ADJ	ADJA	Case=Gen|Gender=Fem|Number=Sing	17	amod	_	_
+17	Zeit	Zeit	NOUN	NN	Case=Gen|Gender=Fem|Number=Sing	14	nmod	_	_
+18	ist	sein	AUX	VAFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	25	aux	_	_
+19	ihm	er	PRON	PPER	Case=Dat|Gender=Masc|Number=Sing|Person=3|PronType=Prs	25	iobj	_	_
+20	während	während	ADP	APPR	_	23	case	_	_
+21	seines	sein	PRON	PPOSAT	Case=Gen|Gender=Neut|Number=Sing|Poss=Yes	23	det:poss	_	_
+22	Wiener	Wiener	ADJ	ADJA	_	23	amod	_	_
+23	Jahrzehnts	Jahrzehnt	NOUN	NN	Case=Gen|Gender=Neut|Number=Sing	25	obl	_	_
+24	nicht	nicht	PART	PTKNEG	Polarity=Neg	25	advmod	_	_
+25	vergangen	vergehen	VERB	VVPP	VerbForm=Part	10	parataxis	_	SpaceAfter=No
+26	.	.	PUNCT	$.	_	10	punct	_	_
 
 # sent_id = dev-s711
 # text = Melden Sie die Gäste an, sonst droht eine Geldstrafe.
@@ -13064,103 +13159,107 @@
 14	:	:	PUNCT	$.	_	7	punct	_	_
 
 # sent_id = dev-s713
-# text = Nationen des Wirtschaftsforums repräsentieren rund 56 Prozent der Weltproduktion und 46 Prozent des Handels auf dem Globus.
-1	Nationen	Nation	NOUN	NN	Case=Nom|Gender=Fem|Number=Plur	4	nsubj	_	_
-2	des	der	DET	ART	Case=Gen|Definite=Def|Gender=Neut|Number=Sing|PronType=Art	3	det	_	_
-3	Wirtschaftsforums	Wirtschaftsforum	NOUN	NN	Case=Gen|Gender=Neut|Number=Sing	1	nmod	_	_
-4	repräsentieren	repräsentieren	VERB	VVFIN	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	0	root	_	_
-5	rund	rund	ADV	ADJD	_	6	advmod	_	_
-6	56	56	NUM	CARD	NumType=Card	7	nummod	_	_
-7	Prozent	Prozent	NOUN	NN	Gender=Neut	4	obj	_	_
-8	der	der	DET	ART	Case=Gen|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	9	det	_	_
-9	Weltproduktion	Weltproduktion	NOUN	NN	Case=Gen|Gender=Fem|Number=Sing	7	nmod	_	_
-10	und	und	CCONJ	KON	_	12	cc	_	_
-11	46	46	NUM	CARD	NumType=Card	12	nummod	_	_
-12	Prozent	Prozent	NOUN	NN	Gender=Neut	7	conj	_	_
-13	des	der	DET	ART	Case=Gen|Definite=Def|Gender=Masc|Number=Sing|PronType=Art	14	det	_	_
-14	Handels	Handel	NOUN	NN	Case=Gen|Gender=Masc|Number=Sing	12	nmod	_	_
-15	auf	auf	ADP	APPR	_	17	case	_	_
-16	dem	der	DET	ART	Case=Dat|Definite=Def|Gender=Masc|Number=Sing|PronType=Art	17	det	_	_
-17	Globus	Globus	NOUN	NN	Case=Dat|Gender=Masc|Number=Sing	14	nmod	_	SpaceAfter=No
-18	.	.	PUNCT	$.	_	4	punct	_	_
+# text = Die Nationen des Wirtschaftsforums repräsentieren rund 56 Prozent der Weltproduktion und 46 Prozent des Handels auf dem Globus.
+1	Die	der	DET	ART	Case=Nom|Definite=Def|Gender=Fem|Number=Plur|PronType=Art	2	dep	_	FixTigerDep=Yes
+2	Nationen	Nation	NOUN	NN	Case=Nom|Gender=Fem|Number=Plur	5	nsubj	_	_
+3	des	der	DET	ART	Case=Gen|Definite=Def|Gender=Neut|Number=Sing|PronType=Art	4	det	_	_
+4	Wirtschaftsforums	Wirtschaftsforum	NOUN	NN	Case=Gen|Gender=Neut|Number=Sing	2	nmod	_	_
+5	repräsentieren	repräsentieren	VERB	VVFIN	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	0	root	_	_
+6	rund	rund	ADV	ADJD	_	7	advmod	_	_
+7	56	56	NUM	CARD	NumType=Card	8	nummod	_	_
+8	Prozent	Prozent	NOUN	NN	Gender=Neut	5	obj	_	_
+9	der	der	DET	ART	Case=Gen|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	10	det	_	_
+10	Weltproduktion	Weltproduktion	NOUN	NN	Case=Gen|Gender=Fem|Number=Sing	8	nmod	_	_
+11	und	und	CCONJ	KON	_	13	cc	_	_
+12	46	46	NUM	CARD	NumType=Card	13	nummod	_	_
+13	Prozent	Prozent	NOUN	NN	Gender=Neut	8	conj	_	_
+14	des	der	DET	ART	Case=Gen|Definite=Def|Gender=Masc|Number=Sing|PronType=Art	15	det	_	_
+15	Handels	Handel	NOUN	NN	Case=Gen|Gender=Masc|Number=Sing	13	nmod	_	_
+16	auf	auf	ADP	APPR	_	18	case	_	_
+17	dem	der	DET	ART	Case=Dat|Definite=Def|Gender=Masc|Number=Sing|PronType=Art	18	det	_	_
+18	Globus	Globus	NOUN	NN	Case=Dat|Gender=Masc|Number=Sing	15	nmod	_	SpaceAfter=No
+19	.	.	PUNCT	$.	_	5	punct	_	_
 
 # sent_id = dev-s714
-# text = Menschen könnten zum Beispiel während einer lauten Gesellschaft die Worte des Gesprächspartners nicht mehr von anderen Störgeräuschen unterscheiden und hörten nur noch ``Wortsalat''.
-1	Menschen	Mensch	NOUN	NN	Case=Nom|Gender=Masc|Number=Plur	19	nsubj	_	_
-2	könnten	können	AUX	VMFIN	Mood=Sub|Number=Plur|Person=3|Tense=Past|VerbForm=Fin	19	aux	_	_
-3-4	zum	_	_	_	_	_	_	_	_
-3	zu	zu	ADP	APPR	_	5	case	_	_
-4	dem	der	DET	ART	Case=Dat|Definite=Def|Gender=Neut|Number=Sing|PronType=Art	5	det	_	_
-5	Beispiel	Beispiel	NOUN	NN	Case=Dat|Gender=Neut|Number=Sing	19	obl	_	_
-6	während	während	ADP	APPR	_	9	case	_	_
-7	einer	ein	DET	ART	Case=Dat|Definite=Ind|Gender=Fem|Number=Sing|PronType=Art	9	det	_	_
-8	lauten	laut	ADJ	ADJA	Case=Dat|Gender=Fem|Number=Sing	9	amod	_	_
-9	Gesellschaft	Gesellschaft	NOUN	NN	Case=Dat|Gender=Fem|Number=Sing	19	obl	_	_
-10	die	der	DET	ART	Case=Acc|Definite=Def|Gender=Neut|Number=Plur|PronType=Art	11	det	_	_
-11	Worte	Wort	NOUN	NN	Case=Acc|Gender=Neut|Number=Plur	19	obj	_	_
-12	des	der	DET	ART	Case=Gen|Definite=Def|Gender=Masc|Number=Sing|PronType=Art	13	det	_	_
-13	Gesprächspartners	Gesprächspartner	NOUN	NN	Case=Gen|Gender=Masc|Number=Sing	11	nmod	_	_
-14	nicht	nicht	PART	PTKNEG	Polarity=Neg	15	advmod	_	_
-15	mehr	mehr	ADV	ADV	_	19	advmod	_	_
-16	von	von	ADP	APPR	_	18	case	_	_
-17	anderen	anderer	ADJ	ADJA	Case=Dat|Gender=Neut|Number=Plur	18	amod	_	_
-18	Störgeräuschen	Störgeräusch	NOUN	NN	Case=Dat|Gender=Neut|Number=Plur	19	obl	_	_
-19	unterscheiden	unterscheiden	VERB	VVINF	VerbForm=Inf	0	root	_	_
-20	und	und	CCONJ	KON	_	21	cc	_	_
-21	hörten	hören	VERB	VVFIN	Mood=Sub|Number=Plur|Person=3|Tense=Past|VerbForm=Fin	19	conj	_	_
-22	nur	nur	ADV	ADV	_	23	advmod	_	_
-23	noch	noch	ADV	ADV	_	21	advmod	_	_
-24	``	``	PUNCT	$(	_	25	punct	_	SpaceAfter=No
-25	Wortsalat	Wortsalat	NOUN	NN	Case=Acc|Gender=Masc|Number=Sing	21	obj	_	SpaceAfter=No
-26	''	''	PUNCT	$(	_	25	punct	_	SpaceAfter=No
-27	.	.	PUNCT	$.	_	19	punct	_	_
+# text = Diese Menschen könnten zum Beispiel während einer lauten Gesellschaft die Worte des Gesprächspartners nicht mehr von anderen Störgeräuschen unterscheiden und hörten nur noch ``Wortsalat''.
+1	Diese	dies	DET	PDAT	Case=Nom|Gender=Masc|Number=Plur|PronType=Dem	2	dep	_	FixTigerDep=Yes
+2	Menschen	Mensch	NOUN	NN	Case=Nom|Gender=Masc|Number=Plur	20	nsubj	_	_
+3	könnten	können	AUX	VMFIN	Mood=Sub|Number=Plur|Person=3|Tense=Past|VerbForm=Fin	20	aux	_	_
+4-5	zum	_	_	_	_	_	_	_	_
+4	zu	zu	ADP	APPR	_	6	case	_	_
+5	dem	der	DET	ART	Case=Dat|Definite=Def|Gender=Neut|Number=Sing|PronType=Art	6	det	_	_
+6	Beispiel	Beispiel	NOUN	NN	Case=Dat|Gender=Neut|Number=Sing	20	obl	_	_
+7	während	während	ADP	APPR	_	10	case	_	_
+8	einer	ein	DET	ART	Case=Dat|Definite=Ind|Gender=Fem|Number=Sing|PronType=Art	10	det	_	_
+9	lauten	laut	ADJ	ADJA	Case=Dat|Gender=Fem|Number=Sing	10	amod	_	_
+10	Gesellschaft	Gesellschaft	NOUN	NN	Case=Dat|Gender=Fem|Number=Sing	20	obl	_	_
+11	die	der	DET	ART	Case=Acc|Definite=Def|Gender=Neut|Number=Plur|PronType=Art	12	det	_	_
+12	Worte	Wort	NOUN	NN	Case=Acc|Gender=Neut|Number=Plur	20	obj	_	_
+13	des	der	DET	ART	Case=Gen|Definite=Def|Gender=Masc|Number=Sing|PronType=Art	14	det	_	_
+14	Gesprächspartners	Gesprächspartner	NOUN	NN	Case=Gen|Gender=Masc|Number=Sing	12	nmod	_	_
+15	nicht	nicht	PART	PTKNEG	Polarity=Neg	16	advmod	_	_
+16	mehr	mehr	ADV	ADV	_	20	advmod	_	_
+17	von	von	ADP	APPR	_	19	case	_	_
+18	anderen	anderer	ADJ	ADJA	Case=Dat|Gender=Neut|Number=Plur	19	amod	_	_
+19	Störgeräuschen	Störgeräusch	NOUN	NN	Case=Dat|Gender=Neut|Number=Plur	20	obl	_	_
+20	unterscheiden	unterscheiden	VERB	VVINF	VerbForm=Inf	0	root	_	_
+21	und	und	CCONJ	KON	_	22	cc	_	_
+22	hörten	hören	VERB	VVFIN	Mood=Sub|Number=Plur|Person=3|Tense=Past|VerbForm=Fin	20	conj	_	_
+23	nur	nur	ADV	ADV	_	24	advmod	_	_
+24	noch	noch	ADV	ADV	_	22	advmod	_	_
+25	``	``	PUNCT	$(	_	26	punct	_	SpaceAfter=No
+26	Wortsalat	Wortsalat	NOUN	NN	Case=Acc|Gender=Masc|Number=Sing	22	obj	_	SpaceAfter=No
+27	''	''	PUNCT	$(	_	26	punct	_	SpaceAfter=No
+28	.	.	PUNCT	$.	_	20	punct	_	_
 
 # sent_id = dev-s715
-# text = 2000 Stellen werden bis Ende kommenden Jahres gestrichen.
-1	2000	2000	NUM	CARD	NumType=Card	2	nummod	_	_
-2	Stellen	Stelle	NOUN	NN	Case=Nom|Gender=Fem|Number=Plur	8	nsubj:pass	_	_
-3	werden	werden	AUX	VAFIN	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin|Voice=Pass	8	aux:pass	_	_
-4	bis	bis	ADP	APPR	_	7	case	_	_
-5	Ende	Ende	NOUN	NN	Case=Dat|Gender=Neut|Number=Sing	7	compound	_	_
-6	kommenden	kommend	ADJ	ADJA	Case=Gen|Gender=Neut|Number=Sing	7	amod	_	_
-7	Jahres	Jahr	NOUN	NN	Case=Gen|Gender=Neut|Number=Sing	8	obl	_	_
-8	gestrichen	streichen	VERB	VVPP	VerbForm=Part	0	root	_	SpaceAfter=No
-9	.	.	PUNCT	$.	_	8	punct	_	_
+# text = Rund 2000 Stellen werden bis Ende kommenden Jahres gestrichen.
+1	Rund	rund	ADJ	ADJD	_	2	dep	_	FixTigerDep=Yes
+2	2000	2000	NUM	CARD	NumType=Card	3	nummod	_	_
+3	Stellen	Stelle	NOUN	NN	Case=Nom|Gender=Fem|Number=Plur	9	nsubj:pass	_	_
+4	werden	werden	AUX	VAFIN	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin|Voice=Pass	9	aux:pass	_	_
+5	bis	bis	ADP	APPR	_	8	case	_	_
+6	Ende	Ende	NOUN	NN	Case=Dat|Gender=Neut|Number=Sing	8	compound	_	_
+7	kommenden	kommend	ADJ	ADJA	Case=Gen|Gender=Neut|Number=Sing	8	amod	_	_
+8	Jahres	Jahr	NOUN	NN	Case=Gen|Gender=Neut|Number=Sing	9	obl	_	_
+9	gestrichen	streichen	VERB	VVPP	VerbForm=Part	0	root	_	SpaceAfter=No
+10	.	.	PUNCT	$.	_	9	punct	_	_
 
 # sent_id = dev-s716
-# text = Braune verhängte sechs Jahre Gefängnis wegen ``planmäßiger Staatshetze'' gegen den Familienvater, obwohl die Tat verjährt war und die Schrift überhaupt nicht verbreitet, sondern zu Hause aufbewahrt wurde.
-1	Braune	braun	PROPN	NE	Case=Nom|Gender=Masc|Number=Sing	2	nsubj	_	_
-2	verhängte	verhängen	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	0	root	_	_
-3	sechs	sechs	NUM	CARD	NumType=Card	4	nummod	_	_
-4	Jahre	Jahr	NOUN	NN	Case=Acc|Gender=Neut|Number=Plur	5	nmod	_	_
-5	Gefängnis	Gefängnis	NOUN	NN	Case=Nom|Gender=Neut|Number=Sing	2	obj	_	_
-6	wegen	wegen	ADP	APPR	_	9	case	_	_
-7	``	``	PUNCT	$(	_	9	punct	_	SpaceAfter=No
-8	planmäßiger	planmäßig	ADJ	ADJA	Gender=Fem|Number=Sing	9	amod	_	_
-9	Staatshetze	Staatshetze	NOUN	NN	Gender=Fem|Number=Sing	2	obl	_	SpaceAfter=No
-10	''	''	PUNCT	$(	_	9	punct	_	_
-11	gegen	gegen	ADP	APPR	_	13	case	_	_
-12	den	der	DET	ART	Case=Acc|Definite=Def|Gender=Masc|Number=Sing|PronType=Art	13	det	_	_
-13	Familienvater	Familienvater	NOUN	NN	Case=Acc|Gender=Masc|Number=Sing	2	obl	_	SpaceAfter=No
-14	,	,	PUNCT	$,	_	2	punct	_	_
-15	obwohl	obwohl	SCONJ	KOUS	_	18	mark	_	_
-16	die	der	DET	ART	Case=Nom|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	17	det	_	_
-17	Tat	Tat	NOUN	NN	Case=Nom|Gender=Fem|Number=Sing	18	nsubj	_	_
-18	verjährt	verjähren	ADJ	VVPP	VerbForm=Part	2	advcl	_	_
-19	war	sein	AUX	VAFIN	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	18	cop	_	_
-20	und	und	CCONJ	KON	_	25	cc	_	_
-21	die	der	DET	ART	Case=Nom|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	22	det	_	_
-22	Schrift	Schrift	NOUN	NN	Case=Nom|Gender=Fem|Number=Sing	25	nsubj:pass	_	_
-23	überhaupt	überhaupt	ADV	ADV	_	24	advmod	_	_
-24	nicht	nicht	PART	PTKNEG	Polarity=Neg	25	advmod	_	_
-25	verbreitet	verbreiten	VERB	VVPP	VerbForm=Part	18	conj	_	SpaceAfter=No
-26	,	,	PUNCT	$,	_	2	punct	_	_
-27	sondern	sondern	CCONJ	KON	_	30	cc	_	_
-28	zu	zu	ADP	APPR	_	29	case	_	_
-29	Hause	Haus	NOUN	NN	Case=Dat|Gender=Neut|Number=Sing	30	obl	_	_
-30	aufbewahrt	aufbewahren	VERB	VVPP	VerbForm=Part	25	conj	_	_
-31	wurde	werden	AUX	VAFIN	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin|Voice=Pass	25	aux:pass	_	SpaceAfter=No
-32	.	.	PUNCT	$.	_	2	punct	_	_
+# text = Strafrichter Braune verhängte sechs Jahre Gefängnis wegen ``planmäßiger Staatshetze'' gegen den Familienvater, obwohl die Tat verjährt war und die Schrift überhaupt nicht verbreitet, sondern zu Hause aufbewahrt wurde.
+1	Strafrichter	Strafrichter	NOUN	NN	Case=Nom|Gender=Masc|Number=Sing	2	dep	_	FixTigerDep=Yes
+2	Braune	Braune	PROPN	NE	Case=Nom|Gender=Masc|Number=Sing	3	nsubj	_	_
+3	verhängte	verhängen	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	0	root	_	_
+4	sechs	sechs	NUM	CARD	NumType=Card	5	nummod	_	_
+5	Jahre	Jahr	NOUN	NN	Case=Acc|Gender=Neut|Number=Plur	6	nmod	_	_
+6	Gefängnis	Gefängnis	NOUN	NN	Case=Nom|Gender=Neut|Number=Sing	3	obj	_	_
+7	wegen	wegen	ADP	APPR	_	10	case	_	_
+8	``	``	PUNCT	$(	_	10	punct	_	SpaceAfter=No
+9	planmäßiger	planmäßig	ADJ	ADJA	Gender=Fem|Number=Sing	10	amod	_	_
+10	Staatshetze	Staatshetze	NOUN	NN	Gender=Fem|Number=Sing	3	obl	_	SpaceAfter=No
+11	''	''	PUNCT	$(	_	10	punct	_	_
+12	gegen	gegen	ADP	APPR	_	14	case	_	_
+13	den	der	DET	ART	Case=Acc|Definite=Def|Gender=Masc|Number=Sing|PronType=Art	14	det	_	_
+14	Familienvater	Familienvater	NOUN	NN	Case=Acc|Gender=Masc|Number=Sing	3	obl	_	SpaceAfter=No
+15	,	,	PUNCT	$,	_	3	punct	_	_
+16	obwohl	obwohl	SCONJ	KOUS	_	19	mark	_	_
+17	die	der	DET	ART	Case=Nom|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	18	det	_	_
+18	Tat	Tat	NOUN	NN	Case=Nom|Gender=Fem|Number=Sing	19	nsubj	_	_
+19	verjährt	verjähren	ADJ	VVPP	VerbForm=Part	3	advcl	_	_
+20	war	sein	AUX	VAFIN	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	19	cop	_	_
+21	und	und	CCONJ	KON	_	26	cc	_	_
+22	die	der	DET	ART	Case=Nom|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	23	det	_	_
+23	Schrift	Schrift	NOUN	NN	Case=Nom|Gender=Fem|Number=Sing	26	nsubj:pass	_	_
+24	überhaupt	überhaupt	ADV	ADV	_	25	advmod	_	_
+25	nicht	nicht	PART	PTKNEG	Polarity=Neg	26	advmod	_	_
+26	verbreitet	verbreiten	VERB	VVPP	VerbForm=Part	19	conj	_	SpaceAfter=No
+27	,	,	PUNCT	$,	_	3	punct	_	_
+28	sondern	sondern	CCONJ	KON	_	31	cc	_	_
+29	zu	zu	ADP	APPR	_	30	case	_	_
+30	Hause	Haus	NOUN	NN	Case=Dat|Gender=Neut|Number=Sing	31	obl	_	_
+31	aufbewahrt	aufbewahren	VERB	VVPP	VerbForm=Part	26	conj	_	_
+32	wurde	werden	AUX	VAFIN	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin|Voice=Pass	26	aux:pass	_	SpaceAfter=No
+33	.	.	PUNCT	$.	_	3	punct	_	_
 
 # sent_id = dev-s717
 # text = Ich habe heute morgen Oskar gefragt, ob er bereit ist zu kandidieren.
@@ -13180,75 +13279,79 @@
 14	.	.	PUNCT	$.	_	6	punct	_	_
 
 # sent_id = dev-s718
-# text = Beifall für diesen spontanen Ausspruch blieb mager.
-1	Beifall	Beifall	NOUN	NN	Case=Nom|Gender=Masc|Number=Sing	6	nsubj	_	_
-2	für	für	ADP	APPR	_	5	case	_	_
-3	diesen	dies	PRON	PDAT	Case=Acc|Gender=Masc|Number=Sing|PronType=Dem	5	det	_	_
-4	spontanen	spontan	ADJ	ADJA	Case=Acc|Gender=Masc|Number=Sing	5	amod	_	_
-5	Ausspruch	Ausspruch	NOUN	NN	Case=Acc|Gender=Masc|Number=Sing	6	obl	_	_
-6	blieb	bleiben	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	0	root	_	_
-7	mager	mager	ADJ	ADJD	_	6	xcomp	_	SpaceAfter=No
-8	.	.	PUNCT	$.	_	6	punct	_	_
+# text = Der Beifall für diesen spontanen Ausspruch blieb mager.
+1	Der	der	DET	ART	Case=Nom|Definite=Def|Gender=Masc|Number=Sing|PronType=Art	2	dep	_	FixTigerDep=Yes
+2	Beifall	Beifall	NOUN	NN	Case=Nom|Gender=Masc|Number=Sing	7	nsubj	_	_
+3	für	für	ADP	APPR	_	6	case	_	_
+4	diesen	dies	PRON	PDAT	Case=Acc|Gender=Masc|Number=Sing|PronType=Dem	6	det	_	_
+5	spontanen	spontan	ADJ	ADJA	Case=Acc|Gender=Masc|Number=Sing	6	amod	_	_
+6	Ausspruch	Ausspruch	NOUN	NN	Case=Acc|Gender=Masc|Number=Sing	7	obl	_	_
+7	blieb	bleiben	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	0	root	_	_
+8	mager	mager	ADJ	ADJD	_	7	xcomp	_	SpaceAfter=No
+9	.	.	PUNCT	$.	_	7	punct	_	_
 
 # sent_id = dev-s719
-# text = Wir prüfen das.
-1	Wir	wir	PRON	PPER	Case=Nom|Number=Plur|Person=1|PronType=Prs	2	nsubj	_	_
-2	prüfen	prüfen	VERB	VVFIN	Mood=Ind|Number=Plur|Person=1|Tense=Pres|VerbForm=Fin	0	root	_	_
-3	das	der	PRON	PDS	Case=Acc|Gender=Neut|Number=Sing|PronType=Dem	2	obj	_	SpaceAfter=No
-4	.	.	PUNCT	$.	_	2	punct	_	_
+# text = ``Wir prüfen das.
+1	``	``	PUNCT	$(	_	2	punct	_	FixTigerDep=Yes|SpaceAfter=No
+2	Wir	wir	PRON	PPER	Case=Nom|Number=Plur|Person=1|PronType=Prs	3	nsubj	_	_
+3	prüfen	prüfen	VERB	VVFIN	Mood=Ind|Number=Plur|Person=1|Tense=Pres|VerbForm=Fin	0	root	_	_
+4	das	der	PRON	PDS	Case=Acc|Gender=Neut|Number=Sing|PronType=Dem	3	obj	_	SpaceAfter=No
+5	.	.	PUNCT	$.	_	3	punct	_	_
 
 # sent_id = dev-s720
-# text = Ich bin wählen gegangen, weil die jetzige Situation nicht weiter andauern kann'', meinte in der Stadt Ouargla ein anderer.
-1	Ich	ich	PRON	PPER	Case=Nom|Gender=Masc|Number=Sing|Person=1|PronType=Prs	4	nsubj	_	_
-2	bin	sein	AUX	VAFIN	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	4	aux	_	_
-3	wählen	wählen	VERB	VVINF	VerbForm=Inf	4	acl	_	_
-4	gegangen	gehen	VERB	VVPP	VerbForm=Part	16	ccomp	_	SpaceAfter=No
-5	,	,	PUNCT	$,	_	16	punct	_	_
-6	weil	weil	SCONJ	KOUS	_	12	mark	_	_
-7	die	der	DET	ART	Case=Nom|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	9	det	_	_
-8	jetzige	jetzig	ADJ	ADJA	Case=Nom|Gender=Fem|Number=Sing	9	amod	_	_
-9	Situation	Situation	NOUN	NN	Case=Nom|Gender=Fem|Number=Sing	12	nsubj	_	_
-10	nicht	nicht	PART	PTKNEG	Polarity=Neg	11	advmod	_	_
-11	weiter	weiter	ADV	ADV	_	12	advmod	_	_
-12	andauern	andauern	VERB	VVINF	VerbForm=Inf	4	advcl	_	_
-13	kann	können	AUX	VMFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	12	aux	_	SpaceAfter=No
-14	''	''	PUNCT	$(	_	16	punct	_	SpaceAfter=No
-15	,	,	PUNCT	$,	_	16	punct	_	_
-16	meinte	meinen	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	0	root	_	_
-17	in	in	ADP	APPR	_	19	case	_	_
-18	der	der	DET	ART	Case=Dat|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	19	det	_	_
-19	Stadt	Stadt	NOUN	NN	Case=Dat|Gender=Fem|Number=Sing	16	obl	_	_
-20	Ouargla	Ouargla	PROPN	NE	Case=Nom|Gender=Neut|Number=Sing	19	appos	_	_
-21	ein	ein	DET	ART	Case=Nom|Definite=Ind|Gender=Masc|Number=Sing|PronType=Art	22	det	_	_
-22	anderer	ander	PRON	PIS	Case=Nom|Definite=Ind|Gender=Masc|Number=Sing|PronType=Ind	16	nsubj	_	SpaceAfter=No
-23	.	.	PUNCT	$.	_	16	punct	_	_
+# text = ``Ich bin wählen gegangen, weil die jetzige Situation nicht weiter andauern kann'', meinte in der Stadt Ouargla ein anderer.
+1	``	``	PUNCT	$(	_	2	punct	_	FixTigerDep=Yes|SpaceAfter=No
+2	Ich	ich	PRON	PPER	Case=Nom|Gender=Masc|Number=Sing|Person=1|PronType=Prs	5	nsubj	_	_
+3	bin	sein	AUX	VAFIN	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	5	aux	_	_
+4	wählen	wählen	VERB	VVINF	VerbForm=Inf	5	acl	_	_
+5	gegangen	gehen	VERB	VVPP	VerbForm=Part	17	ccomp	_	SpaceAfter=No
+6	,	,	PUNCT	$,	_	17	punct	_	_
+7	weil	weil	SCONJ	KOUS	_	13	mark	_	_
+8	die	der	DET	ART	Case=Nom|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	10	det	_	_
+9	jetzige	jetzig	ADJ	ADJA	Case=Nom|Gender=Fem|Number=Sing	10	amod	_	_
+10	Situation	Situation	NOUN	NN	Case=Nom|Gender=Fem|Number=Sing	13	nsubj	_	_
+11	nicht	nicht	PART	PTKNEG	Polarity=Neg	12	advmod	_	_
+12	weiter	weiter	ADV	ADV	_	13	advmod	_	_
+13	andauern	andauern	VERB	VVINF	VerbForm=Inf	5	advcl	_	_
+14	kann	können	AUX	VMFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	13	aux	_	SpaceAfter=No
+15	''	''	PUNCT	$(	_	17	punct	_	SpaceAfter=No
+16	,	,	PUNCT	$,	_	17	punct	_	_
+17	meinte	meinen	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	0	root	_	_
+18	in	in	ADP	APPR	_	20	case	_	_
+19	der	der	DET	ART	Case=Dat|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	20	det	_	_
+20	Stadt	Stadt	NOUN	NN	Case=Dat|Gender=Fem|Number=Sing	17	obl	_	_
+21	Ouargla	Ouargla	PROPN	NE	Case=Nom|Gender=Neut|Number=Sing	20	appos	_	_
+22	ein	ein	DET	ART	Case=Nom|Definite=Ind|Gender=Masc|Number=Sing|PronType=Art	23	det	_	_
+23	anderer	ander	PRON	PIS	Case=Nom|Definite=Ind|Gender=Masc|Number=Sing|PronType=Ind	17	nsubj	_	SpaceAfter=No
+24	.	.	PUNCT	$.	_	17	punct	_	_
 
 # sent_id = dev-s721
-# text = Blöcke mit den Köpfen von Karl Marx, Ernst Thälmann und August Bebel und etlichen anderen bekommt man heute nicht unter 300 Mark.
-1	Blöcke	Block	NOUN	NN	Case=Nom|Gender=Masc|Number=Plur	17	obj	_	_
-2	mit	mit	ADP	APPR	_	4	case	_	_
-3	den	der	DET	ART	Case=Dat|Definite=Def|Gender=Masc|Number=Plur|PronType=Art	4	det	_	_
-4	Köpfen	Kopf	NOUN	NN	Case=Dat|Gender=Masc|Number=Plur	1	nmod	_	_
-5	von	von	ADP	APPR	_	6	case	_	_
-6	Karl	Karl	PROPN	NE	Case=Nom|Gender=Masc|Number=Sing	4	nmod	_	_
-7	Marx	Marx	PROPN	NE	Case=Dat|Gender=Masc|Number=Sing	6	flat	_	SpaceAfter=No
-8	,	,	PUNCT	$,	_	9	punct	_	_
-9	Ernst	Ernst	PROPN	NE	Case=Nom|Gender=Masc|Number=Sing	6	conj	_	_
-10	Thälmann	Thälmann	PROPN	NE	Case=Dat|Gender=Masc|Number=Sing	9	flat	_	_
-11	und	und	CCONJ	KON	_	12	cc	_	_
-12	August	August	PROPN	NE	Case=Nom|Gender=Masc|Number=Sing	6	conj	_	_
-13	Bebel	Bebel	PROPN	NE	Case=Dat|Gender=Masc|Number=Sing	12	flat	_	_
-14	und	und	CCONJ	KON	_	16	cc	_	_
-15	etlichen	etlich	PRON	ADJA	Case=Dat|Number=Plur	16	det	_	_
-16	anderen	ander	PRON	PIS	Case=Dat|Definite=Ind|Number=Plur|PronType=Ind	6	conj	_	_
-17	bekommt	bekommen	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	0	root	_	_
-18	man	man	PRON	PIS	Case=Nom|Definite=Ind|Number=Sing|PronType=Ind	17	nsubj	_	_
-19	heute	heute	ADV	ADV	_	17	advmod	_	_
-20	nicht	nicht	ADV	PTKNEG	Polarity=Neg	23	advmod	_	_
-21	unter	unter	ADP	APPR	_	23	case	_	_
-22	300	300	NUM	CARD	NumType=Card	23	nummod	_	_
-23	Mark	Mark	PROPN	NN	Gender=Fem	17	obl	_	SpaceAfter=No
-24	.	.	PUNCT	$.	_	17	punct	_	_
+# text = Einige Blöcke mit den Köpfen von Karl Marx, Ernst Thälmann und August Bebel und etlichen anderen bekommt man heute nicht unter 300 Mark.
+1	Einige	einiger	DET	PIAT	Case=Nom|Definite=Ind|Gender=Masc|Number=Plur|PronType=Ind	2	dep	_	FixTigerDep=Yes
+2	Blöcke	Block	NOUN	NN	Case=Nom|Gender=Masc|Number=Plur	18	obj	_	_
+3	mit	mit	ADP	APPR	_	5	case	_	_
+4	den	der	DET	ART	Case=Dat|Definite=Def|Gender=Masc|Number=Plur|PronType=Art	5	det	_	_
+5	Köpfen	Kopf	NOUN	NN	Case=Dat|Gender=Masc|Number=Plur	2	nmod	_	_
+6	von	von	ADP	APPR	_	7	case	_	_
+7	Karl	Karl	PROPN	NE	Case=Nom|Gender=Masc|Number=Sing	5	nmod	_	_
+8	Marx	Marx	PROPN	NE	Case=Dat|Gender=Masc|Number=Sing	7	flat	_	SpaceAfter=No
+9	,	,	PUNCT	$,	_	10	punct	_	_
+10	Ernst	Ernst	PROPN	NE	Case=Nom|Gender=Masc|Number=Sing	7	conj	_	_
+11	Thälmann	Thälmann	PROPN	NE	Case=Dat|Gender=Masc|Number=Sing	10	flat	_	_
+12	und	und	CCONJ	KON	_	13	cc	_	_
+13	August	August	PROPN	NE	Case=Nom|Gender=Masc|Number=Sing	7	conj	_	_
+14	Bebel	Bebel	PROPN	NE	Case=Dat|Gender=Masc|Number=Sing	13	flat	_	_
+15	und	und	CCONJ	KON	_	17	cc	_	_
+16	etlichen	etlich	PRON	ADJA	Case=Dat|Number=Plur	17	det	_	_
+17	anderen	ander	PRON	PIS	Case=Dat|Definite=Ind|Number=Plur|PronType=Ind	7	conj	_	_
+18	bekommt	bekommen	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	0	root	_	_
+19	man	man	PRON	PIS	Case=Nom|Definite=Ind|Number=Sing|PronType=Ind	18	nsubj	_	_
+20	heute	heute	ADV	ADV	_	18	advmod	_	_
+21	nicht	nicht	ADV	PTKNEG	Polarity=Neg	24	advmod	_	_
+22	unter	unter	ADP	APPR	_	24	case	_	_
+23	300	300	NUM	CARD	NumType=Card	24	nummod	_	_
+24	Mark	Mark	PROPN	NN	Gender=Fem	18	obl	_	SpaceAfter=No
+25	.	.	PUNCT	$.	_	18	punct	_	_
 
 # sent_id = dev-s722
 # text = Man vermutet, daß es dort noch eine Population gibt.
@@ -13290,60 +13393,63 @@
 22	.	.	PUNCT	$.	_	18	punct	_	_
 
 # sent_id = dev-s724
-# text = Dafür steht die Firma Syncronys gerade, und wir werden auch die Kosten übernehmen'', so Poertner.
-1	Dafür	dafür	ADV	PAV	_	2	advmod	_	_
-2	steht	stehen	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	0	root	_	_
-3	die	der	DET	ART	Case=Nom|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	4	det	_	_
-4	Firma	Firma	NOUN	NN	Case=Nom|Gender=Fem|Number=Sing	2	nsubj	_	_
-5	Syncronys	Syncronys	PROPN	NE	Case=Nom|Number=Sing	4	appos	_	_
-6	gerade	gerade	ADV	PTKVZ	_	2	compound:prt	_	SpaceAfter=No
-7	,	,	PUNCT	$,	_	14	punct	_	_
-8	und	und	CCONJ	KON	_	14	cc	_	_
-9	wir	wir	PRON	PPER	Case=Nom|Number=Plur|Person=1|PronType=Prs	14	nsubj	_	_
-10	werden	werden	AUX	VAFIN	Mood=Ind|Number=Plur|Person=1|Tense=Pres|VerbForm=Fin	14	aux	_	_
-11	auch	auch	ADV	ADV	_	14	advmod	_	_
-12	die	der	DET	ART	Case=Acc|Definite=Def|Number=Plur|PronType=Art	13	det	_	_
-13	Kosten	Kosten	NOUN	NN	Case=Acc|Number=Plur	14	obj	_	_
-14	übernehmen	übernehmen	VERB	VVINF	VerbForm=Inf	2	conj	_	SpaceAfter=No
-15	''	''	PUNCT	$(	_	2	punct	_	SpaceAfter=No
-16	,	,	PUNCT	$,	_	2	punct	_	_
-17	so	so	ADV	ADV	_	18	advmod	_	_
-18	Poertner	Poertner	PROPN	NE	Case=Nom|Number=Sing	2	appos	_	SpaceAfter=No
-19	.	.	PUNCT	$.	_	2	punct	_	_
+# text = ``Dafür steht die Firma Syncronys gerade, und wir werden auch die Kosten übernehmen'', so Poertner.
+1	``	``	PUNCT	$(	_	2	punct	_	FixTigerDep=Yes|SpaceAfter=No
+2	Dafür	dafür	ADV	PAV	_	3	advmod	_	_
+3	steht	stehen	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	0	root	_	_
+4	die	der	DET	ART	Case=Nom|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	5	det	_	_
+5	Firma	Firma	NOUN	NN	Case=Nom|Gender=Fem|Number=Sing	3	nsubj	_	_
+6	Syncronys	Syncronys	PROPN	NE	Case=Nom|Number=Sing	5	appos	_	_
+7	gerade	gerade	ADV	PTKVZ	_	3	compound:prt	_	SpaceAfter=No
+8	,	,	PUNCT	$,	_	15	punct	_	_
+9	und	und	CCONJ	KON	_	15	cc	_	_
+10	wir	wir	PRON	PPER	Case=Nom|Number=Plur|Person=1|PronType=Prs	15	nsubj	_	_
+11	werden	werden	AUX	VAFIN	Mood=Ind|Number=Plur|Person=1|Tense=Pres|VerbForm=Fin	15	aux	_	_
+12	auch	auch	ADV	ADV	_	15	advmod	_	_
+13	die	der	DET	ART	Case=Acc|Definite=Def|Number=Plur|PronType=Art	14	det	_	_
+14	Kosten	Kosten	NOUN	NN	Case=Acc|Number=Plur	15	obj	_	_
+15	übernehmen	übernehmen	VERB	VVINF	VerbForm=Inf	3	conj	_	SpaceAfter=No
+16	''	''	PUNCT	$(	_	3	punct	_	SpaceAfter=No
+17	,	,	PUNCT	$,	_	3	punct	_	_
+18	so	so	ADV	ADV	_	19	advmod	_	_
+19	Poertner	Poertner	PROPN	NE	Case=Nom|Number=Sing	3	appos	_	SpaceAfter=No
+20	.	.	PUNCT	$.	_	3	punct	_	_
 
 # sent_id = dev-s725
-# text = Das Ergebnis hat uns ermutigt'', berichtet Nitz.
-1	Das	der	DET	ART	Case=Nom|Definite=Def|Gender=Neut|Number=Sing|PronType=Art	2	det	_	_
-2	Ergebnis	Ergebnis	NOUN	NN	Case=Nom|Gender=Neut|Number=Sing	5	nsubj	_	_
-3	hat	haben	AUX	VAFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	5	aux	_	_
-4	uns	wir	PRON	PPER	Case=Acc|Number=Plur|Person=1|PronType=Prs	5	obj	_	_
-5	ermutigt	ermutigen	VERB	VVPP	VerbForm=Part	8	ccomp	_	SpaceAfter=No
-6	''	''	PUNCT	$(	_	8	punct	_	SpaceAfter=No
-7	,	,	PUNCT	$,	_	8	punct	_	_
-8	berichtet	berichten	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	0	root	_	_
-9	Nitz	Nitz	PROPN	NE	Case=Nom|Number=Sing	8	nsubj	_	SpaceAfter=No
-10	.	.	PUNCT	$.	_	8	punct	_	_
+# text = ``Das Ergebnis hat uns ermutigt'', berichtet Nitz.
+1	``	``	PUNCT	$(	_	2	punct	_	FixTigerDep=Yes|SpaceAfter=No
+2	Das	der	DET	ART	Case=Nom|Definite=Def|Gender=Neut|Number=Sing|PronType=Art	3	det	_	_
+3	Ergebnis	Ergebnis	NOUN	NN	Case=Nom|Gender=Neut|Number=Sing	6	nsubj	_	_
+4	hat	haben	AUX	VAFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	6	aux	_	_
+5	uns	wir	PRON	PPER	Case=Acc|Number=Plur|Person=1|PronType=Prs	6	obj	_	_
+6	ermutigt	ermutigen	VERB	VVPP	VerbForm=Part	9	ccomp	_	SpaceAfter=No
+7	''	''	PUNCT	$(	_	9	punct	_	SpaceAfter=No
+8	,	,	PUNCT	$,	_	9	punct	_	_
+9	berichtet	berichten	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	0	root	_	_
+10	Nitz	Nitz	PROPN	NE	Case=Nom|Number=Sing	9	nsubj	_	SpaceAfter=No
+11	.	.	PUNCT	$.	_	9	punct	_	_
 
 # sent_id = dev-s726
-# text = Doch nicht die Kinder verdienen daran, sondern Hotels, Vermittler, Bordellbetreiber'', sagt Felizardo.
-1	Doch	doch	CCONJ	KON	_	5	cc	_	_
-2	nicht	nicht	PART	PTKNEG	Polarity=Neg	4	advmod	_	_
-3	die	der	DET	ART	Case=Nom|Definite=Def|Gender=Neut|Number=Plur|PronType=Art	4	det	_	_
-4	Kinder	Kind	NOUN	NN	Case=Nom|Gender=Neut|Number=Plur	5	nsubj	_	_
-5	verdienen	verdienen	VERB	VVFIN	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	16	ccomp	_	_
-6	daran	daran	ADV	PAV	_	5	advmod	_	SpaceAfter=No
-7	,	,	PUNCT	$,	_	16	punct	_	_
-8	sondern	sondern	CCONJ	KON	_	9	cc	_	_
-9	Hotels	Hotel	NOUN	NN	Case=Nom|Gender=Neut|Number=Plur	4	conj	_	SpaceAfter=No
-10	,	,	PUNCT	$,	_	11	punct	_	_
-11	Vermittler	Vermittler	NOUN	NN	Case=Nom|Gender=Masc|Number=Plur	9	conj	_	SpaceAfter=No
-12	,	,	PUNCT	$,	_	13	punct	_	_
-13	Bordellbetreiber	Bordellbetreiber	NOUN	NN	Case=Nom|Gender=Masc|Number=Plur	9	conj	_	SpaceAfter=No
-14	''	''	PUNCT	$(	_	16	punct	_	SpaceAfter=No
-15	,	,	PUNCT	$,	_	16	punct	_	_
-16	sagt	sagen	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	0	root	_	_
-17	Felizardo	Felizardo	PROPN	NE	Case=Nom|Number=Sing	16	nsubj	_	SpaceAfter=No
-18	.	.	PUNCT	$.	_	16	punct	_	_
+# text = ``Doch nicht die Kinder verdienen daran, sondern Hotels, Vermittler, Bordellbetreiber'', sagt Felizardo.
+1	``	``	PUNCT	$(	_	2	punct	_	FixTigerDep=Yes|SpaceAfter=No
+2	Doch	doch	CCONJ	KON	_	6	cc	_	_
+3	nicht	nicht	PART	PTKNEG	Polarity=Neg	5	advmod	_	_
+4	die	der	DET	ART	Case=Nom|Definite=Def|Gender=Neut|Number=Plur|PronType=Art	5	det	_	_
+5	Kinder	Kind	NOUN	NN	Case=Nom|Gender=Neut|Number=Plur	6	nsubj	_	_
+6	verdienen	verdienen	VERB	VVFIN	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	17	ccomp	_	_
+7	daran	daran	ADV	PAV	_	6	advmod	_	SpaceAfter=No
+8	,	,	PUNCT	$,	_	17	punct	_	_
+9	sondern	sondern	CCONJ	KON	_	10	cc	_	_
+10	Hotels	Hotel	NOUN	NN	Case=Nom|Gender=Neut|Number=Plur	5	conj	_	SpaceAfter=No
+11	,	,	PUNCT	$,	_	12	punct	_	_
+12	Vermittler	Vermittler	NOUN	NN	Case=Nom|Gender=Masc|Number=Plur	10	conj	_	SpaceAfter=No
+13	,	,	PUNCT	$,	_	14	punct	_	_
+14	Bordellbetreiber	Bordellbetreiber	NOUN	NN	Case=Nom|Gender=Masc|Number=Plur	10	conj	_	SpaceAfter=No
+15	''	''	PUNCT	$(	_	17	punct	_	SpaceAfter=No
+16	,	,	PUNCT	$,	_	17	punct	_	_
+17	sagt	sagen	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	0	root	_	_
+18	Felizardo	Felizardo	PROPN	NE	Case=Nom|Number=Sing	17	nsubj	_	SpaceAfter=No
+19	.	.	PUNCT	$.	_	17	punct	_	_
 
 # sent_id = dev-s727
 # text = Die Amerikaner sind ein begeisterungsfähiges, aber auch leichtgläubiges Volk.
@@ -13371,51 +13477,53 @@
 8	.	.	PUNCT	$.	_	7	punct	_	_
 
 # sent_id = dev-s729
-# text = Wir haben alles erreicht, was wir wollten'', erklärte Japans Außenminister Yohei Kono.
-1	Wir	wir	PRON	PPER	Case=Nom|Number=Plur|Person=1|PronType=Prs	4	nsubj	_	_
-2	haben	haben	AUX	VAFIN	Mood=Ind|Number=Plur|Person=1|Tense=Pres|VerbForm=Fin	4	aux	_	_
-3	alles	alle	PRON	PIS	Case=Acc|Definite=Ind|Gender=Neut|Number=Sing|PronType=Ind	4	obj	_	_
-4	erreicht	erreichen	VERB	VVPP	VerbForm=Part	11	ccomp	_	SpaceAfter=No
-5	,	,	PUNCT	$,	_	11	punct	_	_
-6	was	was	PRON	PRELS	Case=Acc|Gender=Neut|Number=Sing|PronType=Rel	8	obj	_	_
-7	wir	wir	PRON	PPER	Case=Nom|Number=Plur|Person=1|PronType=Prs	8	nsubj	_	_
-8	wollten	wollen	VERB	VMFIN	Mood=Ind|Number=Plur|Person=1|Tense=Past|VerbForm=Fin	3	acl	_	SpaceAfter=No
-9	''	''	PUNCT	$(	_	11	punct	_	SpaceAfter=No
-10	,	,	PUNCT	$,	_	11	punct	_	_
-11	erklärte	erklären	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	0	root	_	_
-12	Japans	Japan	PROPN	NE	Case=Gen|Gender=Neut|Number=Sing	13	nmod	_	_
-13	Außenminister	Außenminister	NOUN	NN	Case=Nom|Gender=Masc|Number=Sing	11	nsubj	_	_
-14	Yohei	Yohei	PROPN	NE	Case=Nom|Gender=Masc|Number=Sing	13	appos	_	_
-15	Kono	Kono	PROPN	NE	Case=Nom|Gender=Masc|Number=Sing	14	flat	_	SpaceAfter=No
-16	.	.	PUNCT	$.	_	11	punct	_	_
+# text = ``Wir haben alles erreicht, was wir wollten'', erklärte Japans Außenminister Yohei Kono.
+1	``	``	PUNCT	$(	_	2	punct	_	FixTigerDep=Yes|SpaceAfter=No
+2	Wir	wir	PRON	PPER	Case=Nom|Number=Plur|Person=1|PronType=Prs	5	nsubj	_	_
+3	haben	haben	AUX	VAFIN	Mood=Ind|Number=Plur|Person=1|Tense=Pres|VerbForm=Fin	5	aux	_	_
+4	alles	alle	PRON	PIS	Case=Acc|Definite=Ind|Gender=Neut|Number=Sing|PronType=Ind	5	obj	_	_
+5	erreicht	erreichen	VERB	VVPP	VerbForm=Part	12	ccomp	_	SpaceAfter=No
+6	,	,	PUNCT	$,	_	12	punct	_	_
+7	was	was	PRON	PRELS	Case=Acc|Gender=Neut|Number=Sing|PronType=Rel	9	obj	_	_
+8	wir	wir	PRON	PPER	Case=Nom|Number=Plur|Person=1|PronType=Prs	9	nsubj	_	_
+9	wollten	wollen	VERB	VMFIN	Mood=Ind|Number=Plur|Person=1|Tense=Past|VerbForm=Fin	4	acl	_	SpaceAfter=No
+10	''	''	PUNCT	$(	_	12	punct	_	SpaceAfter=No
+11	,	,	PUNCT	$,	_	12	punct	_	_
+12	erklärte	erklären	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	0	root	_	_
+13	Japans	Japan	PROPN	NE	Case=Gen|Gender=Neut|Number=Sing	14	nmod	_	_
+14	Außenminister	Außenminister	NOUN	NN	Case=Nom|Gender=Masc|Number=Sing	12	nsubj	_	_
+15	Yohei	Yohei	PROPN	NE	Case=Nom|Gender=Masc|Number=Sing	14	appos	_	_
+16	Kono	Kono	PROPN	NE	Case=Nom|Gender=Masc|Number=Sing	15	flat	_	SpaceAfter=No
+17	.	.	PUNCT	$.	_	12	punct	_	_
 
 # sent_id = dev-s730
-# text = Jahre nach der Wende muß Lech Walesa, der den Freiheitskampf der Polen und den friedlichen Systemwandel symbolisiert, einem ehemaligen kommunistischen Funktionär weichen.
-1	Jahre	Jahr	NOUN	NN	Case=Acc|Gender=Neut|Number=Plur	24	obl	_	_
-2	nach	nach	ADP	APPR	_	4	case	_	_
-3	der	der	DET	ART	Case=Dat|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	4	det	_	_
-4	Wende	Wende	NOUN	NN	Case=Dat|Gender=Fem|Number=Sing	1	nmod	_	_
-5	muß	müssen	AUX	VMFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	24	aux	_	_
-6	Lech	Lech	PROPN	NE	Case=Nom|Gender=Masc|Number=Sing	24	nsubj	_	_
-7	Walesa	Walesa	PROPN	NE	Case=Nom|Gender=Masc|Number=Sing	6	flat	_	SpaceAfter=No
-8	,	,	PUNCT	$,	_	24	punct	_	_
-9	der	der	PRON	PRELS	Case=Nom|Gender=Masc|Number=Sing|PronType=Rel	18	nsubj	_	_
-10	den	der	DET	ART	Case=Acc|Definite=Def|Gender=Masc|Number=Sing|PronType=Art	11	det	_	_
-11	Freiheitskampf	Freiheitskampf	NOUN	NN	Case=Acc|Gender=Masc|Number=Sing	18	obj	_	_
-12	der	der	DET	ART	Case=Gen|Definite=Def|Gender=Masc|Number=Plur|PronType=Art	13	det	_	_
-13	Polen	Pole	NOUN	NN	Case=Gen|Gender=Masc|Number=Plur	11	nmod	_	_
-14	und	und	CCONJ	KON	_	17	cc	_	_
-15	den	der	DET	ART	Case=Acc|Definite=Def|Gender=Masc|Number=Sing|PronType=Art	17	det	_	_
-16	friedlichen	friedlich	ADJ	ADJA	Case=Acc|Gender=Masc|Number=Sing	17	amod	_	_
-17	Systemwandel	Systemwandel	NOUN	NN	Case=Acc|Gender=Masc|Number=Sing	11	conj	_	_
-18	symbolisiert	symbolisieren	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	6	acl	_	SpaceAfter=No
-19	,	,	PUNCT	$,	_	24	punct	_	_
-20	einem	ein	DET	ART	Case=Dat|Definite=Ind|Gender=Masc|Number=Sing|PronType=Art	23	det	_	_
-21	ehemaligen	ehemalig	ADJ	ADJA	Case=Dat|Gender=Masc|Number=Sing	22	amod	_	_
-22	kommunistischen	kommunistisch	ADJ	ADJA	Case=Dat|Gender=Masc|Number=Sing	23	amod	_	_
-23	Funktionär	Funktionär	NOUN	NN	Case=Dat|Gender=Masc|Number=Sing	24	iobj	_	_
-24	weichen	weichen	VERB	VVINF	VerbForm=Inf	0	root	_	SpaceAfter=No
-25	.	.	PUNCT	$.	_	24	punct	_	_
+# text = Sechs Jahre nach der Wende muß Lech Walesa, der den Freiheitskampf der Polen und den friedlichen Systemwandel symbolisiert, einem ehemaligen kommunistischen Funktionär weichen.
+1	Sechs	sechs	NUM	CARD	NumType=Card	2	dep	_	FixTigerDep=Yes
+2	Jahre	Jahr	NOUN	NN	Case=Acc|Gender=Neut|Number=Plur	25	obl	_	_
+3	nach	nach	ADP	APPR	_	5	case	_	_
+4	der	der	DET	ART	Case=Dat|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	5	det	_	_
+5	Wende	Wende	NOUN	NN	Case=Dat|Gender=Fem|Number=Sing	2	nmod	_	_
+6	muß	müssen	AUX	VMFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	25	aux	_	_
+7	Lech	Lech	PROPN	NE	Case=Nom|Gender=Masc|Number=Sing	25	nsubj	_	_
+8	Walesa	Walesa	PROPN	NE	Case=Nom|Gender=Masc|Number=Sing	7	flat	_	SpaceAfter=No
+9	,	,	PUNCT	$,	_	25	punct	_	_
+10	der	der	PRON	PRELS	Case=Nom|Gender=Masc|Number=Sing|PronType=Rel	19	nsubj	_	_
+11	den	der	DET	ART	Case=Acc|Definite=Def|Gender=Masc|Number=Sing|PronType=Art	12	det	_	_
+12	Freiheitskampf	Freiheitskampf	NOUN	NN	Case=Acc|Gender=Masc|Number=Sing	19	obj	_	_
+13	der	der	DET	ART	Case=Gen|Definite=Def|Gender=Masc|Number=Plur|PronType=Art	14	det	_	_
+14	Polen	Pole	NOUN	NN	Case=Gen|Gender=Masc|Number=Plur	12	nmod	_	_
+15	und	und	CCONJ	KON	_	18	cc	_	_
+16	den	der	DET	ART	Case=Acc|Definite=Def|Gender=Masc|Number=Sing|PronType=Art	18	det	_	_
+17	friedlichen	friedlich	ADJ	ADJA	Case=Acc|Gender=Masc|Number=Sing	18	amod	_	_
+18	Systemwandel	Systemwandel	NOUN	NN	Case=Acc|Gender=Masc|Number=Sing	12	conj	_	_
+19	symbolisiert	symbolisieren	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	7	acl	_	SpaceAfter=No
+20	,	,	PUNCT	$,	_	25	punct	_	_
+21	einem	ein	DET	ART	Case=Dat|Definite=Ind|Gender=Masc|Number=Sing|PronType=Art	24	det	_	_
+22	ehemaligen	ehemalig	ADJ	ADJA	Case=Dat|Gender=Masc|Number=Sing	23	amod	_	_
+23	kommunistischen	kommunistisch	ADJ	ADJA	Case=Dat|Gender=Masc|Number=Sing	24	amod	_	_
+24	Funktionär	Funktionär	NOUN	NN	Case=Dat|Gender=Masc|Number=Sing	25	iobj	_	_
+25	weichen	weichen	VERB	VVINF	VerbForm=Inf	0	root	_	SpaceAfter=No
+26	.	.	PUNCT	$.	_	25	punct	_	_
 
 # sent_id = dev-s731
 # text = Die Gläubigen wurden aufgerufen, dem Ex-Kommunisten Kwasniewski keine Chance zu geben und für einen Sieg Walesas zu beten.
@@ -13525,14 +13633,15 @@
 20	.	.	PUNCT	$.	_	3	punct	_	_
 
 # sent_id = dev-s737
-# text = Wir sind laut Vereinsrecht die Hauptverantwortlichen.
-1	Wir	wir	PRON	PPER	Case=Nom|Number=Plur|Person=1|PronType=Prs	6	nsubj	_	_
-2	sind	sein	AUX	VAFIN	Mood=Ind|Number=Plur|Person=1|Tense=Pres|VerbForm=Fin	6	cop	_	_
-3	laut	laut	ADP	APPR	_	4	case	_	_
-4	Vereinsrecht	Vereinsrecht	NOUN	NN	Case=Gen|Gender=Neut|Number=Sing	6	nmod	_	_
-5	die	der	DET	ART	Case=Nom|Definite=Def|Number=Plur|PronType=Art	6	det	_	_
-6	Hauptverantwortlichen	Hauptverantwortliche	NOUN	NN	Case=Nom|Number=Plur	0	root	_	SpaceAfter=No
-7	.	.	PUNCT	$.	_	6	punct	_	_
+# text = ``Wir sind laut Vereinsrecht die Hauptverantwortlichen.
+1	``	``	PUNCT	$(	_	2	punct	_	FixTigerDep=Yes|SpaceAfter=No
+2	Wir	wir	PRON	PPER	Case=Nom|Number=Plur|Person=1|PronType=Prs	7	nsubj	_	_
+3	sind	sein	AUX	VAFIN	Mood=Ind|Number=Plur|Person=1|Tense=Pres|VerbForm=Fin	7	cop	_	_
+4	laut	laut	ADP	APPR	_	5	case	_	_
+5	Vereinsrecht	Vereinsrecht	NOUN	NN	Case=Gen|Gender=Neut|Number=Sing	7	nmod	_	_
+6	die	der	DET	ART	Case=Nom|Definite=Def|Number=Plur|PronType=Art	7	det	_	_
+7	Hauptverantwortlichen	Hauptverantwortliche	NOUN	NN	Case=Nom|Number=Plur	0	root	_	SpaceAfter=No
+8	.	.	PUNCT	$.	_	7	punct	_	_
 
 # sent_id = dev-s738
 # text = Letztlich sind die handelnden Personen entscheidend, nicht die Rechtsform.
@@ -13549,37 +13658,39 @@
 11	.	.	PUNCT	$.	_	6	punct	_	_
 
 # sent_id = dev-s739
-# text = Den Beschäftigten ist es nicht weiter zuzumuten, ohne Bezahlung weiterzuarbeiten'', betonte Gesamtbetriebsratschefin Silke Striezel.
-1	Den	der	DET	ART	Case=Dat|Definite=Def|Number=Plur|PronType=Art	2	det	_	_
-2	Beschäftigten	Beschäftigter	NOUN	NN	Case=Dat|Number=Plur	3	iobj	_	_
-3	ist	sein	VERB	VAFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	14	ccomp	_	_
-4	es	es	PRON	PPER	Case=Nom|Gender=Neut|Number=Sing|Person=3|PronType=Prs	3	nsubj	_	_
-5	nicht	nicht	PART	PTKNEG	Polarity=Neg	6	advmod	_	_
-6	weiter	weiter	ADV	ADV	_	7	advmod	_	_
-7	zuzumuten	zumuten	VERB	VVIZU	VerbForm=Inf	3	acl	_	SpaceAfter=No
-8	,	,	PUNCT	$,	_	14	punct	_	_
-9	ohne	ohne	ADP	APPR	_	10	case	_	_
-10	Bezahlung	Bezahlung	NOUN	NN	Case=Acc|Gender=Fem|Number=Sing	11	obl	_	_
-11	weiterzuarbeiten	weiterarbeiten	VERB	VVIZU	VerbForm=Inf	7	xcomp	_	SpaceAfter=No
-12	''	''	PUNCT	$(	_	14	punct	_	SpaceAfter=No
-13	,	,	PUNCT	$,	_	14	punct	_	_
-14	betonte	betonen	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	0	root	_	_
-15	Gesamtbetriebsratschefin	Gesamtbetriebsratschefin	NOUN	NN	Case=Nom|Gender=Fem|Number=Sing	14	nsubj	_	_
-16	Silke	Silke	PROPN	NE	Case=Nom|Gender=Fem|Number=Sing	15	appos	_	_
-17	Striezel	Striezel	PROPN	NE	Case=Nom|Gender=Fem|Number=Sing	16	flat	_	SpaceAfter=No
-18	.	.	PUNCT	$.	_	14	punct	_	_
+# text = ``Den Beschäftigten ist es nicht weiter zuzumuten, ohne Bezahlung weiterzuarbeiten'', betonte Gesamtbetriebsratschefin Silke Striezel.
+1	``	``	PUNCT	$(	_	2	punct	_	FixTigerDep=Yes|SpaceAfter=No
+2	Den	der	DET	ART	Case=Dat|Definite=Def|Number=Plur|PronType=Art	3	det	_	_
+3	Beschäftigten	Beschäftigter	NOUN	NN	Case=Dat|Number=Plur	4	iobj	_	_
+4	ist	sein	VERB	VAFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	15	ccomp	_	_
+5	es	es	PRON	PPER	Case=Nom|Gender=Neut|Number=Sing|Person=3|PronType=Prs	4	nsubj	_	_
+6	nicht	nicht	PART	PTKNEG	Polarity=Neg	7	advmod	_	_
+7	weiter	weiter	ADV	ADV	_	8	advmod	_	_
+8	zuzumuten	zumuten	VERB	VVIZU	VerbForm=Inf	4	acl	_	SpaceAfter=No
+9	,	,	PUNCT	$,	_	15	punct	_	_
+10	ohne	ohne	ADP	APPR	_	11	case	_	_
+11	Bezahlung	Bezahlung	NOUN	NN	Case=Acc|Gender=Fem|Number=Sing	12	obl	_	_
+12	weiterzuarbeiten	weiterarbeiten	VERB	VVIZU	VerbForm=Inf	8	xcomp	_	SpaceAfter=No
+13	''	''	PUNCT	$(	_	15	punct	_	SpaceAfter=No
+14	,	,	PUNCT	$,	_	15	punct	_	_
+15	betonte	betonen	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	0	root	_	_
+16	Gesamtbetriebsratschefin	Gesamtbetriebsratschefin	NOUN	NN	Case=Nom|Gender=Fem|Number=Sing	15	nsubj	_	_
+17	Silke	Silke	PROPN	NE	Case=Nom|Gender=Fem|Number=Sing	16	appos	_	_
+18	Striezel	Striezel	PROPN	NE	Case=Nom|Gender=Fem|Number=Sing	17	flat	_	SpaceAfter=No
+19	.	.	PUNCT	$.	_	15	punct	_	_
 
 # sent_id = dev-s740
-# text = Aber es kommt eine neue Dimension hinzu.''
-1	Aber	aber	CCONJ	KON	_	3	cc	_	_
-2	es	es	PRON	PPER	Case=Nom|Gender=Neut|Number=Sing|Person=3|PronType=Prs	3	expl	_	_
-3	kommt	kommen	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	0	root	_	_
-4	eine	ein	DET	ART	Case=Nom|Definite=Ind|Gender=Fem|Number=Sing|PronType=Art	6	det	_	_
-5	neue	neu	ADJ	ADJA	Case=Nom|Gender=Fem|Number=Sing	6	amod	_	_
-6	Dimension	Dimension	NOUN	NN	Case=Nom|Gender=Fem|Number=Sing	3	nsubj	_	_
-7	hinzu	hinzu	ADV	PTKVZ	_	3	compound:prt	_	SpaceAfter=No
-8	.	.	PUNCT	$.	_	3	punct	_	SpaceAfter=No
-9	''	''	PUNCT	$(	_	3	punct	_	_
+# text = ``Aber es kommt eine neue Dimension hinzu.''
+1	``	``	PUNCT	$(	_	2	punct	_	FixTigerDep=Yes|SpaceAfter=No
+2	Aber	aber	CCONJ	KON	_	4	cc	_	_
+3	es	es	PRON	PPER	Case=Nom|Gender=Neut|Number=Sing|Person=3|PronType=Prs	4	expl	_	_
+4	kommt	kommen	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	0	root	_	_
+5	eine	ein	DET	ART	Case=Nom|Definite=Ind|Gender=Fem|Number=Sing|PronType=Art	7	det	_	_
+6	neue	neu	ADJ	ADJA	Case=Nom|Gender=Fem|Number=Sing	7	amod	_	_
+7	Dimension	Dimension	NOUN	NN	Case=Nom|Gender=Fem|Number=Sing	4	nsubj	_	_
+8	hinzu	hinzu	ADV	PTKVZ	_	4	compound:prt	_	SpaceAfter=No
+9	.	.	PUNCT	$.	_	4	punct	_	SpaceAfter=No
+10	''	''	PUNCT	$(	_	4	punct	_	_
 
 # sent_id = dev-s741
 # text = Die Inflation hat ihr niedrigstes Niveau seit den siebziger Jahren errreicht, in mehr als der Hälfte der Staaten ist die Rate einstellig.
@@ -13609,62 +13720,65 @@
 24	.	.	PUNCT	$.	_	11	punct	_	_
 
 # sent_id = dev-s742
-# text = Siegfrieds Vater Ludwig räumte Widerstand mit bayerischem Granteln zur Seite.
-1	Siegfrieds	Siegfried	PROPN	NE	Case=Gen|Gender=Masc|Number=Sing	2	nmod	_	_
-2	Vater	Vater	NOUN	NN	Case=Nom|Gender=Masc|Number=Sing	4	nsubj	_	_
-3	Ludwig	Ludwig	PROPN	NE	Case=Nom|Gender=Masc|Number=Sing	2	appos	_	_
-4	räumte	räumen	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	0	root	_	_
-5	Widerstand	Widerstand	NOUN	NN	Case=Acc|Gender=Masc|Number=Sing	4	obj	_	_
-6	mit	mit	ADP	APPR	_	8	case	_	_
-7	bayerischem	bayerisch	ADJ	ADJA	Case=Dat|Gender=Neut|Number=Sing	8	amod	_	_
-8	Granteln	Granteln	NOUN	NN	Case=Dat|Gender=Neut|Number=Sing	4	obl	_	_
-9-10	zur	_	_	_	_	_	_	_	_
-9	zu	zu	ADP	APPR	_	11	case	_	_
-10	der	der	DET	ART	Case=Dat|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	11	det	_	_
-11	Seite	Seite	NOUN	NN	Case=Dat|Gender=Fem|Number=Sing	4	obl	_	SpaceAfter=No
-12	.	.	PUNCT	$.	_	4	punct	_	_
+# text = Schon Siegfrieds Vater Ludwig räumte Widerstand mit bayerischem Granteln zur Seite.
+1	Schon	schon	ADV	ADV	_	2	dep	_	FixTigerDep=Yes
+2	Siegfrieds	Siegfried	PROPN	NE	Case=Gen|Gender=Masc|Number=Sing	3	nmod	_	_
+3	Vater	Vater	NOUN	NN	Case=Nom|Gender=Masc|Number=Sing	5	nsubj	_	_
+4	Ludwig	Ludwig	PROPN	NE	Case=Nom|Gender=Masc|Number=Sing	3	appos	_	_
+5	räumte	räumen	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	0	root	_	_
+6	Widerstand	Widerstand	NOUN	NN	Case=Acc|Gender=Masc|Number=Sing	5	obj	_	_
+7	mit	mit	ADP	APPR	_	9	case	_	_
+8	bayerischem	bayerisch	ADJ	ADJA	Case=Dat|Gender=Neut|Number=Sing	9	amod	_	_
+9	Granteln	Granteln	NOUN	NN	Case=Dat|Gender=Neut|Number=Sing	5	obl	_	_
+10-11	zur	_	_	_	_	_	_	_	_
+10	zu	zu	ADP	APPR	_	12	case	_	_
+11	der	der	DET	ART	Case=Dat|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	12	det	_	_
+12	Seite	Seite	NOUN	NN	Case=Dat|Gender=Fem|Number=Sing	5	obl	_	SpaceAfter=No
+13	.	.	PUNCT	$.	_	5	punct	_	_
 
 # sent_id = dev-s743
-# text = Überall ist unser Geschäft ein politisches'', resümiert Farnung, ``und beliebig schwierig''.
-1	Überall	überall	ADV	ADV	_	6	advmod	_	_
-2	ist	sein	AUX	VAFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	6	cop	_	_
-3	unser	unser	PRON	PPOSAT	Case=Nom|Gender=Neut|Number=Sing|Poss=Yes	4	det:poss	_	_
-4	Geschäft	Geschäft	NOUN	NN	Case=Nom|Gender=Neut|Number=Sing	6	nsubj	_	_
-5	ein	ein	DET	ART	Case=Nom|Definite=Ind|Gender=Neut|Number=Sing|PronType=Art	6	det	_	_
-6	politisches	politisch	ADJ	ADJA	Case=Nom|Gender=Neut|Number=Sing	0	root	_	SpaceAfter=No
-7	''	''	PUNCT	$(	_	15	punct	_	SpaceAfter=No
-8	,	,	PUNCT	$,	_	15	punct	_	_
-9	resümiert	resümieren	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	6	parataxis	_	_
-10	Farnung	Farnung	PROPN	NE	Case=Nom|Number=Sing	9	nsubj	_	SpaceAfter=No
-11	,	,	PUNCT	$,	_	15	punct	_	_
-12	``	``	PUNCT	$(	_	15	punct	_	SpaceAfter=No
-13	und	und	CCONJ	KON	_	15	cc	_	_
-14	beliebig	beliebig	ADV	ADJD	_	15	advmod	_	_
-15	schwierig	schwierig	ADJ	ADJD	_	6	conj	_	SpaceAfter=No
-16	''	''	PUNCT	$(	_	6	punct	_	SpaceAfter=No
-17	.	.	PUNCT	$.	_	6	punct	_	_
+# text = ``Überall ist unser Geschäft ein politisches'', resümiert Farnung, ``und beliebig schwierig''.
+1	``	``	PUNCT	$(	_	2	punct	_	FixTigerDep=Yes|SpaceAfter=No
+2	Überall	überall	ADV	ADV	_	7	advmod	_	_
+3	ist	sein	AUX	VAFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	7	cop	_	_
+4	unser	unser	PRON	PPOSAT	Case=Nom|Gender=Neut|Number=Sing|Poss=Yes	5	det:poss	_	_
+5	Geschäft	Geschäft	NOUN	NN	Case=Nom|Gender=Neut|Number=Sing	7	nsubj	_	_
+6	ein	ein	DET	ART	Case=Nom|Definite=Ind|Gender=Neut|Number=Sing|PronType=Art	7	det	_	_
+7	politisches	politisch	ADJ	ADJA	Case=Nom|Gender=Neut|Number=Sing	0	root	_	SpaceAfter=No
+8	''	''	PUNCT	$(	_	16	punct	_	SpaceAfter=No
+9	,	,	PUNCT	$,	_	16	punct	_	_
+10	resümiert	resümieren	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	7	parataxis	_	_
+11	Farnung	Farnung	PROPN	NE	Case=Nom|Number=Sing	10	nsubj	_	SpaceAfter=No
+12	,	,	PUNCT	$,	_	16	punct	_	_
+13	``	``	PUNCT	$(	_	16	punct	_	SpaceAfter=No
+14	und	und	CCONJ	KON	_	16	cc	_	_
+15	beliebig	beliebig	ADV	ADJD	_	16	advmod	_	_
+16	schwierig	schwierig	ADJ	ADJD	_	7	conj	_	SpaceAfter=No
+17	''	''	PUNCT	$(	_	7	punct	_	SpaceAfter=No
+18	.	.	PUNCT	$.	_	7	punct	_	_
 
 # sent_id = dev-s744
-# text = Es ist vielmehr so, daß der Markt uns richten wird, wenn wir nicht höllisch aufpassen.''
-1	Es	es	PRON	PPER	Case=Nom|Gender=Neut|Number=Sing|Person=3|PronType=Prs	2	nsubj	_	_
-2	ist	sein	VERB	VAFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	0	root	_	_
-3	vielmehr	vielmehr	ADV	ADV	_	4	advmod	_	_
-4	so	so	ADV	ADV	_	2	advmod	_	SpaceAfter=No
-5	,	,	PUNCT	$,	_	2	punct	_	_
-6	daß	daß	SCONJ	KOUS	_	10	mark	_	_
-7	der	der	DET	ART	Case=Nom|Definite=Def|Gender=Masc|Number=Sing|PronType=Art	8	det	_	_
-8	Markt	Markt	NOUN	NN	Case=Nom|Gender=Masc|Number=Sing	10	nsubj	_	_
-9	uns	wir	PRON	PPER	Case=Acc|Number=Plur|Person=1|PronType=Prs	10	obj	_	_
-10	richten	richten	VERB	VVINF	VerbForm=Inf	4	ccomp	_	_
-11	wird	werden	AUX	VAFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	10	aux	_	SpaceAfter=No
-12	,	,	PUNCT	$,	_	2	punct	_	_
-13	wenn	wenn	SCONJ	KOUS	_	17	mark	_	_
-14	wir	wir	PRON	PPER	Case=Nom|Number=Plur|Person=1|PronType=Prs	17	nsubj	_	_
-15	nicht	nicht	PART	PTKNEG	Polarity=Neg	17	advmod	_	_
-16	höllisch	höllisch	ADV	ADJD	_	17	advmod	_	_
-17	aufpassen	aufpassen	VERB	VVFIN	Mood=Ind|Number=Plur|Person=1|Tense=Pres|VerbForm=Fin	10	advcl	_	SpaceAfter=No
-18	.	.	PUNCT	$.	_	2	punct	_	SpaceAfter=No
-19	''	''	PUNCT	$(	_	2	punct	_	_
+# text = ``Es ist vielmehr so, daß der Markt uns richten wird, wenn wir nicht höllisch aufpassen.''
+1	``	``	PUNCT	$(	_	2	punct	_	FixTigerDep=Yes|SpaceAfter=No
+2	Es	es	PRON	PPER	Case=Nom|Gender=Neut|Number=Sing|Person=3|PronType=Prs	3	nsubj	_	_
+3	ist	sein	VERB	VAFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	0	root	_	_
+4	vielmehr	vielmehr	ADV	ADV	_	5	advmod	_	_
+5	so	so	ADV	ADV	_	3	advmod	_	SpaceAfter=No
+6	,	,	PUNCT	$,	_	3	punct	_	_
+7	daß	daß	SCONJ	KOUS	_	11	mark	_	_
+8	der	der	DET	ART	Case=Nom|Definite=Def|Gender=Masc|Number=Sing|PronType=Art	9	det	_	_
+9	Markt	Markt	NOUN	NN	Case=Nom|Gender=Masc|Number=Sing	11	nsubj	_	_
+10	uns	wir	PRON	PPER	Case=Acc|Number=Plur|Person=1|PronType=Prs	11	obj	_	_
+11	richten	richten	VERB	VVINF	VerbForm=Inf	5	ccomp	_	_
+12	wird	werden	AUX	VAFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	11	aux	_	SpaceAfter=No
+13	,	,	PUNCT	$,	_	3	punct	_	_
+14	wenn	wenn	SCONJ	KOUS	_	18	mark	_	_
+15	wir	wir	PRON	PPER	Case=Nom|Number=Plur|Person=1|PronType=Prs	18	nsubj	_	_
+16	nicht	nicht	PART	PTKNEG	Polarity=Neg	18	advmod	_	_
+17	höllisch	höllisch	ADV	ADJD	_	18	advmod	_	_
+18	aufpassen	aufpassen	VERB	VVFIN	Mood=Ind|Number=Plur|Person=1|Tense=Pres|VerbForm=Fin	11	advcl	_	SpaceAfter=No
+19	.	.	PUNCT	$.	_	3	punct	_	SpaceAfter=No
+20	''	''	PUNCT	$(	_	3	punct	_	_
 
 # sent_id = dev-s745
 # text = Wo suchen sich diese Jugendlichen dann die überlebensnotwendige emotionale Zuwendung?
@@ -13704,23 +13818,24 @@
 20	.	.	PUNCT	$.	_	8	punct	_	_
 
 # sent_id = dev-s747
-# text = Natürlich nur mit legalen Methoden'', wie Ellen Waitzis von der Hessischen Verbraucherzentrale betont.
-1	Natürlich	natürlich	ADV	ADV	_	5	advmod	_	_
-2	nur	nur	ADV	ADV	_	5	advmod	_	_
-3	mit	mit	ADP	APPR	_	5	case	_	_
-4	legalen	legal	ADJ	ADJA	Case=Dat|Gender=Fem|Number=Plur	5	amod	_	_
-5	Methoden	Methode	NOUN	NN	Case=Dat|Gender=Fem|Number=Plur	0	root	_	SpaceAfter=No
-6	''	''	PUNCT	$(	_	5	punct	_	SpaceAfter=No
-7	,	,	PUNCT	$,	_	5	punct	_	_
-8	wie	wie	SCONJ	PWAV	PronType=Int	15	mark	_	_
-9	Ellen	Ellen	PROPN	NE	Case=Nom|Gender=Fem|Number=Sing	15	nsubj	_	_
-10	Waitzis	Waitzis	PROPN	NE	Case=Nom|Gender=Fem|Number=Sing	9	flat	_	_
-11	von	von	ADP	APPR	_	14	case	_	_
-12	der	der	DET	ART	Case=Dat|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	14	det	_	_
-13	Hessischen	hessisch	ADJ	ADJA	Case=Dat|Gender=Fem|Number=Sing	14	amod	_	_
-14	Verbraucherzentrale	Verbraucherzentrale	NOUN	NN	Case=Dat|Gender=Fem|Number=Sing	9	nmod	_	_
-15	betont	betonen	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	5	advcl	_	SpaceAfter=No
-16	.	.	PUNCT	$.	_	5	punct	_	_
+# text = ``Natürlich nur mit legalen Methoden'', wie Ellen Waitzis von der Hessischen Verbraucherzentrale betont.
+1	``	``	PUNCT	$(	_	2	punct	_	FixTigerDep=Yes|SpaceAfter=No
+2	Natürlich	natürlich	ADV	ADV	_	6	advmod	_	_
+3	nur	nur	ADV	ADV	_	6	advmod	_	_
+4	mit	mit	ADP	APPR	_	6	case	_	_
+5	legalen	legal	ADJ	ADJA	Case=Dat|Gender=Fem|Number=Plur	6	amod	_	_
+6	Methoden	Methode	NOUN	NN	Case=Dat|Gender=Fem|Number=Plur	0	root	_	SpaceAfter=No
+7	''	''	PUNCT	$(	_	6	punct	_	SpaceAfter=No
+8	,	,	PUNCT	$,	_	6	punct	_	_
+9	wie	wie	SCONJ	PWAV	PronType=Int	16	mark	_	_
+10	Ellen	Ellen	PROPN	NE	Case=Nom|Gender=Fem|Number=Sing	16	nsubj	_	_
+11	Waitzis	Waitzis	PROPN	NE	Case=Nom|Gender=Fem|Number=Sing	10	flat	_	_
+12	von	von	ADP	APPR	_	15	case	_	_
+13	der	der	DET	ART	Case=Dat|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	15	det	_	_
+14	Hessischen	hessisch	ADJ	ADJA	Case=Dat|Gender=Fem|Number=Sing	15	amod	_	_
+15	Verbraucherzentrale	Verbraucherzentrale	NOUN	NN	Case=Dat|Gender=Fem|Number=Sing	10	nmod	_	_
+16	betont	betonen	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	6	advcl	_	SpaceAfter=No
+17	.	.	PUNCT	$.	_	6	punct	_	_
 
 # sent_id = dev-s748
 # text = Die Einkünfte werden mit dem persönlichen Einkommensteuersatz von maximal 53 Prozent belegt.
@@ -13778,187 +13893,197 @@
 34	.	.	PUNCT	$.	_	28	punct	_	_
 
 # sent_id = dev-s750
-# text = Bald werden wir den Befehl erhalten, den Ring um Sarajewo zu öffnen.
-1	Bald	bald	ADV	ADV	_	6	advmod	_	_
-2	werden	werden	AUX	VAFIN	Mood=Ind|Number=Plur|Person=1|Tense=Pres|VerbForm=Fin	6	aux	_	_
-3	wir	wir	PRON	PPER	Case=Nom|Number=Plur|Person=1|PronType=Prs	6	nsubj	_	_
-4	den	der	DET	ART	Case=Acc|Definite=Def|Gender=Masc|Number=Sing|PronType=Art	5	det	_	_
-5	Befehl	Befehl	NOUN	NN	Case=Acc|Gender=Masc|Number=Sing	6	obj	_	_
-6	erhalten	erhalten	VERB	VVINF	VerbForm=Inf	0	root	_	SpaceAfter=No
-7	,	,	PUNCT	$,	_	6	punct	_	_
-8	den	der	DET	ART	Case=Acc|Definite=Def|Gender=Masc|Number=Sing|PronType=Art	9	det	_	_
-9	Ring	Ring	NOUN	NN	Case=Acc|Gender=Masc|Number=Sing	13	obj	_	_
-10	um	um	ADP	APPR	_	11	case	_	_
-11	Sarajewo	Sarajewo	PROPN	NE	Case=Acc|Gender=Neut|Number=Sing	9	nmod	_	_
-12	zu	zu	PART	PTKZU	_	13	mark	_	_
-13	öffnen	öffnen	VERB	VVINF	VerbForm=Inf	6	xcomp	_	SpaceAfter=No
-14	.	.	PUNCT	$.	_	6	punct	_	_
+# text = ``Bald werden wir den Befehl erhalten, den Ring um Sarajewo zu öffnen.
+1	``	``	PUNCT	$(	_	2	punct	_	FixTigerDep=Yes|SpaceAfter=No
+2	Bald	bald	ADV	ADV	_	7	advmod	_	_
+3	werden	werden	AUX	VAFIN	Mood=Ind|Number=Plur|Person=1|Tense=Pres|VerbForm=Fin	7	aux	_	_
+4	wir	wir	PRON	PPER	Case=Nom|Number=Plur|Person=1|PronType=Prs	7	nsubj	_	_
+5	den	der	DET	ART	Case=Acc|Definite=Def|Gender=Masc|Number=Sing|PronType=Art	6	det	_	_
+6	Befehl	Befehl	NOUN	NN	Case=Acc|Gender=Masc|Number=Sing	7	obj	_	_
+7	erhalten	erhalten	VERB	VVINF	VerbForm=Inf	0	root	_	SpaceAfter=No
+8	,	,	PUNCT	$,	_	7	punct	_	_
+9	den	der	DET	ART	Case=Acc|Definite=Def|Gender=Masc|Number=Sing|PronType=Art	10	det	_	_
+10	Ring	Ring	NOUN	NN	Case=Acc|Gender=Masc|Number=Sing	14	obj	_	_
+11	um	um	ADP	APPR	_	12	case	_	_
+12	Sarajewo	Sarajewo	PROPN	NE	Case=Acc|Gender=Neut|Number=Sing	10	nmod	_	_
+13	zu	zu	PART	PTKZU	_	14	mark	_	_
+14	öffnen	öffnen	VERB	VVINF	VerbForm=Inf	7	xcomp	_	SpaceAfter=No
+15	.	.	PUNCT	$.	_	7	punct	_	_
 
 # sent_id = dev-s751
-# text = 70 Personen gelang es, den Sicherheitskordon der Polizei zu durchbrechen und bis zur deutschen Botschaft vorzudringen.
-1	70	70	NUM	CARD	NumType=Card	2	nummod	_	_
-2	Personen	Person	NOUN	NN	Case=Dat|Gender=Fem|Number=Plur	3	nsubj	_	_
-3	gelang	gelingen	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	0	root	_	_
-4	es	es	PRON	PPER	Case=Nom|Gender=Neut|Number=Sing|Person=3|PronType=Prs	3	expl	_	SpaceAfter=No
-5	,	,	PUNCT	$,	_	3	punct	_	_
-6	den	der	DET	ART	Case=Acc|Definite=Def|Gender=Masc|Number=Sing|PronType=Art	7	det	_	_
-7	Sicherheitskordon	Sicherheitskordon	NOUN	NN	Case=Acc|Gender=Masc|Number=Sing	11	obj	_	_
-8	der	der	DET	ART	Case=Gen|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	9	det	_	_
-9	Polizei	Polizei	NOUN	NN	Case=Gen|Gender=Fem|Number=Sing	7	nmod	_	_
-10	zu	zu	PART	PTKZU	_	11	mark	_	_
-11	durchbrechen	durchbrechen	VERB	VVINF	VerbForm=Inf	3	xcomp	_	_
-12	und	und	CCONJ	KON	_	18	cc	_	_
-13	bis	bis	ADP	APPR	_	18	case	_	_
-14-15	zur	_	_	_	_	_	_	_	_
-14	zu	zu	ADP	APPR	_	17	case	_	_
-15	der	der	DET	ART	Case=Dat|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	17	det	_	_
-16	deutschen	deutsch	ADJ	ADJA	Case=Dat|Gender=Fem|Number=Sing	17	amod	_	_
-17	Botschaft	Botschaft	NOUN	NN	Case=Dat|Gender=Fem|Number=Sing	13	nmod	_	_
-18	vorzudringen	vordringen	VERB	VVIZU	VerbForm=Inf	11	conj	_	SpaceAfter=No
-19	.	.	PUNCT	$.	_	3	punct	_	_
+# text = Etwa 70 Personen gelang es, den Sicherheitskordon der Polizei zu durchbrechen und bis zur deutschen Botschaft vorzudringen.
+1	Etwa	etwa	ADV	ADV	_	2	dep	_	FixTigerDep=Yes
+2	70	70	NUM	CARD	NumType=Card	3	nummod	_	_
+3	Personen	Person	NOUN	NN	Case=Dat|Gender=Fem|Number=Plur	4	nsubj	_	_
+4	gelang	gelingen	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	0	root	_	_
+5	es	es	PRON	PPER	Case=Nom|Gender=Neut|Number=Sing|Person=3|PronType=Prs	4	expl	_	SpaceAfter=No
+6	,	,	PUNCT	$,	_	4	punct	_	_
+7	den	der	DET	ART	Case=Acc|Definite=Def|Gender=Masc|Number=Sing|PronType=Art	8	det	_	_
+8	Sicherheitskordon	Sicherheitskordon	NOUN	NN	Case=Acc|Gender=Masc|Number=Sing	12	obj	_	_
+9	der	der	DET	ART	Case=Gen|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	10	det	_	_
+10	Polizei	Polizei	NOUN	NN	Case=Gen|Gender=Fem|Number=Sing	8	nmod	_	_
+11	zu	zu	PART	PTKZU	_	12	mark	_	_
+12	durchbrechen	durchbrechen	VERB	VVINF	VerbForm=Inf	4	xcomp	_	_
+13	und	und	CCONJ	KON	_	19	cc	_	_
+14	bis	bis	ADP	APPR	_	19	case	_	_
+15-16	zur	_	_	_	_	_	_	_	_
+15	zu	zu	ADP	APPR	_	18	case	_	_
+16	der	der	DET	ART	Case=Dat|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	18	det	_	_
+17	deutschen	deutsch	ADJ	ADJA	Case=Dat|Gender=Fem|Number=Sing	18	amod	_	_
+18	Botschaft	Botschaft	NOUN	NN	Case=Dat|Gender=Fem|Number=Sing	14	nmod	_	_
+19	vorzudringen	vordringen	VERB	VVIZU	VerbForm=Inf	12	conj	_	SpaceAfter=No
+20	.	.	PUNCT	$.	_	4	punct	_	_
 
 # sent_id = dev-s752
-# text = In Verhandlungen muß man ausloten, bis zu welchem Punkt man gemeinsam gehen kann, um die Arbeitslosigkeit in Deutschland nun wirklich nachhaltig zu bekämpfen.''
-1	In	in	ADP	APPR	_	2	case	_	_
-2	Verhandlungen	Verhandlung	NOUN	NN	Case=Dat|Gender=Fem|Number=Plur	5	obl	_	_
-3	muß	müssen	AUX	VMFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	5	aux	_	_
-4	man	man	PRON	PIS	Case=Nom|Definite=Ind|Number=Sing|PronType=Ind	5	nsubj	_	_
-5	ausloten	ausloten	VERB	VVINF	VerbForm=Inf	0	root	_	SpaceAfter=No
-6	,	,	PUNCT	$,	_	5	punct	_	_
-7	bis	bis	ADP	APPR	_	13	case	_	_
-8	zu	zu	ADP	APPR	_	7	fixed	_	_
-9	welchem	welch	PRON	PWAT	Case=Dat|Gender=Masc|Number=Sing|PronType=Int	10	det	_	_
-10	Punkt	Punkt	NOUN	NN	Case=Dat|Gender=Masc|Number=Sing	8	nmod	_	_
-11	man	man	PRON	PIS	Case=Nom|Definite=Ind|Number=Sing|PronType=Ind	13	nsubj	_	_
-12	gemeinsam	gemeinsam	ADV	ADJD	_	13	advmod	_	_
-13	gehen	gehen	VERB	VVINF	VerbForm=Inf	5	ccomp	_	_
-14	kann	können	AUX	VMFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	13	aux	_	SpaceAfter=No
-15	,	,	PUNCT	$,	_	5	punct	_	_
-16	um	um	ADP	KOUI	_	25	mark	_	_
-17	die	der	DET	ART	Case=Acc|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	18	det	_	_
-18	Arbeitslosigkeit	Arbeitslosigkeit	NOUN	NN	Case=Acc|Gender=Fem|Number=Sing	25	obj	_	_
-19	in	in	ADP	APPR	_	20	case	_	_
-20	Deutschland	Deutschland	PROPN	NE	Case=Dat|Gender=Neut|Number=Sing	18	nmod	_	_
-21	nun	nun	ADV	ADV	_	25	advmod	_	_
-22	wirklich	wirklich	ADV	ADJD	_	23	advmod	_	_
-23	nachhaltig	nachhaltig	ADV	ADJD	_	25	advmod	_	_
-24	zu	zu	PART	PTKZU	_	25	mark	_	_
-25	bekämpfen	bekämpfen	VERB	VVINF	VerbForm=Inf	13	advcl	_	SpaceAfter=No
-26	.	.	PUNCT	$.	_	5	punct	_	SpaceAfter=No
-27	''	''	PUNCT	$(	_	5	punct	_	_
+# text = ``In Verhandlungen muß man ausloten, bis zu welchem Punkt man gemeinsam gehen kann, um die Arbeitslosigkeit in Deutschland nun wirklich nachhaltig zu bekämpfen.''
+1	``	``	PUNCT	$(	_	2	punct	_	FixTigerDep=Yes|SpaceAfter=No
+2	In	in	ADP	APPR	_	3	case	_	_
+3	Verhandlungen	Verhandlung	NOUN	NN	Case=Dat|Gender=Fem|Number=Plur	6	obl	_	_
+4	muß	müssen	AUX	VMFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	6	aux	_	_
+5	man	man	PRON	PIS	Case=Nom|Definite=Ind|Number=Sing|PronType=Ind	6	nsubj	_	_
+6	ausloten	ausloten	VERB	VVINF	VerbForm=Inf	0	root	_	SpaceAfter=No
+7	,	,	PUNCT	$,	_	6	punct	_	_
+8	bis	bis	ADP	APPR	_	14	case	_	_
+9	zu	zu	ADP	APPR	_	8	fixed	_	_
+10	welchem	welch	PRON	PWAT	Case=Dat|Gender=Masc|Number=Sing|PronType=Int	11	det	_	_
+11	Punkt	Punkt	NOUN	NN	Case=Dat|Gender=Masc|Number=Sing	9	nmod	_	_
+12	man	man	PRON	PIS	Case=Nom|Definite=Ind|Number=Sing|PronType=Ind	14	nsubj	_	_
+13	gemeinsam	gemeinsam	ADV	ADJD	_	14	advmod	_	_
+14	gehen	gehen	VERB	VVINF	VerbForm=Inf	6	ccomp	_	_
+15	kann	können	AUX	VMFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	14	aux	_	SpaceAfter=No
+16	,	,	PUNCT	$,	_	6	punct	_	_
+17	um	um	ADP	KOUI	_	26	mark	_	_
+18	die	der	DET	ART	Case=Acc|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	19	det	_	_
+19	Arbeitslosigkeit	Arbeitslosigkeit	NOUN	NN	Case=Acc|Gender=Fem|Number=Sing	26	obj	_	_
+20	in	in	ADP	APPR	_	21	case	_	_
+21	Deutschland	Deutschland	PROPN	NE	Case=Dat|Gender=Neut|Number=Sing	19	nmod	_	_
+22	nun	nun	ADV	ADV	_	26	advmod	_	_
+23	wirklich	wirklich	ADV	ADJD	_	24	advmod	_	_
+24	nachhaltig	nachhaltig	ADV	ADJD	_	26	advmod	_	_
+25	zu	zu	PART	PTKZU	_	26	mark	_	_
+26	bekämpfen	bekämpfen	VERB	VVINF	VerbForm=Inf	14	advcl	_	SpaceAfter=No
+27	.	.	PUNCT	$.	_	6	punct	_	SpaceAfter=No
+28	''	''	PUNCT	$(	_	6	punct	_	_
 
 # sent_id = dev-s753
-# text = Präsident Alija Izetbegovic äußerte sich optimistisch über den Ausgang des Balkan-Gipfels in den USA.
-1	Präsident	Präsident	NOUN	NN	Case=Nom|Gender=Masc|Number=Sing	4	nsubj	_	_
-2	Alija	Alija	PROPN	NE	Case=Nom|Gender=Masc|Number=Sing	1	appos	_	_
-3	Izetbegovic	Izetbegovic	PROPN	NE	Case=Nom|Gender=Masc|Number=Sing	2	flat	_	_
-4	äußerte	äußern	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	0	root	_	_
-5	sich	er|es|sie	PRON	PRF	Case=Acc|Number=Sing|Person=3|PronType=Prs|Reflex=Yes	4	obj	_	_
-6	optimistisch	optimistisch	ADJ	ADJD	_	4	amod	_	_
-7	über	über	ADP	APPR	_	9	case	_	_
-8	den	der	DET	ART	Case=Acc|Definite=Def|Gender=Masc|Number=Sing|PronType=Art	9	det	_	_
-9	Ausgang	Ausgang	NOUN	NN	Case=Acc|Gender=Masc|Number=Sing	4	obl	_	_
-10	des	der	DET	ART	Case=Gen|Definite=Def|Gender=Masc|Number=Sing|PronType=Art	11	det	_	_
-11	Balkan	Balkan	PROPN	NN	Case=Gen|Gender=Masc|Number=Sing	13	compound	_	SpaceAfter=No
-12	-	-	PUNCT	$(	_	11	punct	_	SpaceAfter=No
-13	Gipfels	Gipfel	NOUN	NN	Case=Gen|Gender=Masc|Number=Sing	9	nmod	_	_
-14	in	in	ADP	APPR	_	16	case	_	_
-15	den	der	DET	ART	Case=Dat|Definite=Def|Number=Plur|PronType=Art	16	det	_	_
-16	USA	USA	PROPN	NE	Case=Dat|Number=Plur	11	nmod	_	SpaceAfter=No
-17	.	.	PUNCT	$.	_	4	punct	_	_
+# text = Bosniens Präsident Alija Izetbegovic äußerte sich optimistisch über den Ausgang des Balkan-Gipfels in den USA.
+1	Bosniens	Bosnien	PROPN	NE	Case=Gen|Gender=Neut|Number=Sing	2	dep	_	FixTigerDep=Yes
+2	Präsident	Präsident	NOUN	NN	Case=Nom|Gender=Masc|Number=Sing	5	nsubj	_	_
+3	Alija	Alija	PROPN	NE	Case=Nom|Gender=Masc|Number=Sing	2	appos	_	_
+4	Izetbegovic	Izetbegovic	PROPN	NE	Case=Nom|Gender=Masc|Number=Sing	3	flat	_	_
+5	äußerte	äußern	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	0	root	_	_
+6	sich	er|es|sie	PRON	PRF	Case=Acc|Number=Sing|Person=3|PronType=Prs|Reflex=Yes	5	obj	_	_
+7	optimistisch	optimistisch	ADJ	ADJD	_	5	amod	_	_
+8	über	über	ADP	APPR	_	10	case	_	_
+9	den	der	DET	ART	Case=Acc|Definite=Def|Gender=Masc|Number=Sing|PronType=Art	10	det	_	_
+10	Ausgang	Ausgang	NOUN	NN	Case=Acc|Gender=Masc|Number=Sing	5	obl	_	_
+11	des	der	DET	ART	Case=Gen|Definite=Def|Gender=Masc|Number=Sing|PronType=Art	12	det	_	_
+12	Balkan	Balkan	PROPN	NN	Case=Gen|Gender=Masc|Number=Sing	14	compound	_	SpaceAfter=No
+13	-	-	PUNCT	$(	_	12	punct	_	SpaceAfter=No
+14	Gipfels	Gipfel	NOUN	NN	Case=Gen|Gender=Masc|Number=Sing	10	nmod	_	_
+15	in	in	ADP	APPR	_	17	case	_	_
+16	den	der	DET	ART	Case=Dat|Definite=Def|Number=Plur|PronType=Art	17	det	_	_
+17	USA	USA	PROPN	NE	Case=Dat|Number=Plur	12	nmod	_	SpaceAfter=No
+18	.	.	PUNCT	$.	_	5	punct	_	_
 
 # sent_id = dev-s754
-# text = Generalsekretär Butros Butros-Ghali hat die internationale Gemeinschaft zu sofortiger Hilfe für die rund 400 000 Flüchtlinge in Sri Lanka aufgerufen.
-1	Generalsekretär	Generalsekretär	NOUN	NN	Case=Nom|Gender=Masc|Number=Sing	22	nsubj	_	_
-2	Butros	Butros	PROPN	NE	Case=Nom|Gender=Masc|Number=Sing	1	appos	_	_
-3	Butros	Butros	PROPN	NE	Case=Nom|Gender=Masc|Number=Sing	2	flat	_	SpaceAfter=No
-4	-	-	PUNCT	$(	_	3	punct	_	SpaceAfter=No
-5	Ghali	Ghali	PROPN	NE	Case=Nom|Gender=Masc|Number=Sing	2	flat	_	_
-6	hat	haben	AUX	VAFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	22	aux	_	_
-7	die	der	DET	ART	Case=Acc|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	9	det	_	_
-8	internationale	international	ADJ	ADJA	Case=Acc|Gender=Fem|Number=Sing	9	amod	_	_
-9	Gemeinschaft	Gemeinschaft	NOUN	NN	Case=Acc|Gender=Fem|Number=Sing	22	obj	_	_
-10	zu	zu	ADP	APPR	_	12	case	_	_
-11	sofortiger	sofortig	ADJ	ADJA	Case=Dat|Gender=Fem|Number=Sing	12	amod	_	_
-12	Hilfe	Hilfe	NOUN	NN	Case=Dat|Gender=Fem|Number=Sing	22	obl	_	_
-13	für	für	ADP	APPR	_	18	case	_	_
-14	die	der	DET	ART	Case=Acc|Definite=Def|Gender=Masc|Number=Plur|PronType=Art	18	det	_	_
-15	rund	rund	ADV	ADJD	_	16	advmod	_	_
-16	400	400	NUM	CARD	NumType=Card	17	nummod	_	_
-17	000	000	NUM	CARD	NumType=Card	18	nummod	_	_
-18	Flüchtlinge	Flüchtling	NOUN	NN	Case=Acc|Gender=Masc|Number=Plur	12	nmod	_	_
-19	in	in	ADP	APPR	_	20	case	_	_
-20	Sri	Sri	PROPN	NE	_	18	nmod	_	_
-21	Lanka	Lanka	PROPN	NE	Case=Dat|Gender=Neut|Number=Sing	20	flat	_	_
-22	aufgerufen	aufrufen	VERB	VVPP	VerbForm=Part	0	root	_	SpaceAfter=No
-23	.	.	PUNCT	$.	_	22	punct	_	_
+# text = UN-Generalsekretär Butros Butros-Ghali hat die internationale Gemeinschaft zu sofortiger Hilfe für die rund 400 000 Flüchtlinge in Sri Lanka aufgerufen.
+1	UN	UN	NOUN	NN	Case=Nom|Gender=Masc|Number=Sing	3	compound	_	SpaceAfter=No
+2	-	-	PUNCT	_	_	3	punct	_	SpaceAfter=No
+3	Generalsekretär	Generalsekretär	NOUN	NN	Case=Nom|Gender=Masc|Number=Sing	24	nsubj	_	_
+4	Butros	Butros	PROPN	NE	Case=Nom|Gender=Masc|Number=Sing	1	appos	_	_
+5	Butros	Butros	PROPN	NE	Case=Nom|Gender=Masc|Number=Sing	4	flat	_	SpaceAfter=No
+6	-	-	PUNCT	$(	_	5	punct	_	SpaceAfter=No
+7	Ghali	Ghali	PROPN	NE	Case=Nom|Gender=Masc|Number=Sing	4	flat	_	_
+8	hat	haben	AUX	VAFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	24	aux	_	_
+9	die	der	DET	ART	Case=Acc|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	11	det	_	_
+10	internationale	international	ADJ	ADJA	Case=Acc|Gender=Fem|Number=Sing	11	amod	_	_
+11	Gemeinschaft	Gemeinschaft	NOUN	NN	Case=Acc|Gender=Fem|Number=Sing	24	obj	_	_
+12	zu	zu	ADP	APPR	_	14	case	_	_
+13	sofortiger	sofortig	ADJ	ADJA	Case=Dat|Gender=Fem|Number=Sing	14	amod	_	_
+14	Hilfe	Hilfe	NOUN	NN	Case=Dat|Gender=Fem|Number=Sing	24	obl	_	_
+15	für	für	ADP	APPR	_	20	case	_	_
+16	die	der	DET	ART	Case=Acc|Definite=Def|Gender=Masc|Number=Plur|PronType=Art	20	det	_	_
+17	rund	rund	ADV	ADJD	_	18	advmod	_	_
+18	400	400	NUM	CARD	NumType=Card	19	nummod	_	_
+19	000	000	NUM	CARD	NumType=Card	20	nummod	_	_
+20	Flüchtlinge	Flüchtling	NOUN	NN	Case=Acc|Gender=Masc|Number=Plur	14	nmod	_	_
+21	in	in	ADP	APPR	_	22	case	_	_
+22	Sri	Sri	PROPN	NE	_	20	nmod	_	_
+23	Lanka	Lanka	PROPN	NE	Case=Dat|Gender=Neut|Number=Sing	22	flat	_	_
+24	aufgerufen	aufrufen	VERB	VVPP	VerbForm=Part	0	root	_	SpaceAfter=No
+25	.	.	PUNCT	$.	_	24	punct	_	_
 
 # sent_id = dev-s755
-# text = 15 000 Einwohner flüchteten ins Umland oder wurden evakuiert.
-1	15	15	NUM	CARD	NumType=Card	2	nummod	_	_
-2	000	000	NUM	CARD	NumType=Card	3	nummod	_	_
-3	Einwohner	Einwohner	NOUN	NN	Case=Nom|Gender=Masc|Number=Plur	4	nsubj	_	_
-4	flüchteten	flüchten	VERB	VVFIN	Mood=Ind|Number=Plur|Person=3|Tense=Past|VerbForm=Fin	0	root	_	_
-5-6	ins	_	_	_	_	_	_	_	_
-5	in	in	ADP	APPR	_	7	case	_	_
-6	das	der	DET	ART	Case=Acc|Definite=Def|Gender=Neut|Number=Sing|PronType=Art	7	det	_	_
-7	Umland	Umland	NOUN	NN	Case=Acc|Gender=Neut|Number=Sing	4	obl	_	_
-8	oder	oder	CCONJ	KON	_	10	cc	_	_
-9	wurden	werden	AUX	VAFIN	Mood=Ind|Number=Plur|Person=3|Tense=Past|VerbForm=Fin|Voice=Pass	10	aux:pass	_	_
-10	evakuiert	evakuieren	VERB	VVPP	VerbForm=Part	4	conj	_	SpaceAfter=No
-11	.	.	PUNCT	$.	_	4	punct	_	_
+# text = Rund 15 000 Einwohner flüchteten ins Umland oder wurden evakuiert.
+1	Rund	rund	ADJ	ADJD	_	2	dep	_	FixTigerDep=Yes
+2	15	15	NUM	CARD	NumType=Card	3	nummod	_	_
+3	000	000	NUM	CARD	NumType=Card	4	nummod	_	_
+4	Einwohner	Einwohner	NOUN	NN	Case=Nom|Gender=Masc|Number=Plur	5	nsubj	_	_
+5	flüchteten	flüchten	VERB	VVFIN	Mood=Ind|Number=Plur|Person=3|Tense=Past|VerbForm=Fin	0	root	_	_
+6-7	ins	_	_	_	_	_	_	_	_
+6	in	in	ADP	APPR	_	8	case	_	_
+7	das	der	DET	ART	Case=Acc|Definite=Def|Gender=Neut|Number=Sing|PronType=Art	8	det	_	_
+8	Umland	Umland	NOUN	NN	Case=Acc|Gender=Neut|Number=Sing	5	obl	_	_
+9	oder	oder	CCONJ	KON	_	11	cc	_	_
+10	wurden	werden	AUX	VAFIN	Mood=Ind|Number=Plur|Person=3|Tense=Past|VerbForm=Fin|Voice=Pass	11	aux:pass	_	_
+11	evakuiert	evakuieren	VERB	VVPP	VerbForm=Part	5	conj	_	SpaceAfter=No
+12	.	.	PUNCT	$.	_	5	punct	_	_
 
 # sent_id = dev-s756
-# text = Helmut Kohl erklärte, der feige Mord habe einen Mann getroffen, der durch großen Mut und vollen Einsatz seiner Persönlichkeit den Frieden im Nahen Osten erreichen wollte.
-1	Helmut	Helmut	PROPN	NE	Case=Nom|Gender=Masc|Number=Sing	3	nsubj	_	_
-2	Kohl	Kohl	PROPN	NE	Case=Nom|Gender=Masc|Number=Sing	1	flat	_	_
-3	erklärte	erklären	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	0	root	_	SpaceAfter=No
-4	,	,	PUNCT	$,	_	3	punct	_	_
-5	der	der	DET	ART	Case=Nom|Definite=Def|Gender=Masc|Number=Sing|PronType=Art	7	det	_	_
-6	feige	feig	ADJ	ADJA	Case=Nom|Gender=Masc|Number=Sing	7	amod	_	_
-7	Mord	Mord	NOUN	NN	Case=Nom|Gender=Masc|Number=Sing	11	nsubj	_	_
-8	habe	haben	AUX	VAFIN	Mood=Sub|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	11	aux	_	_
-9	einen	ein	DET	ART	Case=Acc|Definite=Ind|Gender=Masc|Number=Sing|PronType=Art	10	det	_	_
-10	Mann	Mann	NOUN	NN	Case=Acc|Gender=Masc|Number=Sing	11	obj	_	_
-11	getroffen	treffen	VERB	VVPP	VerbForm=Part	3	ccomp	_	SpaceAfter=No
-12	,	,	PUNCT	$,	_	3	punct	_	_
-13	der	der	DET	PRELS	Case=Nom|Gender=Masc|Number=Sing|PronType=Rel	28	nsubj	_	_
-14	durch	durch	ADP	APPR	_	16	case	_	_
-15	großen	groß	ADJ	ADJA	Case=Acc|Gender=Masc|Number=Sing	16	amod	_	_
-16	Mut	Mut	NOUN	NN	Case=Acc|Gender=Masc|Number=Sing	28	obl	_	_
-17	und	und	CCONJ	KON	_	19	cc	_	_
-18	vollen	voll	ADJ	ADJA	Case=Acc|Gender=Masc|Number=Sing	19	amod	_	_
-19	Einsatz	Einsatz	NOUN	NN	Case=Acc|Gender=Masc|Number=Sing	16	conj	_	_
-20	seiner	sein	PRON	PPOSAT	Case=Gen|Gender=Fem|Number=Sing|Poss=Yes	21	det:poss	_	_
-21	Persönlichkeit	Persönlichkeit	NOUN	NN	Case=Gen|Gender=Fem|Number=Sing	19	nmod	_	_
-22	den	der	DET	ART	Case=Acc|Definite=Def|Gender=Masc|Number=Sing|PronType=Art	23	det	_	_
-23	Frieden	Frieden	NOUN	NN	Case=Acc|Gender=Masc|Number=Sing	28	obj	_	_
-24-25	im	_	_	_	_	_	_	_	_
-24	in	in	ADP	APPR	_	26	case	_	_
-25	dem	der	DET	ART	Case=Dat|Definite=Def|Gender=Masc|Number=Sing|PronType=Art	26	det	_	_
-26	Nahen	nah	PROPN	ADJA	Case=Dat|Gender=Masc|Number=Sing	23	nmod	_	_
-27	Osten	Osten	PROPN	NN	Case=Dat|Gender=Masc|Number=Sing	26	flat	_	_
-28	erreichen	erreichen	VERB	VVINF	VerbForm=Inf	10	acl	_	_
-29	wollte	wollen	AUX	VMFIN	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	28	aux	_	SpaceAfter=No
-30	.	.	PUNCT	$.	_	3	punct	_	_
+# text = Bundeskanzler Helmut Kohl erklärte, der feige Mord habe einen Mann getroffen, der durch großen Mut und vollen Einsatz seiner Persönlichkeit den Frieden im Nahen Osten erreichen wollte.
+1	Bundeskanzler	Bundeskanzler	NOUN	NN	Case=Nom|Gender=Masc|Number=Sing	2	dep	_	FixTigerDep=Yes
+2	Helmut	Helmut	PROPN	NE	Case=Nom|Gender=Masc|Number=Sing	4	nsubj	_	_
+3	Kohl	Kohl	PROPN	NE	Case=Nom|Gender=Masc|Number=Sing	2	flat	_	_
+4	erklärte	erklären	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	0	root	_	SpaceAfter=No
+5	,	,	PUNCT	$,	_	4	punct	_	_
+6	der	der	DET	ART	Case=Nom|Definite=Def|Gender=Masc|Number=Sing|PronType=Art	8	det	_	_
+7	feige	feig	ADJ	ADJA	Case=Nom|Gender=Masc|Number=Sing	8	amod	_	_
+8	Mord	Mord	NOUN	NN	Case=Nom|Gender=Masc|Number=Sing	12	nsubj	_	_
+9	habe	haben	AUX	VAFIN	Mood=Sub|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	12	aux	_	_
+10	einen	ein	DET	ART	Case=Acc|Definite=Ind|Gender=Masc|Number=Sing|PronType=Art	11	det	_	_
+11	Mann	Mann	NOUN	NN	Case=Acc|Gender=Masc|Number=Sing	12	obj	_	_
+12	getroffen	treffen	VERB	VVPP	VerbForm=Part	4	ccomp	_	SpaceAfter=No
+13	,	,	PUNCT	$,	_	4	punct	_	_
+14	der	der	DET	PRELS	Case=Nom|Gender=Masc|Number=Sing|PronType=Rel	29	nsubj	_	_
+15	durch	durch	ADP	APPR	_	17	case	_	_
+16	großen	groß	ADJ	ADJA	Case=Acc|Gender=Masc|Number=Sing	17	amod	_	_
+17	Mut	Mut	NOUN	NN	Case=Acc|Gender=Masc|Number=Sing	29	obl	_	_
+18	und	und	CCONJ	KON	_	20	cc	_	_
+19	vollen	voll	ADJ	ADJA	Case=Acc|Gender=Masc|Number=Sing	20	amod	_	_
+20	Einsatz	Einsatz	NOUN	NN	Case=Acc|Gender=Masc|Number=Sing	17	conj	_	_
+21	seiner	sein	PRON	PPOSAT	Case=Gen|Gender=Fem|Number=Sing|Poss=Yes	22	det:poss	_	_
+22	Persönlichkeit	Persönlichkeit	NOUN	NN	Case=Gen|Gender=Fem|Number=Sing	20	nmod	_	_
+23	den	der	DET	ART	Case=Acc|Definite=Def|Gender=Masc|Number=Sing|PronType=Art	24	det	_	_
+24	Frieden	Frieden	NOUN	NN	Case=Acc|Gender=Masc|Number=Sing	29	obj	_	_
+25-26	im	_	_	_	_	_	_	_	_
+25	in	in	ADP	APPR	_	27	case	_	_
+26	dem	der	DET	ART	Case=Dat|Definite=Def|Gender=Masc|Number=Sing|PronType=Art	27	det	_	_
+27	Nahen	nah	PROPN	ADJA	Case=Dat|Gender=Masc|Number=Sing	24	nmod	_	_
+28	Osten	Osten	PROPN	NN	Case=Dat|Gender=Masc|Number=Sing	27	flat	_	_
+29	erreichen	erreichen	VERB	VVINF	VerbForm=Inf	11	acl	_	_
+30	wollte	wollen	AUX	VMFIN	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	29	aux	_	SpaceAfter=No
+31	.	.	PUNCT	$.	_	4	punct	_	_
 
 # sent_id = dev-s757
-# text = Gurion und seine Außenministerin Golda Meir wurden leicht, Innenminister Mosche Schapira schwer verletzt.
-1	Gurion	Gurion	PROPN	NE	Case=Nom|Gender=Fem|Number=Sing	14	nsubj:pass	_	_
-2	und	und	CCONJ	KON	_	4	cc	_	_
-3	seine	sein	PRON	PPOSAT	Case=Nom|Gender=Fem|Number=Sing|Poss=Yes	4	det:poss	_	_
-4	Außenministerin	Außenministerin	NOUN	NN	Case=Nom|Gender=Fem|Number=Sing	1	conj	_	_
-5	Golda	Golda	PROPN	NE	Case=Nom|Gender=Fem|Number=Sing	4	appos	_	_
-6	Meir	Meir	PROPN	NE	Case=Nom|Gender=Fem|Number=Sing	5	flat	_	_
-7	wurden	werden	AUX	VAFIN	Mood=Ind|Number=Plur|Person=3|Tense=Past|VerbForm=Fin|Voice=Pass	14	aux:pass	_	_
-8	leicht	leicht	ADV	ADJD	_	14	advmod	_	SpaceAfter=No
-9	,	,	PUNCT	$,	_	10	punct	_	_
-10	Innenminister	Innenminister	NOUN	NN	Case=Nom|Gender=Masc|Number=Sing	1	conj	_	_
-11	Mosche	Mosche	PROPN	NE	Case=Nom|Gender=Masc|Number=Sing	10	appos	_	_
-12	Schapira	Schapira	PROPN	NE	Case=Nom|Gender=Masc|Number=Sing	11	flat	_	_
-13	schwer	schwer	ADV	ADJD	_	14	advmod	_	_
-14	verletzt	verletzen	VERB	VVPP	VerbForm=Part	0	root	_	SpaceAfter=No
-15	.	.	PUNCT	$.	_	14	punct	_	_
+# text = Ben-Gurion und seine Außenministerin Golda Meir wurden leicht, Innenminister Mosche Schapira schwer verletzt.
+1	Ben	Ben	PROPN	NE	Case=Nom|Gender=Masc|Number=Sing	16	nsubj:pass	_	SpaceAfter=No
+2	-	-	PUNCT	_	_	1	punct	_	SpaceAfter=No
+3	Gurion	Gurion	PROPN	NE	Case=Nom|Gender=Masc|Number=Sing	1	flat	_	_
+4	und	und	CCONJ	KON	_	6	cc	_	_
+5	seine	sein	PRON	PPOSAT	Case=Nom|Gender=Fem|Number=Sing|Poss=Yes	6	det:poss	_	_
+6	Außenministerin	Außenministerin	NOUN	NN	Case=Nom|Gender=Fem|Number=Sing	1	conj	_	_
+7	Golda	Golda	PROPN	NE	Case=Nom|Gender=Fem|Number=Sing	6	appos	_	_
+8	Meir	Meir	PROPN	NE	Case=Nom|Gender=Fem|Number=Sing	7	flat	_	_
+9	wurden	werden	AUX	VAFIN	Mood=Ind|Number=Plur|Person=3|Tense=Past|VerbForm=Fin|Voice=Pass	16	aux:pass	_	_
+10	leicht	leicht	ADV	ADJD	_	16	advmod	_	SpaceAfter=No
+11	,	,	PUNCT	$,	_	12	punct	_	_
+12	Innenminister	Innenminister	NOUN	NN	Case=Nom|Gender=Masc|Number=Sing	1	conj	_	_
+13	Mosche	Mosche	PROPN	NE	Case=Nom|Gender=Masc|Number=Sing	12	appos	_	_
+14	Schapira	Schapira	PROPN	NE	Case=Nom|Gender=Masc|Number=Sing	13	flat	_	_
+15	schwer	schwer	ADV	ADJD	_	16	advmod	_	_
+16	verletzt	verletzen	VERB	VVPP	VerbForm=Part	0	root	_	SpaceAfter=No
+17	.	.	PUNCT	$.	_	16	punct	_	_
 
 # sent_id = dev-s758
 # text = Die SPD -- Politiker hatten angekündigt, die Währungsunion zum Thema des Bundestagswahlkampfes 1998 zu machen.
@@ -14012,59 +14137,62 @@
 25	.	.	PUNCT	$.	_	24	punct	_	_
 
 # sent_id = dev-s760
-# text = Schmugglern drohen Geldstrafen, und der Grenzpolizei wird die Sache mittlerweile etwas zu heiß.
-1	Schmugglern	Schmuggler	NOUN	NN	Case=Dat|Gender=Masc|Number=Plur	2	iobj	_	_
-2	drohen	drohen	VERB	VVFIN	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	0	root	_	_
-3	Geldstrafen	Geldstrafe	NOUN	NN	Case=Nom|Gender=Fem|Number=Plur	2	nsubj	_	SpaceAfter=No
-4	,	,	PUNCT	$,	_	14	punct	_	_
-5	und	und	CCONJ	KON	_	14	cc	_	_
-6	der	der	DET	ART	Case=Dat|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	7	det	_	_
-7	Grenzpolizei	Grenzpolizei	NOUN	NN	Case=Dat|Gender=Fem|Number=Sing	8	iobj	_	_
-8	wird	werden	AUX	VAFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	14	cop	_	_
-9	die	der	DET	ART	Case=Nom|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	10	det	_	_
-10	Sache	Sache	NOUN	NN	Case=Nom|Gender=Fem|Number=Sing	14	nsubj	_	_
-11	mittlerweile	mittlerweile	ADV	ADV	_	14	advmod	_	_
-12	etwas	etwas	ADV	ADV	_	13	advmod	_	_
-13	zu	zu	ADV	PTKA	_	14	advmod	_	_
-14	heiß	heiß	ADJ	ADJD	_	2	conj	_	SpaceAfter=No
-15	.	.	PUNCT	$.	_	2	punct	_	_
+# text = Den Schmugglern drohen Geldstrafen, und der Grenzpolizei wird die Sache mittlerweile etwas zu heiß.
+1	Den	der	DET	ART	Case=Dat|Definite=Def|Gender=Masc|Number=Plur|PronType=Art	2	dep	_	FixTigerDep=Yes
+2	Schmugglern	Schmuggler	NOUN	NN	Case=Dat|Gender=Masc|Number=Plur	3	iobj	_	_
+3	drohen	drohen	VERB	VVFIN	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	0	root	_	_
+4	Geldstrafen	Geldstrafe	NOUN	NN	Case=Nom|Gender=Fem|Number=Plur	3	nsubj	_	SpaceAfter=No
+5	,	,	PUNCT	$,	_	15	punct	_	_
+6	und	und	CCONJ	KON	_	15	cc	_	_
+7	der	der	DET	ART	Case=Dat|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	8	det	_	_
+8	Grenzpolizei	Grenzpolizei	NOUN	NN	Case=Dat|Gender=Fem|Number=Sing	9	iobj	_	_
+9	wird	werden	AUX	VAFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	15	cop	_	_
+10	die	der	DET	ART	Case=Nom|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	11	det	_	_
+11	Sache	Sache	NOUN	NN	Case=Nom|Gender=Fem|Number=Sing	15	nsubj	_	_
+12	mittlerweile	mittlerweile	ADV	ADV	_	15	advmod	_	_
+13	etwas	etwas	ADV	ADV	_	14	advmod	_	_
+14	zu	zu	ADV	PTKA	_	15	advmod	_	_
+15	heiß	heiß	ADJ	ADJD	_	3	conj	_	SpaceAfter=No
+16	.	.	PUNCT	$.	_	3	punct	_	_
 
 # sent_id = dev-s761
-# text = Die Denkschrift kommt in bildungspolitisch nicht gerade leichten Zeiten'', räumte Rau ein.
-1	Die	der	DET	ART	Case=Nom|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	2	det	_	_
-2	Denkschrift	Denkschrift	NOUN	NN	Case=Nom|Gender=Fem|Number=Sing	3	nsubj	_	_
-3	kommt	kommen	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	12	ccomp	_	_
-4	in	in	ADP	APPR	_	9	case	_	_
-5	bildungspolitisch	bildungspolitisch	ADV	ADJD	_	8	advmod	_	_
-6	nicht	nicht	PART	PTKNEG	Polarity=Neg	8	advmod	_	_
-7	gerade	gerade	ADV	ADV	_	6	advmod	_	_
-8	leichten	leicht	ADJ	ADJA	Case=Dat|Gender=Fem|Number=Plur	9	amod	_	_
-9	Zeiten	Zeit	NOUN	NN	Case=Dat|Gender=Fem|Number=Plur	3	obl	_	SpaceAfter=No
-10	''	''	PUNCT	$(	_	12	punct	_	SpaceAfter=No
-11	,	,	PUNCT	$,	_	12	punct	_	_
-12	räumte	räumen	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	0	root	_	_
-13	Rau	Rau	PROPN	NE	Case=Nom|Number=Sing	12	nsubj	_	_
-14	ein	ein	ADV	PTKVZ	_	12	compound:prt	_	SpaceAfter=No
-15	.	.	PUNCT	$.	_	12	punct	_	_
+# text = ``Die Denkschrift kommt in bildungspolitisch nicht gerade leichten Zeiten'', räumte Rau ein.
+1	``	``	PUNCT	$(	_	2	punct	_	FixTigerDep=Yes|SpaceAfter=No
+2	Die	der	DET	ART	Case=Nom|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	3	det	_	_
+3	Denkschrift	Denkschrift	NOUN	NN	Case=Nom|Gender=Fem|Number=Sing	4	nsubj	_	_
+4	kommt	kommen	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	13	ccomp	_	_
+5	in	in	ADP	APPR	_	10	case	_	_
+6	bildungspolitisch	bildungspolitisch	ADV	ADJD	_	9	advmod	_	_
+7	nicht	nicht	PART	PTKNEG	Polarity=Neg	9	advmod	_	_
+8	gerade	gerade	ADV	ADV	_	7	advmod	_	_
+9	leichten	leicht	ADJ	ADJA	Case=Dat|Gender=Fem|Number=Plur	10	amod	_	_
+10	Zeiten	Zeit	NOUN	NN	Case=Dat|Gender=Fem|Number=Plur	4	obl	_	SpaceAfter=No
+11	''	''	PUNCT	$(	_	13	punct	_	SpaceAfter=No
+12	,	,	PUNCT	$,	_	13	punct	_	_
+13	räumte	räumen	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	0	root	_	_
+14	Rau	Rau	PROPN	NE	Case=Nom|Number=Sing	13	nsubj	_	_
+15	ein	ein	ADV	PTKVZ	_	13	compound:prt	_	SpaceAfter=No
+16	.	.	PUNCT	$.	_	13	punct	_	_
 
 # sent_id = dev-s762
-# text = Er fiel im Kampf für den Frieden'', sagte Präsident Ezer Weizman.
-1	Er	er	PRON	PPER	Case=Nom|Gender=Masc|Number=Sing|Person=3|PronType=Prs	2	nsubj	_	_
-2	fiel	fallen	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	11	ccomp	_	_
-3-4	im	_	_	_	_	_	_	_	_
-3	in	in	ADP	APPR	_	5	case	_	_
-4	dem	der	DET	ART	Case=Dat|Definite=Def|Gender=Masc|Number=Sing|PronType=Art	5	det	_	_
-5	Kampf	Kampf	NOUN	NN	Case=Dat|Gender=Masc|Number=Sing	2	obl	_	_
-6	für	für	ADP	APPR	_	8	case	_	_
-7	den	der	DET	ART	Case=Acc|Definite=Def|Gender=Masc|Number=Sing|PronType=Art	8	det	_	_
-8	Frieden	Frieden	NOUN	NN	Case=Acc|Gender=Masc|Number=Sing	5	nmod	_	SpaceAfter=No
-9	''	''	PUNCT	$(	_	11	punct	_	SpaceAfter=No
-10	,	,	PUNCT	$,	_	11	punct	_	_
-11	sagte	sagen	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	0	root	_	_
-12	Präsident	Präsident	NOUN	NN	Case=Nom|Gender=Masc|Number=Sing	11	nsubj	_	_
-13	Ezer	Ezer	PROPN	NE	Case=Nom|Gender=Masc|Number=Sing	12	appos	_	_
-14	Weizman	Weizman	PROPN	NE	Case=Nom|Gender=Masc|Number=Sing	13	flat	_	SpaceAfter=No
-15	.	.	PUNCT	$.	_	11	punct	_	_
+# text = ``Er fiel im Kampf für den Frieden'', sagte Präsident Ezer Weizman.
+1	``	``	PUNCT	$(	_	2	punct	_	FixTigerDep=Yes|SpaceAfter=No
+2	Er	er	PRON	PPER	Case=Nom|Gender=Masc|Number=Sing|Person=3|PronType=Prs	3	nsubj	_	_
+3	fiel	fallen	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	12	ccomp	_	_
+4-5	im	_	_	_	_	_	_	_	_
+4	in	in	ADP	APPR	_	6	case	_	_
+5	dem	der	DET	ART	Case=Dat|Definite=Def|Gender=Masc|Number=Sing|PronType=Art	6	det	_	_
+6	Kampf	Kampf	NOUN	NN	Case=Dat|Gender=Masc|Number=Sing	3	obl	_	_
+7	für	für	ADP	APPR	_	9	case	_	_
+8	den	der	DET	ART	Case=Acc|Definite=Def|Gender=Masc|Number=Sing|PronType=Art	9	det	_	_
+9	Frieden	Frieden	NOUN	NN	Case=Acc|Gender=Masc|Number=Sing	6	nmod	_	SpaceAfter=No
+10	''	''	PUNCT	$(	_	12	punct	_	SpaceAfter=No
+11	,	,	PUNCT	$,	_	12	punct	_	_
+12	sagte	sagen	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	0	root	_	_
+13	Präsident	Präsident	NOUN	NN	Case=Nom|Gender=Masc|Number=Sing	12	nsubj	_	_
+14	Ezer	Ezer	PROPN	NE	Case=Nom|Gender=Masc|Number=Sing	13	appos	_	_
+15	Weizman	Weizman	PROPN	NE	Case=Nom|Gender=Masc|Number=Sing	14	flat	_	SpaceAfter=No
+16	.	.	PUNCT	$.	_	12	punct	_	_
 
 # sent_id = dev-s763
 # text = Die Augen blickten leer ohne Verständnis, ohne Hoffnung.
@@ -14080,62 +14208,64 @@
 10	.	.	PUNCT	$.	_	3	punct	_	_
 
 # sent_id = dev-s764
-# text = Die Regierung Israels gibt mit tiefer Trauer den Tod des Ministerpräsidenten und Verteidigungsministers Yitzhak Rabin bekannt, der heute von einem Attentäter in Tel Aviv ermordet wurde'', teilte ein Regierungssprecher vor dem Krankenhaus Journalisten und ängstlich wartenden Israelis mit.
-1	Die	der	DET	ART	Case=Nom|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	2	det	_	_
-2	Regierung	Regierung	NOUN	NN	Case=Nom|Gender=Fem|Number=Sing	4	nsubj	_	_
-3	Israels	Israel	PROPN	NE	Case=Gen|Gender=Neut|Number=Sing	2	nmod	_	_
-4	gibt	geben	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	30	ccomp	_	_
-5	mit	mit	ADP	APPR	_	7	case	_	_
-6	tiefer	tief	ADJ	ADJA	Case=Dat|Gender=Fem|Number=Sing	7	amod	_	_
-7	Trauer	Trauer	NOUN	NN	Case=Dat|Gender=Fem|Number=Sing	4	obl	_	_
-8	den	der	DET	ART	Case=Acc|Definite=Def|Gender=Masc|Number=Sing|PronType=Art	9	det	_	_
-9	Tod	Tod	NOUN	NN	Case=Acc|Gender=Masc|Number=Sing	4	obj	_	_
-10	des	der	DET	ART	Case=Gen|Definite=Def|Gender=Masc|Number=Sing|PronType=Art	11	det	_	_
-11	Ministerpräsidenten	Ministerpräsident	NOUN	NN	Case=Gen|Gender=Masc|Number=Sing	9	nmod	_	_
-12	und	und	CCONJ	KON	_	13	cc	_	_
-13	Verteidigungsministers	Verteidigungsminister	NOUN	NN	Case=Gen|Gender=Masc|Number=Sing	11	conj	_	_
-14	Yitzhak	Yitzhak	PROPN	NE	Case=Nom|Gender=Masc|Number=Sing	11	appos	_	_
-15	Rabin	Rabin	PROPN	NE	Case=Nom|Gender=Masc|Number=Sing	14	flat	_	_
-16	bekannt	bekannt	ADV	PTKVZ	_	4	mark	_	SpaceAfter=No
-17	,	,	PUNCT	$,	_	30	punct	_	_
-18	der	der	PRON	PRELS	Case=Nom|Gender=Masc|Number=Sing|PronType=Rel	26	nsubj:pass	_	_
-19	heute	heute	ADV	ADV	_	26	advmod	_	_
-20	von	von	ADP	APPR	_	22	case	_	_
-21	einem	ein	DET	ART	Case=Dat|Definite=Ind|Gender=Masc|Number=Sing|PronType=Art	22	det	_	_
-22	Attentäter	Attentäter	NOUN	NN	Case=Dat|Gender=Masc|Number=Sing	26	obl	_	_
-23	in	in	ADP	APPR	_	24	case	_	_
-24	Tel	Tel	PROPN	NE	_	26	obl	_	_
-25	Aviv	Aviv	PROPN	NE	Case=Dat|Gender=Neut|Number=Sing	24	flat	_	_
-26	ermordet	ermorden	VERB	VVPP	VerbForm=Part	11	acl	_	_
-27	wurde	werden	AUX	VAFIN	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin|Voice=Pass	26	aux:pass	_	SpaceAfter=No
-28	''	''	PUNCT	$(	_	30	punct	_	SpaceAfter=No
-29	,	,	PUNCT	$,	_	30	punct	_	_
-30	teilte	teilen	VERB	VVFIN	Mood=Sub|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	0	root	_	_
-31	ein	ein	DET	ART	Case=Nom|Definite=Ind|Gender=Masc|Number=Sing|PronType=Art	32	det	_	_
-32	Regierungssprecher	Regierungssprecher	NOUN	NN	Case=Nom|Gender=Masc|Number=Sing	30	nsubj	_	_
-33	vor	vor	ADP	APPR	_	35	case	_	_
-34	dem	der	DET	ART	Case=Dat|Definite=Def|Gender=Neut|Number=Sing|PronType=Art	35	det	_	_
-35	Krankenhaus	Krankenhaus	NOUN	NN	Case=Dat|Gender=Neut|Number=Sing	30	obl	_	_
-36	Journalisten	Journalist	NOUN	NN	Case=Dat|Gender=Masc|Number=Sing	30	iobj	_	_
-37	und	und	CCONJ	KON	_	40	cc	_	_
-38	ängstlich	ängstlich	ADV	ADJD	_	39	advmod	_	_
-39	wartenden	wartend	ADJ	ADJA	Case=Dat|Gender=Masc|Number=Plur	40	amod	_	_
-40	Israelis	Israeli	NOUN	NN	Case=Dat|Gender=Masc|Number=Plur	36	conj	_	_
-41	mit	mit	ADP	PTKVZ	_	30	compound:prt	_	SpaceAfter=No
-42	.	.	PUNCT	$.	_	30	punct	_	_
+# text = ``Die Regierung Israels gibt mit tiefer Trauer den Tod des Ministerpräsidenten und Verteidigungsministers Yitzhak Rabin bekannt, der heute von einem Attentäter in Tel Aviv ermordet wurde'', teilte ein Regierungssprecher vor dem Krankenhaus Journalisten und ängstlich wartenden Israelis mit.
+1	``	``	PUNCT	$(	_	2	punct	_	FixTigerDep=Yes|SpaceAfter=No
+2	Die	der	DET	ART	Case=Nom|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	3	det	_	_
+3	Regierung	Regierung	NOUN	NN	Case=Nom|Gender=Fem|Number=Sing	5	nsubj	_	_
+4	Israels	Israel	PROPN	NE	Case=Gen|Gender=Neut|Number=Sing	3	nmod	_	_
+5	gibt	geben	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	31	ccomp	_	_
+6	mit	mit	ADP	APPR	_	8	case	_	_
+7	tiefer	tief	ADJ	ADJA	Case=Dat|Gender=Fem|Number=Sing	8	amod	_	_
+8	Trauer	Trauer	NOUN	NN	Case=Dat|Gender=Fem|Number=Sing	5	obl	_	_
+9	den	der	DET	ART	Case=Acc|Definite=Def|Gender=Masc|Number=Sing|PronType=Art	10	det	_	_
+10	Tod	Tod	NOUN	NN	Case=Acc|Gender=Masc|Number=Sing	5	obj	_	_
+11	des	der	DET	ART	Case=Gen|Definite=Def|Gender=Masc|Number=Sing|PronType=Art	12	det	_	_
+12	Ministerpräsidenten	Ministerpräsident	NOUN	NN	Case=Gen|Gender=Masc|Number=Sing	10	nmod	_	_
+13	und	und	CCONJ	KON	_	14	cc	_	_
+14	Verteidigungsministers	Verteidigungsminister	NOUN	NN	Case=Gen|Gender=Masc|Number=Sing	12	conj	_	_
+15	Yitzhak	Yitzhak	PROPN	NE	Case=Nom|Gender=Masc|Number=Sing	12	appos	_	_
+16	Rabin	Rabin	PROPN	NE	Case=Nom|Gender=Masc|Number=Sing	15	flat	_	_
+17	bekannt	bekannt	ADV	PTKVZ	_	5	mark	_	SpaceAfter=No
+18	,	,	PUNCT	$,	_	31	punct	_	_
+19	der	der	PRON	PRELS	Case=Nom|Gender=Masc|Number=Sing|PronType=Rel	27	nsubj:pass	_	_
+20	heute	heute	ADV	ADV	_	27	advmod	_	_
+21	von	von	ADP	APPR	_	23	case	_	_
+22	einem	ein	DET	ART	Case=Dat|Definite=Ind|Gender=Masc|Number=Sing|PronType=Art	23	det	_	_
+23	Attentäter	Attentäter	NOUN	NN	Case=Dat|Gender=Masc|Number=Sing	27	obl	_	_
+24	in	in	ADP	APPR	_	25	case	_	_
+25	Tel	Tel	PROPN	NE	_	27	obl	_	_
+26	Aviv	Aviv	PROPN	NE	Case=Dat|Gender=Neut|Number=Sing	25	flat	_	_
+27	ermordet	ermorden	VERB	VVPP	VerbForm=Part	12	acl	_	_
+28	wurde	werden	AUX	VAFIN	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin|Voice=Pass	27	aux:pass	_	SpaceAfter=No
+29	''	''	PUNCT	$(	_	31	punct	_	SpaceAfter=No
+30	,	,	PUNCT	$,	_	31	punct	_	_
+31	teilte	teilen	VERB	VVFIN	Mood=Sub|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	0	root	_	_
+32	ein	ein	DET	ART	Case=Nom|Definite=Ind|Gender=Masc|Number=Sing|PronType=Art	33	det	_	_
+33	Regierungssprecher	Regierungssprecher	NOUN	NN	Case=Nom|Gender=Masc|Number=Sing	31	nsubj	_	_
+34	vor	vor	ADP	APPR	_	36	case	_	_
+35	dem	der	DET	ART	Case=Dat|Definite=Def|Gender=Neut|Number=Sing|PronType=Art	36	det	_	_
+36	Krankenhaus	Krankenhaus	NOUN	NN	Case=Dat|Gender=Neut|Number=Sing	31	obl	_	_
+37	Journalisten	Journalist	NOUN	NN	Case=Dat|Gender=Masc|Number=Sing	31	iobj	_	_
+38	und	und	CCONJ	KON	_	41	cc	_	_
+39	ängstlich	ängstlich	ADV	ADJD	_	40	advmod	_	_
+40	wartenden	wartend	ADJ	ADJA	Case=Dat|Gender=Masc|Number=Plur	41	amod	_	_
+41	Israelis	Israeli	NOUN	NN	Case=Dat|Gender=Masc|Number=Plur	37	conj	_	_
+42	mit	mit	ADP	PTKVZ	_	31	compound:prt	_	SpaceAfter=No
+43	.	.	PUNCT	$.	_	31	punct	_	_
 
 # sent_id = dev-s765
-# text = Es war klar, daß er getötet werden würde.
-1	Es	es	PRON	PPER	Case=Nom|Gender=Neut|Number=Sing|Person=3|PronType=Prs	3	nsubj	_	_
-2	war	sein	AUX	VAFIN	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	3	cop	_	_
-3	klar	klar	ADJ	ADJD	_	0	root	_	SpaceAfter=No
-4	,	,	PUNCT	$,	_	3	punct	_	_
-5	daß	daß	SCONJ	KOUS	_	7	mark	_	_
-6	er	er	PRON	PPER	Case=Nom|Gender=Masc|Number=Sing|Person=3|PronType=Prs	7	nsubj:pass	_	_
-7	getötet	töten	VERB	VVPP	VerbForm=Part	3	ccomp	_	_
-8	werden	werden	AUX	VAINF	VerbForm=Inf|Voice=Pass	7	aux:pass	_	_
-9	würde	werden	AUX	VAFIN	Mood=Sub|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	7	aux	_	SpaceAfter=No
-10	.	.	PUNCT	$.	_	3	punct	_	_
+# text = ``Es war klar, daß er getötet werden würde.
+1	``	``	PUNCT	$(	_	2	punct	_	FixTigerDep=Yes|SpaceAfter=No
+2	Es	es	PRON	PPER	Case=Nom|Gender=Neut|Number=Sing|Person=3|PronType=Prs	4	nsubj	_	_
+3	war	sein	AUX	VAFIN	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	4	cop	_	_
+4	klar	klar	ADJ	ADJD	_	0	root	_	SpaceAfter=No
+5	,	,	PUNCT	$,	_	4	punct	_	_
+6	daß	daß	SCONJ	KOUS	_	8	mark	_	_
+7	er	er	PRON	PPER	Case=Nom|Gender=Masc|Number=Sing|Person=3|PronType=Prs	8	nsubj:pass	_	_
+8	getötet	töten	VERB	VVPP	VerbForm=Part	4	ccomp	_	_
+9	werden	werden	AUX	VAINF	VerbForm=Inf|Voice=Pass	8	aux:pass	_	_
+10	würde	werden	AUX	VAFIN	Mood=Sub|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	8	aux	_	SpaceAfter=No
+11	.	.	PUNCT	$.	_	4	punct	_	_
 
 # sent_id = dev-s766
 # text = Und es braucht nur ein paar Leute, um das dann auch auszuführen.
@@ -14169,16 +14299,17 @@
 11	.	.	PUNCT	$.	_	2	punct	_	_
 
 # sent_id = dev-s768
-# text = Ich kann mich nur schwer in Worten ausdrücken.
-1	Ich	ich	PRON	PPER	Case=Nom|Number=Sing|Person=1|PronType=Prs	8	nsubj	_	_
-2	kann	können	AUX	VMFIN	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	8	aux	_	_
-3	mich	ich	PRON	PRF	Case=Acc|Number=Sing|Person=1|PronType=Prs|Reflex=Yes	8	obj	_	_
-4	nur	nur	ADV	ADV	_	5	advmod	_	_
-5	schwer	schwer	ADV	ADJD	_	8	advmod	_	_
-6	in	in	ADP	APPR	_	7	case	_	_
-7	Worten	Wort	NOUN	NN	Case=Dat|Gender=Neut|Number=Plur	8	obl	_	_
-8	ausdrücken	ausdrücken	VERB	VVINF	VerbForm=Inf	0	root	_	SpaceAfter=No
-9	.	.	PUNCT	$.	_	8	punct	_	_
+# text = ``Ich kann mich nur schwer in Worten ausdrücken.
+1	``	``	PUNCT	$(	_	2	punct	_	FixTigerDep=Yes|SpaceAfter=No
+2	Ich	ich	PRON	PPER	Case=Nom|Number=Sing|Person=1|PronType=Prs	9	nsubj	_	_
+3	kann	können	AUX	VMFIN	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	9	aux	_	_
+4	mich	ich	PRON	PRF	Case=Acc|Number=Sing|Person=1|PronType=Prs|Reflex=Yes	9	obj	_	_
+5	nur	nur	ADV	ADV	_	6	advmod	_	_
+6	schwer	schwer	ADV	ADJD	_	9	advmod	_	_
+7	in	in	ADP	APPR	_	8	case	_	_
+8	Worten	Wort	NOUN	NN	Case=Dat|Gender=Neut|Number=Plur	9	obl	_	_
+9	ausdrücken	ausdrücken	VERB	VVINF	VerbForm=Inf	0	root	_	SpaceAfter=No
+10	.	.	PUNCT	$.	_	9	punct	_	_
 
 # sent_id = dev-s769
 # text = Dank der Antibiotika sei eine größere Epidemie nicht zu befürchten.
@@ -14217,125 +14348,129 @@
 18	:	:	PUNCT	$.	_	7	punct	_	_
 
 # sent_id = dev-s771
-# text = Grund ist vor allem Enttäuschung über die traditionellen Parteien, die sich durch Korruption, Mißwirtschaft oder Machtmißbrauch auszeichneten und kaum Antwort auf die drängenden Fragen wie Verelendung und eine sich verschärfende soziale Krise finden.
-1	Grund	Grund	NOUN	NN	Case=Nom|Gender=Masc|Number=Sing	0	root	_	_
-2	ist	sein	AUX	VAFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	1	cop	_	_
-3	vor	vor	ADP	APPR	_	4	case	_	_
-4	allem	alle	PRON	PIS	Case=Dat|Definite=Ind|Gender=Neut|Number=Sing|PronType=Ind	1	nmod	_	_
-5	Enttäuschung	Enttäuschung	NOUN	NN	Case=Nom|Gender=Fem|Number=Sing	1	nsubj	_	_
-6	über	über	ADP	APPR	_	9	case	_	_
-7	die	der	DET	ART	Case=Acc|Definite=Def|Gender=Fem|Number=Plur|PronType=Art	9	det	_	_
-8	traditionellen	traditionell	ADJ	ADJA	Case=Acc|Gender=Fem|Number=Plur	9	amod	_	_
-9	Parteien	Partei	NOUN	NN	Case=Acc|Gender=Fem|Number=Plur	5	nmod	_	SpaceAfter=No
-10	,	,	PUNCT	$,	_	1	punct	_	_
-11	die	der	PRON	PRELS	Case=Nom|Gender=Fem|Number=Plur|PronType=Rel	19	nsubj	_	_
-12	sich	er|es|sie	PRON	PRF	Case=Acc|Number=Plur|Person=3|PronType=Prs|Reflex=Yes	19	obj	_	_
-13	durch	durch	ADP	APPR	_	14	case	_	_
-14	Korruption	Korruption	NOUN	NN	Case=Acc|Gender=Fem|Number=Sing	19	obl	_	SpaceAfter=No
-15	,	,	PUNCT	$,	_	16	punct	_	_
-16	Mißwirtschaft	Mißwirtschaft	NOUN	NN	Case=Acc|Gender=Fem|Number=Sing	14	conj	_	_
-17	oder	oder	CCONJ	KON	_	18	cc	_	_
-18	Machtmißbrauch	Machtmißbrauch	NOUN	NN	Case=Acc|Gender=Masc|Number=Sing	14	conj	_	_
-19	auszeichneten	auszeichnen	VERB	VVFIN	Mood=Ind|Number=Plur|Person=3|Tense=Past|VerbForm=Fin	9	acl	_	_
-20	und	und	CCONJ	KON	_	35	cc	_	_
-21	kaum	kaum	ADV	ADV	_	35	advmod	_	_
-22	Antwort	Antwort	NOUN	NN	Case=Acc|Gender=Fem|Number=Sing	35	obj	_	_
-23	auf	auf	ADP	APPR	_	26	case	_	_
-24	die	der	DET	ART	Case=Acc|Definite=Def|Gender=Fem|Number=Plur|PronType=Art	26	det	_	_
-25	drängenden	drängend	ADJ	ADJA	Case=Acc|Gender=Fem|Number=Plur	26	amod	_	_
-26	Fragen	Frage	NOUN	NN	Case=Acc|Gender=Fem|Number=Plur	22	nmod	_	_
-27	wie	wie	CCONJ	KOKOM	_	28	case	_	_
-28	Verelendung	Verelendung	NOUN	NN	Case=Nom|Gender=Fem|Number=Sing	26	nmod	_	_
-29	und	und	CCONJ	KON	_	34	cc	_	_
-30	eine	ein	DET	ART	Case=Nom|Definite=Ind|Gender=Fem|Number=Sing|PronType=Art	34	det	_	_
-31	sich	er|es|sie	PRON	PRF	Case=Acc|Number=Sing|Person=3|PronType=Prs|Reflex=Yes	32	obj	_	_
-32	verschärfende	verschärfend	ADJ	ADJA	Case=Nom|Gender=Fem|Number=Sing	34	amod	_	_
-33	soziale	sozial	ADJ	ADJA	Case=Nom|Gender=Fem|Number=Sing	34	amod	_	_
-34	Krise	Krise	NOUN	NN	Case=Nom|Gender=Fem|Number=Sing	28	conj	_	_
-35	finden	finden	VERB	VVFIN	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	19	conj	_	SpaceAfter=No
-36	.	.	PUNCT	$.	_	1	punct	_	_
+# text = Der Grund ist vor allem Enttäuschung über die traditionellen Parteien, die sich durch Korruption, Mißwirtschaft oder Machtmißbrauch auszeichneten und kaum Antwort auf die drängenden Fragen wie Verelendung und eine sich verschärfende soziale Krise finden.
+1	Der	der	DET	ART	Case=Nom|Definite=Def|Gender=Masc|Number=Sing|PronType=Art	2	dep	_	FixTigerDep=Yes
+2	Grund	Grund	NOUN	NN	Case=Nom|Gender=Masc|Number=Sing	0	root	_	_
+3	ist	sein	AUX	VAFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	2	cop	_	_
+4	vor	vor	ADP	APPR	_	5	case	_	_
+5	allem	alle	PRON	PIS	Case=Dat|Definite=Ind|Gender=Neut|Number=Sing|PronType=Ind	2	nmod	_	_
+6	Enttäuschung	Enttäuschung	NOUN	NN	Case=Nom|Gender=Fem|Number=Sing	2	nsubj	_	_
+7	über	über	ADP	APPR	_	10	case	_	_
+8	die	der	DET	ART	Case=Acc|Definite=Def|Gender=Fem|Number=Plur|PronType=Art	10	det	_	_
+9	traditionellen	traditionell	ADJ	ADJA	Case=Acc|Gender=Fem|Number=Plur	10	amod	_	_
+10	Parteien	Partei	NOUN	NN	Case=Acc|Gender=Fem|Number=Plur	6	nmod	_	SpaceAfter=No
+11	,	,	PUNCT	$,	_	2	punct	_	_
+12	die	der	PRON	PRELS	Case=Nom|Gender=Fem|Number=Plur|PronType=Rel	20	nsubj	_	_
+13	sich	er|es|sie	PRON	PRF	Case=Acc|Number=Plur|Person=3|PronType=Prs|Reflex=Yes	20	obj	_	_
+14	durch	durch	ADP	APPR	_	15	case	_	_
+15	Korruption	Korruption	NOUN	NN	Case=Acc|Gender=Fem|Number=Sing	20	obl	_	SpaceAfter=No
+16	,	,	PUNCT	$,	_	17	punct	_	_
+17	Mißwirtschaft	Mißwirtschaft	NOUN	NN	Case=Acc|Gender=Fem|Number=Sing	15	conj	_	_
+18	oder	oder	CCONJ	KON	_	19	cc	_	_
+19	Machtmißbrauch	Machtmißbrauch	NOUN	NN	Case=Acc|Gender=Masc|Number=Sing	15	conj	_	_
+20	auszeichneten	auszeichnen	VERB	VVFIN	Mood=Ind|Number=Plur|Person=3|Tense=Past|VerbForm=Fin	10	acl	_	_
+21	und	und	CCONJ	KON	_	36	cc	_	_
+22	kaum	kaum	ADV	ADV	_	36	advmod	_	_
+23	Antwort	Antwort	NOUN	NN	Case=Acc|Gender=Fem|Number=Sing	36	obj	_	_
+24	auf	auf	ADP	APPR	_	27	case	_	_
+25	die	der	DET	ART	Case=Acc|Definite=Def|Gender=Fem|Number=Plur|PronType=Art	27	det	_	_
+26	drängenden	drängend	ADJ	ADJA	Case=Acc|Gender=Fem|Number=Plur	27	amod	_	_
+27	Fragen	Frage	NOUN	NN	Case=Acc|Gender=Fem|Number=Plur	23	nmod	_	_
+28	wie	wie	CCONJ	KOKOM	_	29	case	_	_
+29	Verelendung	Verelendung	NOUN	NN	Case=Nom|Gender=Fem|Number=Sing	27	nmod	_	_
+30	und	und	CCONJ	KON	_	35	cc	_	_
+31	eine	ein	DET	ART	Case=Nom|Definite=Ind|Gender=Fem|Number=Sing|PronType=Art	35	det	_	_
+32	sich	er|es|sie	PRON	PRF	Case=Acc|Number=Sing|Person=3|PronType=Prs|Reflex=Yes	33	obj	_	_
+33	verschärfende	verschärfend	ADJ	ADJA	Case=Nom|Gender=Fem|Number=Sing	35	amod	_	_
+34	soziale	sozial	ADJ	ADJA	Case=Nom|Gender=Fem|Number=Sing	35	amod	_	_
+35	Krise	Krise	NOUN	NN	Case=Nom|Gender=Fem|Number=Sing	29	conj	_	_
+36	finden	finden	VERB	VVFIN	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	20	conj	_	SpaceAfter=No
+37	.	.	PUNCT	$.	_	2	punct	_	_
 
 # sent_id = dev-s772
-# text = Helmut Kohl (CDU) kündigte im Bundestag an, er wolle das vom IG-Metall-Vorsitzenden Klaus Zwickel angebotene ``Bündnis für Arbeit'' prüfen.
-1	Helmut	Helmut	PROPN	NE	Case=Nom|Gender=Masc|Number=Sing	6	nsubj	_	_
-2	Kohl	Kohl	PROPN	NE	Case=Nom|Gender=Masc|Number=Sing	1	flat	_	_
-3	(	(	PUNCT	$(	_	4	punct	_	SpaceAfter=No
-4	CDU	CDU	PROPN	NE	Case=Nom|Gender=Fem|Number=Sing	1	appos	_	SpaceAfter=No
-5	)	)	PUNCT	$(	_	4	punct	_	_
-6	kündigte	kündigen	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	0	root	_	_
-7-8	im	_	_	_	_	_	_	_	_
-7	in	in	ADP	APPR	_	9	case	_	_
-8	dem	der	DET	ART	Case=Dat|Definite=Def|Gender=Masc|Number=Sing|PronType=Art	9	det	_	_
-9	Bundestag	Bundestag	PROPN	NN	Case=Dat|Gender=Masc|Number=Sing	6	obl	_	_
-10	an	an	ADP	PTKVZ	_	6	compound:prt	_	SpaceAfter=No
-11	,	,	PUNCT	$,	_	6	punct	_	_
-12	er	er	PRON	PPER	Case=Nom|Gender=Masc|Number=Sing|Person=3|PronType=Prs	30	nsubj	_	_
-13	wolle	wollen	AUX	VMFIN	Mood=Sub|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	30	aux	_	_
-14	das	der	DET	ART	Case=Acc|Definite=Def|Gender=Neut|Number=Sing|PronType=Art	26	det	_	_
-15-16	vom	_	_	_	_	_	_	_	_
-15	von	von	ADP	APPR	_	17	case	_	_
-16	dem	der	DET	ART	Case=Dat|Definite=Def|Gender=Masc|Number=Sing|PronType=Art	17	det	_	_
-17	IG	IG	PROPN	NN	Case=Dat|Gender=Masc|Number=Sing	19	compound	_	SpaceAfter=No
-18	-	-	PUNCT	$(	_	17	punct	_	SpaceAfter=No
-19	Metall	Metall	PROPN	NN	Case=Dat|Gender=Masc|Number=Sing	21	compound	_	SpaceAfter=No
-20	-	-	PUNCT	$(	_	19	punct	_	SpaceAfter=No
-21	Vorsitzenden	Vorsitzende	NOUN	NN	Case=Dat|Gender=Masc|Number=Sing	24	nmod	_	_
-22	Klaus	Klaus	PROPN	NE	Case=Nom|Gender=Masc|Number=Sing	17	appos	_	_
-23	Zwickel	Zwickel	PROPN	NE	Case=Nom|Gender=Masc|Number=Sing	22	flat	_	_
-24	angebotene	angeboten	ADJ	ADJA	Case=Acc|Gender=Neut|Number=Sing	26	amod	_	_
-25	``	``	PUNCT	$(	_	26	punct	_	SpaceAfter=No
-26	Bündnis	Bündnis	PROPN	NN	Case=Acc|Gender=Neut|Number=Sing	30	obj	_	_
-27	für	für	ADP	APPR	_	28	case	_	_
-28	Arbeit	Arbeit	NOUN	NN	Case=Acc|Gender=Fem|Number=Sing	26	nmod	_	SpaceAfter=No
-29	''	''	PUNCT	$(	_	26	punct	_	_
-30	prüfen	prüfen	VERB	VVINF	VerbForm=Inf	6	ccomp	_	SpaceAfter=No
-31	.	.	PUNCT	$.	_	6	punct	_	_
+# text = Bundeskanzler Helmut Kohl (CDU) kündigte im Bundestag an, er wolle das vom IG-Metall-Vorsitzenden Klaus Zwickel angebotene ``Bündnis für Arbeit'' prüfen.
+1	Bundeskanzler	Bundeskanzler	NOUN	NN	Case=Nom|Gender=Masc|Number=Sing	2	dep	_	FixTigerDep=Yes
+2	Helmut	Helmut	PROPN	NE	Case=Nom|Gender=Masc|Number=Sing	7	nsubj	_	_
+3	Kohl	Kohl	PROPN	NE	Case=Nom|Gender=Masc|Number=Sing	2	flat	_	_
+4	(	(	PUNCT	$(	_	5	punct	_	SpaceAfter=No
+5	CDU	CDU	PROPN	NE	Case=Nom|Gender=Fem|Number=Sing	2	appos	_	SpaceAfter=No
+6	)	)	PUNCT	$(	_	5	punct	_	_
+7	kündigte	kündigen	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	0	root	_	_
+8-9	im	_	_	_	_	_	_	_	_
+8	in	in	ADP	APPR	_	10	case	_	_
+9	dem	der	DET	ART	Case=Dat|Definite=Def|Gender=Masc|Number=Sing|PronType=Art	10	det	_	_
+10	Bundestag	Bundestag	PROPN	NN	Case=Dat|Gender=Masc|Number=Sing	7	obl	_	_
+11	an	an	ADP	PTKVZ	_	7	compound:prt	_	SpaceAfter=No
+12	,	,	PUNCT	$,	_	7	punct	_	_
+13	er	er	PRON	PPER	Case=Nom|Gender=Masc|Number=Sing|Person=3|PronType=Prs	31	nsubj	_	_
+14	wolle	wollen	AUX	VMFIN	Mood=Sub|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	31	aux	_	_
+15	das	der	DET	ART	Case=Acc|Definite=Def|Gender=Neut|Number=Sing|PronType=Art	27	det	_	_
+16-17	vom	_	_	_	_	_	_	_	_
+16	von	von	ADP	APPR	_	18	case	_	_
+17	dem	der	DET	ART	Case=Dat|Definite=Def|Gender=Masc|Number=Sing|PronType=Art	18	det	_	_
+18	IG	IG	PROPN	NN	Case=Dat|Gender=Masc|Number=Sing	20	compound	_	SpaceAfter=No
+19	-	-	PUNCT	$(	_	18	punct	_	SpaceAfter=No
+20	Metall	Metall	PROPN	NN	Case=Dat|Gender=Masc|Number=Sing	22	compound	_	SpaceAfter=No
+21	-	-	PUNCT	$(	_	20	punct	_	SpaceAfter=No
+22	Vorsitzenden	Vorsitzende	NOUN	NN	Case=Dat|Gender=Masc|Number=Sing	25	nmod	_	_
+23	Klaus	Klaus	PROPN	NE	Case=Nom|Gender=Masc|Number=Sing	18	appos	_	_
+24	Zwickel	Zwickel	PROPN	NE	Case=Nom|Gender=Masc|Number=Sing	23	flat	_	_
+25	angebotene	angeboten	ADJ	ADJA	Case=Acc|Gender=Neut|Number=Sing	27	amod	_	_
+26	``	``	PUNCT	$(	_	27	punct	_	SpaceAfter=No
+27	Bündnis	Bündnis	PROPN	NN	Case=Acc|Gender=Neut|Number=Sing	31	obj	_	_
+28	für	für	ADP	APPR	_	29	case	_	_
+29	Arbeit	Arbeit	NOUN	NN	Case=Acc|Gender=Fem|Number=Sing	27	nmod	_	SpaceAfter=No
+30	''	''	PUNCT	$(	_	27	punct	_	_
+31	prüfen	prüfen	VERB	VVINF	VerbForm=Inf	7	ccomp	_	SpaceAfter=No
+32	.	.	PUNCT	$.	_	7	punct	_	_
 
 # sent_id = dev-s773
-# text = Kohl sei er der Ansicht, daß es zu einem vereinten Europa keine Alternative gebe.
-1	Kohl	Kohl	PROPN	NE	Case=Nom|Number=Sing	2	nsubj	_	_
-2	sei	sein	VERB	VAFIN	Mood=Sub|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	0	root	_	_
-3	er	er	PRON	PPER	Case=Nom|Gender=Masc|Number=Sing|Person=3|PronType=Prs	2	dep	_	_
-4	der	der	DET	ART	Case=Gen|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	5	det	_	_
-5	Ansicht	Ansicht	NOUN	NN	Case=Gen|Gender=Fem|Number=Sing	2	iobj	_	SpaceAfter=No
-6	,	,	PUNCT	$,	_	2	punct	_	_
-7	daß	daß	SCONJ	KOUS	_	15	mark	_	_
-8	es	es	PRON	PPER	Case=Nom|Gender=Neut|Number=Sing|Person=3|PronType=Prs	15	nsubj	_	_
-9	zu	zu	ADP	APPR	_	12	case	_	_
-10	einem	ein	DET	ART	Case=Dat|Definite=Ind|Gender=Neut|Number=Sing|PronType=Art	12	det	_	_
-11	vereinten	vereint	ADJ	ADJA	Case=Dat|Gender=Neut|Number=Sing	12	amod	_	_
-12	Europa	Europa	PROPN	NE	Case=Dat|Gender=Neut|Number=Sing	15	obl	_	_
-13	keine	kein	PRON	PIAT	Case=Acc|Definite=Ind|Gender=Fem|Number=Sing|Polarity=Neg|PronType=Neg	14	advmod	_	_
-14	Alternative	Alternative	NOUN	NN	Case=Acc|Gender=Fem|Number=Sing	15	obj	_	_
-15	gebe	geben	VERB	VVFIN	Mood=Sub|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	5	ccomp	_	SpaceAfter=No
-16	.	.	PUNCT	$.	_	2	punct	_	_
+# text = Wie Kohl sei er der Ansicht, daß es zu einem vereinten Europa keine Alternative gebe.
+1	Wie	wie	ADP	KOKOM	_	2	dep	_	FixTigerDep=Yes
+2	Kohl	Kohl	PROPN	NE	Case=Nom|Number=Sing	3	nsubj	_	_
+3	sei	sein	VERB	VAFIN	Mood=Sub|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	0	root	_	_
+4	er	er	PRON	PPER	Case=Nom|Gender=Masc|Number=Sing|Person=3|PronType=Prs	3	dep	_	_
+5	der	der	DET	ART	Case=Gen|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	6	det	_	_
+6	Ansicht	Ansicht	NOUN	NN	Case=Gen|Gender=Fem|Number=Sing	3	iobj	_	SpaceAfter=No
+7	,	,	PUNCT	$,	_	3	punct	_	_
+8	daß	daß	SCONJ	KOUS	_	16	mark	_	_
+9	es	es	PRON	PPER	Case=Nom|Gender=Neut|Number=Sing|Person=3|PronType=Prs	16	nsubj	_	_
+10	zu	zu	ADP	APPR	_	13	case	_	_
+11	einem	ein	DET	ART	Case=Dat|Definite=Ind|Gender=Neut|Number=Sing|PronType=Art	13	det	_	_
+12	vereinten	vereint	ADJ	ADJA	Case=Dat|Gender=Neut|Number=Sing	13	amod	_	_
+13	Europa	Europa	PROPN	NE	Case=Dat|Gender=Neut|Number=Sing	16	obl	_	_
+14	keine	kein	PRON	PIAT	Case=Acc|Definite=Ind|Gender=Fem|Number=Sing|Polarity=Neg|PronType=Neg	15	advmod	_	_
+15	Alternative	Alternative	NOUN	NN	Case=Acc|Gender=Fem|Number=Sing	16	obj	_	_
+16	gebe	geben	VERB	VVFIN	Mood=Sub|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	6	ccomp	_	SpaceAfter=No
+17	.	.	PUNCT	$.	_	3	punct	_	_
 
 # sent_id = dev-s774
-# text = Ich habe den Feuerlöscher leergemacht, aber es war nichts zu machen'', sagte ein Hausbewohner, der das Unglück unverletzt überlebte.
-1	Ich	ich	PRON	PPER	Case=Nom|Number=Sing|Person=1|PronType=Prs	5	nsubj	_	_
-2	habe	haben	AUX	VAFIN	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	5	aux	_	_
-3	den	der	DET	ART	Case=Acc|Definite=Def|Gender=Masc|Number=Sing|PronType=Art	4	det	_	_
-4	Feuerlöscher	Feuerlöscher	NOUN	NN	Case=Acc|Gender=Masc|Number=Sing	5	obj	_	_
-5	leergemacht	leermachen	VERB	VVPP	VerbForm=Part	15	ccomp	_	SpaceAfter=No
-6	,	,	PUNCT	$,	_	15	punct	_	_
-7	aber	aber	CCONJ	KON	_	5	cc	_	_
-8	es	es	PRON	PPER	Case=Nom|Gender=Neut|Number=Sing|Person=3|PronType=Prs	9	expl	_	_
-9	war	sein	AUX	VAFIN	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	5	aux	_	_
-10	nichts	nichts	PRON	PIS	Definite=Ind|Gender=Neut|PronType=Ind	9	nsubj	_	_
-11	zu	zu	PART	PTKZU	_	12	mark	_	_
-12	machen	machen	VERB	VVINF	VerbForm=Inf	9	acl	_	SpaceAfter=No
-13	''	''	PUNCT	$(	_	15	punct	_	SpaceAfter=No
-14	,	,	PUNCT	$,	_	15	punct	_	_
-15	sagte	sagen	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	0	root	_	_
-16	ein	ein	DET	ART	Case=Nom|Definite=Ind|Gender=Masc|Number=Sing|PronType=Art	17	det	_	_
-17	Hausbewohner	Hausbewohner	NOUN	NN	Case=Nom|Gender=Masc|Number=Sing	15	nsubj	_	SpaceAfter=No
-18	,	,	PUNCT	$,	_	15	punct	_	_
-19	der	der	DET	PRELS	Case=Nom|Gender=Masc|Number=Sing|PronType=Rel	23	nsubj	_	_
-20	das	der	DET	ART	Case=Acc|Definite=Def|Gender=Neut|Number=Sing|PronType=Art	21	det	_	_
-21	Unglück	Unglück	NOUN	NN	Case=Acc|Gender=Neut|Number=Sing	23	obj	_	_
-22	unverletzt	unverletzt	ADV	ADJD	_	23	advmod	_	_
-23	überlebte	überleben	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	17	acl	_	SpaceAfter=No
-24	.	.	PUNCT	$.	_	15	punct	_	_
+# text = ``Ich habe den Feuerlöscher leergemacht, aber es war nichts zu machen'', sagte ein Hausbewohner, der das Unglück unverletzt überlebte.
+1	``	``	PUNCT	$(	_	2	punct	_	FixTigerDep=Yes|SpaceAfter=No
+2	Ich	ich	PRON	PPER	Case=Nom|Number=Sing|Person=1|PronType=Prs	6	nsubj	_	_
+3	habe	haben	AUX	VAFIN	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	6	aux	_	_
+4	den	der	DET	ART	Case=Acc|Definite=Def|Gender=Masc|Number=Sing|PronType=Art	5	det	_	_
+5	Feuerlöscher	Feuerlöscher	NOUN	NN	Case=Acc|Gender=Masc|Number=Sing	6	obj	_	_
+6	leergemacht	leermachen	VERB	VVPP	VerbForm=Part	16	ccomp	_	SpaceAfter=No
+7	,	,	PUNCT	$,	_	16	punct	_	_
+8	aber	aber	CCONJ	KON	_	6	cc	_	_
+9	es	es	PRON	PPER	Case=Nom|Gender=Neut|Number=Sing|Person=3|PronType=Prs	10	expl	_	_
+10	war	sein	AUX	VAFIN	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	6	aux	_	_
+11	nichts	nichts	PRON	PIS	Definite=Ind|Gender=Neut|PronType=Ind	10	nsubj	_	_
+12	zu	zu	PART	PTKZU	_	13	mark	_	_
+13	machen	machen	VERB	VVINF	VerbForm=Inf	10	acl	_	SpaceAfter=No
+14	''	''	PUNCT	$(	_	16	punct	_	SpaceAfter=No
+15	,	,	PUNCT	$,	_	16	punct	_	_
+16	sagte	sagen	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	0	root	_	_
+17	ein	ein	DET	ART	Case=Nom|Definite=Ind|Gender=Masc|Number=Sing|PronType=Art	18	det	_	_
+18	Hausbewohner	Hausbewohner	NOUN	NN	Case=Nom|Gender=Masc|Number=Sing	16	nsubj	_	SpaceAfter=No
+19	,	,	PUNCT	$,	_	16	punct	_	_
+20	der	der	DET	PRELS	Case=Nom|Gender=Masc|Number=Sing|PronType=Rel	24	nsubj	_	_
+21	das	der	DET	ART	Case=Acc|Definite=Def|Gender=Neut|Number=Sing|PronType=Art	22	det	_	_
+22	Unglück	Unglück	NOUN	NN	Case=Acc|Gender=Neut|Number=Sing	24	obj	_	_
+23	unverletzt	unverletzt	ADV	ADJD	_	24	advmod	_	_
+24	überlebte	überleben	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	18	acl	_	SpaceAfter=No
+25	.	.	PUNCT	$.	_	16	punct	_	_
 
 # sent_id = dev-s775
 # text = Die Beschwerden richten sich gegen die unzureichende Finanzausstattung der Kommunen bei der vorgeschriebenen Schaffung von Kindergartenplätzen.
@@ -14440,29 +14575,31 @@
 32	.	.	PUNCT	$.	_	18	punct	_	_
 
 # sent_id = dev-s778
-# text = Wir werden dagegen gerichtlich vorgehen'', kündigte die Pressesprecherin an.
-1	Wir	wir	PRON	PPER	Case=Nom|Number=Plur|Person=1|PronType=Prs	5	nsubj	_	_
-2	werden	werden	AUX	VAFIN	Mood=Ind|Number=Plur|Person=1|Tense=Pres|VerbForm=Fin	5	aux	_	_
-3	dagegen	dagegen	ADV	PAV	_	5	advmod	_	_
-4	gerichtlich	gerichtlich	ADV	ADJD	_	5	advmod	_	_
-5	vorgehen	vorgehen	VERB	VVINF	VerbForm=Inf	8	ccomp	_	SpaceAfter=No
-6	''	''	PUNCT	$(	_	8	punct	_	SpaceAfter=No
-7	,	,	PUNCT	$,	_	8	punct	_	_
-8	kündigte	kündigen	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	0	root	_	_
-9	die	der	DET	ART	Case=Nom|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	10	det	_	_
-10	Pressesprecherin	Pressesprecherin	NOUN	NN	Case=Nom|Gender=Fem|Number=Sing	8	nsubj	_	_
-11	an	an	ADP	PTKVZ	_	8	compound:prt	_	SpaceAfter=No
-12	.	.	PUNCT	$.	_	8	punct	_	_
+# text = ``Wir werden dagegen gerichtlich vorgehen'', kündigte die Pressesprecherin an.
+1	``	``	PUNCT	$(	_	2	punct	_	FixTigerDep=Yes|SpaceAfter=No
+2	Wir	wir	PRON	PPER	Case=Nom|Number=Plur|Person=1|PronType=Prs	6	nsubj	_	_
+3	werden	werden	AUX	VAFIN	Mood=Ind|Number=Plur|Person=1|Tense=Pres|VerbForm=Fin	6	aux	_	_
+4	dagegen	dagegen	ADV	PAV	_	6	advmod	_	_
+5	gerichtlich	gerichtlich	ADV	ADJD	_	6	advmod	_	_
+6	vorgehen	vorgehen	VERB	VVINF	VerbForm=Inf	9	ccomp	_	SpaceAfter=No
+7	''	''	PUNCT	$(	_	9	punct	_	SpaceAfter=No
+8	,	,	PUNCT	$,	_	9	punct	_	_
+9	kündigte	kündigen	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	0	root	_	_
+10	die	der	DET	ART	Case=Nom|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	11	det	_	_
+11	Pressesprecherin	Pressesprecherin	NOUN	NN	Case=Nom|Gender=Fem|Number=Sing	9	nsubj	_	_
+12	an	an	ADP	PTKVZ	_	9	compound:prt	_	SpaceAfter=No
+13	.	.	PUNCT	$.	_	9	punct	_	_
 
 # sent_id = dev-s779
-# text = Das hat der Partei genutzt.''
-1	Das	der	PRON	PDS	Case=Nom|Gender=Neut|Number=Sing|PronType=Dem	5	nsubj	_	_
-2	hat	haben	AUX	VAFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	5	aux	_	_
-3	der	der	DET	ART	Case=Dat|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	4	det	_	_
-4	Partei	Partei	NOUN	NN	Case=Dat|Gender=Fem|Number=Sing	5	iobj	_	_
-5	genutzt	nützen	VERB	VVPP	VerbForm=Part	0	root	_	SpaceAfter=No
-6	.	.	PUNCT	$.	_	5	punct	_	SpaceAfter=No
-7	''	''	PUNCT	$(	_	5	punct	_	_
+# text = ``Das hat der Partei genutzt.''
+1	``	``	PUNCT	$(	_	2	punct	_	FixTigerDep=Yes|SpaceAfter=No
+2	Das	der	PRON	PDS	Case=Nom|Gender=Neut|Number=Sing|PronType=Dem	6	nsubj	_	_
+3	hat	haben	AUX	VAFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	6	aux	_	_
+4	der	der	DET	ART	Case=Dat|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	5	det	_	_
+5	Partei	Partei	NOUN	NN	Case=Dat|Gender=Fem|Number=Sing	6	iobj	_	_
+6	genutzt	nützen	VERB	VVPP	VerbForm=Part	0	root	_	SpaceAfter=No
+7	.	.	PUNCT	$.	_	6	punct	_	SpaceAfter=No
+8	''	''	PUNCT	$(	_	6	punct	_	_
 
 # sent_id = dev-s780
 # text = Die New Yorker Börse reagierte bislang nur mit leichten Kursverlusten auf den Bugdetkonflikt in Washington.
@@ -14484,82 +14621,85 @@
 16	.	.	PUNCT	$.	_	5	punct	_	_
 
 # sent_id = dev-s781
-# text = Wenn Rußland den Vertrag vollständig erfüllt, dann wird das Sicherheitssystem des Landes, besonders an den südlichen und nördlichen Flanken vollständig zerstört'', sagte Verteidigungsminister Pawel Gratschow.
-1	Wenn	wenn	SCONJ	KOUS	_	6	mark	_	_
-2	Rußland	Rußland	PROPN	NE	Case=Nom|Gender=Neut|Number=Sing	6	nsubj	_	_
-3	den	der	DET	ART	Case=Acc|Definite=Def|Gender=Masc|Number=Sing|PronType=Art	4	det	_	_
-4	Vertrag	Vertrag	NOUN	NN	Case=Acc|Gender=Masc|Number=Sing	6	obj	_	_
-5	vollständig	vollständig	ADV	ADJD	_	6	advmod	_	_
-6	erfüllt	erfüllen	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	23	advcl	_	SpaceAfter=No
-7	,	,	PUNCT	$,	_	26	punct	_	_
-8	dann	dann	ADV	ADV	_	23	advmod	_	_
-9	wird	werden	AUX	VAFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	23	aux:pass	_	_
-10	das	der	DET	ART	Case=Nom|Definite=Def|Gender=Neut|Number=Sing|PronType=Art	11	det	_	_
-11	Sicherheitssystem	Sicherheitssystem	NOUN	NN	Case=Nom|Gender=Neut|Number=Sing	23	nsubj:pass	_	_
-12	des	der	DET	ART	Case=Gen|Definite=Def|Gender=Neut|Number=Sing|PronType=Art	13	det	_	_
-13	Landes	Land	NOUN	NN	Case=Gen|Gender=Neut|Number=Sing	11	nmod	_	SpaceAfter=No
-14	,	,	PUNCT	$,	_	26	punct	_	_
-15	besonders	besonders	ADV	ADV	_	21	advmod	_	_
-16	an	an	ADP	APPR	_	21	case	_	_
-17	den	der	DET	ART	Case=Dat|Definite=Def|Gender=Fem|Number=Plur|PronType=Art	21	det	_	_
-18	südlichen	südlich	ADJ	ADJA	Case=Dat|Gender=Fem|Number=Plur	21	amod	_	_
-19	und	und	CCONJ	KON	_	20	cc	_	_
-20	nördlichen	nördlich	ADJ	ADJA	Case=Dat|Gender=Fem|Number=Plur	18	conj	_	_
-21	Flanken	Flanke	NOUN	NN	Case=Dat|Gender=Fem|Number=Plur	23	obl	_	_
-22	vollständig	vollständig	ADV	ADJD	_	23	advmod	_	_
-23	zerstört	zerstören	VERB	VVPP	VerbForm=Part	26	ccomp	_	SpaceAfter=No
-24	''	''	PUNCT	$(	_	26	punct	_	SpaceAfter=No
-25	,	,	PUNCT	$,	_	26	punct	_	_
-26	sagte	sagen	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	0	root	_	_
-27	Verteidigungsminister	Verteidigungsminister	NOUN	NN	Case=Nom|Gender=Masc|Number=Sing	26	nsubj	_	_
-28	Pawel	Pawel	PROPN	NE	Case=Nom|Gender=Masc|Number=Sing	27	appos	_	_
-29	Gratschow	Gratschow	PROPN	NE	Case=Nom|Gender=Masc|Number=Sing	28	flat	_	SpaceAfter=No
-30	.	.	PUNCT	$.	_	26	punct	_	_
+# text = ``Wenn Rußland den Vertrag vollständig erfüllt, dann wird das Sicherheitssystem des Landes, besonders an den südlichen und nördlichen Flanken vollständig zerstört'', sagte Verteidigungsminister Pawel Gratschow.
+1	``	``	PUNCT	$(	_	2	punct	_	FixTigerDep=Yes|SpaceAfter=No
+2	Wenn	wenn	SCONJ	KOUS	_	7	mark	_	_
+3	Rußland	Rußland	PROPN	NE	Case=Nom|Gender=Neut|Number=Sing	7	nsubj	_	_
+4	den	der	DET	ART	Case=Acc|Definite=Def|Gender=Masc|Number=Sing|PronType=Art	5	det	_	_
+5	Vertrag	Vertrag	NOUN	NN	Case=Acc|Gender=Masc|Number=Sing	7	obj	_	_
+6	vollständig	vollständig	ADV	ADJD	_	7	advmod	_	_
+7	erfüllt	erfüllen	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	24	advcl	_	SpaceAfter=No
+8	,	,	PUNCT	$,	_	27	punct	_	_
+9	dann	dann	ADV	ADV	_	24	advmod	_	_
+10	wird	werden	AUX	VAFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	24	aux:pass	_	_
+11	das	der	DET	ART	Case=Nom|Definite=Def|Gender=Neut|Number=Sing|PronType=Art	12	det	_	_
+12	Sicherheitssystem	Sicherheitssystem	NOUN	NN	Case=Nom|Gender=Neut|Number=Sing	24	nsubj:pass	_	_
+13	des	der	DET	ART	Case=Gen|Definite=Def|Gender=Neut|Number=Sing|PronType=Art	14	det	_	_
+14	Landes	Land	NOUN	NN	Case=Gen|Gender=Neut|Number=Sing	12	nmod	_	SpaceAfter=No
+15	,	,	PUNCT	$,	_	27	punct	_	_
+16	besonders	besonders	ADV	ADV	_	22	advmod	_	_
+17	an	an	ADP	APPR	_	22	case	_	_
+18	den	der	DET	ART	Case=Dat|Definite=Def|Gender=Fem|Number=Plur|PronType=Art	22	det	_	_
+19	südlichen	südlich	ADJ	ADJA	Case=Dat|Gender=Fem|Number=Plur	22	amod	_	_
+20	und	und	CCONJ	KON	_	21	cc	_	_
+21	nördlichen	nördlich	ADJ	ADJA	Case=Dat|Gender=Fem|Number=Plur	19	conj	_	_
+22	Flanken	Flanke	NOUN	NN	Case=Dat|Gender=Fem|Number=Plur	24	obl	_	_
+23	vollständig	vollständig	ADV	ADJD	_	24	advmod	_	_
+24	zerstört	zerstören	VERB	VVPP	VerbForm=Part	27	ccomp	_	SpaceAfter=No
+25	''	''	PUNCT	$(	_	27	punct	_	SpaceAfter=No
+26	,	,	PUNCT	$,	_	27	punct	_	_
+27	sagte	sagen	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	0	root	_	_
+28	Verteidigungsminister	Verteidigungsminister	NOUN	NN	Case=Nom|Gender=Masc|Number=Sing	27	nsubj	_	_
+29	Pawel	Pawel	PROPN	NE	Case=Nom|Gender=Masc|Number=Sing	28	appos	_	_
+30	Gratschow	Gratschow	PROPN	NE	Case=Nom|Gender=Masc|Number=Sing	29	flat	_	SpaceAfter=No
+31	.	.	PUNCT	$.	_	27	punct	_	_
 
 # sent_id = dev-s782
-# text = Aber die Bundesbank ist natürlich immer für eine Überraschung gut'', hieß es bei einer Bank.
-1	Aber	aber	CCONJ	KON	_	10	cc	_	_
-2	die	der	DET	ART	Case=Nom|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	3	det	_	_
-3	Bundesbank	Bundesbank	PROPN	NN	Case=Nom|Gender=Fem|Number=Sing	10	nsubj	_	_
-4	ist	sein	AUX	VAFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	10	cop	_	_
-5	natürlich	natürlich	ADV	ADV	_	10	advmod	_	_
-6	immer	immer	ADV	ADV	_	10	advmod	_	_
-7	für	für	ADP	APPR	_	9	case	_	_
-8	eine	ein	DET	ART	Case=Acc|Definite=Ind|Gender=Fem|Number=Sing|PronType=Art	9	det	_	_
-9	Überraschung	Überraschung	NOUN	NN	Case=Acc|Gender=Fem|Number=Sing	10	nmod	_	_
-10	gut	gut	ADJ	ADJD	_	13	ccomp	_	SpaceAfter=No
-11	''	''	PUNCT	$(	_	13	punct	_	SpaceAfter=No
-12	,	,	PUNCT	$,	_	13	punct	_	_
-13	hieß	heißen	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	0	root	_	_
-14	es	es	PRON	PPER	Case=Nom|Gender=Neut|Number=Sing|Person=3|PronType=Prs	13	nsubj	_	_
-15	bei	bei	ADP	APPR	_	17	case	_	_
-16	einer	ein	DET	ART	Case=Dat|Definite=Ind|Gender=Fem|Number=Sing|PronType=Art	17	det	_	_
-17	Bank	Bank	NOUN	NN	Case=Dat|Gender=Fem|Number=Sing	13	obl	_	SpaceAfter=No
-18	.	.	PUNCT	$.	_	13	punct	_	_
+# text = ``Aber die Bundesbank ist natürlich immer für eine Überraschung gut'', hieß es bei einer Bank.
+1	``	``	PUNCT	$(	_	2	punct	_	FixTigerDep=Yes|SpaceAfter=No
+2	Aber	aber	CCONJ	KON	_	11	cc	_	_
+3	die	der	DET	ART	Case=Nom|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	4	det	_	_
+4	Bundesbank	Bundesbank	PROPN	NN	Case=Nom|Gender=Fem|Number=Sing	11	nsubj	_	_
+5	ist	sein	AUX	VAFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	11	cop	_	_
+6	natürlich	natürlich	ADV	ADV	_	11	advmod	_	_
+7	immer	immer	ADV	ADV	_	11	advmod	_	_
+8	für	für	ADP	APPR	_	10	case	_	_
+9	eine	ein	DET	ART	Case=Acc|Definite=Ind|Gender=Fem|Number=Sing|PronType=Art	10	det	_	_
+10	Überraschung	Überraschung	NOUN	NN	Case=Acc|Gender=Fem|Number=Sing	11	nmod	_	_
+11	gut	gut	ADJ	ADJD	_	14	ccomp	_	SpaceAfter=No
+12	''	''	PUNCT	$(	_	14	punct	_	SpaceAfter=No
+13	,	,	PUNCT	$,	_	14	punct	_	_
+14	hieß	heißen	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	0	root	_	_
+15	es	es	PRON	PPER	Case=Nom|Gender=Neut|Number=Sing|Person=3|PronType=Prs	14	nsubj	_	_
+16	bei	bei	ADP	APPR	_	18	case	_	_
+17	einer	ein	DET	ART	Case=Dat|Definite=Ind|Gender=Fem|Number=Sing|PronType=Art	18	det	_	_
+18	Bank	Bank	NOUN	NN	Case=Dat|Gender=Fem|Number=Sing	14	obl	_	SpaceAfter=No
+19	.	.	PUNCT	$.	_	14	punct	_	_
 
 # sent_id = dev-s783
-# text = Wir wissen, daß Aufklärung nicht so schnell zu erreichen ist, wie wir das vor zwanzig Jahren gedacht haben;
-1	Wir	wir	PRON	PPER	Case=Nom|Number=Plur|Person=1|PronType=Prs	2	nsubj	_	_
-2	wissen	wissen	VERB	VVFIN	Mood=Ind|Number=Plur|Person=1|Tense=Pres|VerbForm=Fin	0	root	_	SpaceAfter=No
-3	,	,	PUNCT	$,	_	2	punct	_	_
-4	daß	daß	SCONJ	KOUS	_	11	mark	_	_
-5	Aufklärung	Aufklärung	NOUN	NN	Case=Nom|Gender=Fem|Number=Sing	11	nsubj	_	_
-6	nicht	nicht	PART	PTKNEG	Polarity=Neg	7	advmod	_	_
-7	so	so	ADV	ADV	_	8	advmod	_	_
-8	schnell	schnell	ADV	ADJD	_	11	advmod	_	_
-9	zu	zu	PART	PTKZU	_	10	mark	_	_
-10	erreichen	erreichen	VERB	VVINF	VerbForm=Inf	11	ccomp	_	_
-11	ist	sein	VERB	VAFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	2	ccomp	_	SpaceAfter=No
-12	,	,	PUNCT	$,	_	2	punct	_	_
-13	wie	wie	SCONJ	KOKOM	_	19	mark	_	_
-14	wir	wir	PRON	PPER	Case=Nom|Number=Plur|Person=1|PronType=Prs	19	nsubj	_	_
-15	das	der	PRON	PDS	Case=Acc|Gender=Neut|Number=Sing|PronType=Dem	19	obj	_	_
-16	vor	vor	ADP	APPR	_	18	case	_	_
-17	zwanzig	zwanzig	NUM	CARD	NumType=Card	18	nummod	_	_
-18	Jahren	Jahr	NOUN	NN	Case=Dat|Gender=Neut|Number=Plur	19	obl	_	_
-19	gedacht	denken	VERB	VVPP	VerbForm=Part	11	advcl	_	_
-20	haben	haben	AUX	VAFIN	Mood=Ind|Number=Plur|Person=1|Tense=Pres|VerbForm=Fin	19	aux	_	SpaceAfter=No
-21	;	;	PUNCT	$.	_	2	punct	_	_
+# text = ``Wir wissen, daß Aufklärung nicht so schnell zu erreichen ist, wie wir das vor zwanzig Jahren gedacht haben;
+1	``	``	PUNCT	$(	_	2	punct	_	FixTigerDep=Yes|SpaceAfter=No
+2	Wir	wir	PRON	PPER	Case=Nom|Number=Plur|Person=1|PronType=Prs	3	nsubj	_	_
+3	wissen	wissen	VERB	VVFIN	Mood=Ind|Number=Plur|Person=1|Tense=Pres|VerbForm=Fin	0	root	_	SpaceAfter=No
+4	,	,	PUNCT	$,	_	3	punct	_	_
+5	daß	daß	SCONJ	KOUS	_	12	mark	_	_
+6	Aufklärung	Aufklärung	NOUN	NN	Case=Nom|Gender=Fem|Number=Sing	12	nsubj	_	_
+7	nicht	nicht	PART	PTKNEG	Polarity=Neg	8	advmod	_	_
+8	so	so	ADV	ADV	_	9	advmod	_	_
+9	schnell	schnell	ADV	ADJD	_	12	advmod	_	_
+10	zu	zu	PART	PTKZU	_	11	mark	_	_
+11	erreichen	erreichen	VERB	VVINF	VerbForm=Inf	12	ccomp	_	_
+12	ist	sein	VERB	VAFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	3	ccomp	_	SpaceAfter=No
+13	,	,	PUNCT	$,	_	3	punct	_	_
+14	wie	wie	SCONJ	KOKOM	_	20	mark	_	_
+15	wir	wir	PRON	PPER	Case=Nom|Number=Plur|Person=1|PronType=Prs	20	nsubj	_	_
+16	das	der	PRON	PDS	Case=Acc|Gender=Neut|Number=Sing|PronType=Dem	20	obj	_	_
+17	vor	vor	ADP	APPR	_	19	case	_	_
+18	zwanzig	zwanzig	NUM	CARD	NumType=Card	19	nummod	_	_
+19	Jahren	Jahr	NOUN	NN	Case=Dat|Gender=Neut|Number=Plur	20	obl	_	_
+20	gedacht	denken	VERB	VVPP	VerbForm=Part	12	advcl	_	_
+21	haben	haben	AUX	VAFIN	Mood=Ind|Number=Plur|Person=1|Tense=Pres|VerbForm=Fin	20	aux	_	SpaceAfter=No
+22	;	;	PUNCT	$.	_	3	punct	_	_
 
 # sent_id = dev-s784
 # text = Die Tierversuche hätten ergeben, daß Tiere, deren tägliche Futterrationen um die Hälfte reduziert wurden, eine erhöhte Melatoninkonzentration aufwiesen.
@@ -14587,75 +14727,79 @@
 22	.	.	PUNCT	$.	_	4	punct	_	_
 
 # sent_id = dev-s785
-# text = Naumann wurde erstmals konkret:
-1	Naumann	Naumann	PROPN	NE	Case=Nom|Gender=Masc|Number=Sing	4	nsubj	_	_
-2	wurde	werden	AUX	VAFIN	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin|Voice=Pass	4	cop	_	_
-3	erstmals	erstmals	ADV	ADV	_	4	advmod	_	_
-4	konkret	konkret	ADJ	ADJD	_	0	root	_	SpaceAfter=No
-5	:	:	PUNCT	$.	_	4	punct	_	_
+# text = Generalinspekteur Naumann wurde erstmals konkret:
+1	Generalinspekteur	Generalinspekteur	NOUN	NN	Case=Nom|Gender=Masc|Number=Sing	2	dep	_	FixTigerDep=Yes
+2	Naumann	Naumann	PROPN	NE	Case=Nom|Gender=Masc|Number=Sing	5	nsubj	_	_
+3	wurde	werden	AUX	VAFIN	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin|Voice=Pass	5	cop	_	_
+4	erstmals	erstmals	ADV	ADV	_	5	advmod	_	_
+5	konkret	konkret	ADJ	ADJD	_	0	root	_	SpaceAfter=No
+6	:	:	PUNCT	$.	_	5	punct	_	_
 
 # sent_id = dev-s786
-# text = Generalsekretär Bernd Protzner betonte, der Machtwechsel an der SPD-Spitze stelle ``einen personellen und inhaltlichen Linksruck dar''.
-1	Generalsekretär	Generalsekretär	NOUN	NN	Case=Nom|Gender=Masc|Number=Sing	4	nsubj	_	_
-2	Bernd	Bernd	PROPN	NE	Case=Nom|Gender=Masc|Number=Sing	1	appos	_	_
-3	Protzner	Protzner	PROPN	NE	Case=Nom|Gender=Masc|Number=Sing	2	flat	_	_
-4	betonte	betonen	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	0	root	_	SpaceAfter=No
-5	,	,	PUNCT	$,	_	4	punct	_	_
-6	der	der	DET	ART	Case=Nom|Definite=Def|Gender=Masc|Number=Sing|PronType=Art	7	det	_	_
-7	Machtwechsel	Machtwechsel	NOUN	NN	Case=Nom|Gender=Masc|Number=Sing	13	nsubj	_	_
-8	an	an	ADP	APPR	_	10	case	_	_
-9	der	der	DET	ART	Case=Dat|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	10	det	_	_
-10	SPD	SPD	PROPN	NN	Case=Dat|Gender=Fem|Number=Sing	12	compound	_	SpaceAfter=No
-11	-	-	PUNCT	$(	_	10	punct	_	SpaceAfter=No
-12	Spitze	Spitze	NOUN	NN	Case=Dat|Gender=Fem|Number=Sing	7	nmod	_	_
-13	stelle	stellen	VERB	VVFIN	Mood=Sub|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	4	ccomp	_	_
-14	``	``	PUNCT	$(	_	19	punct	_	SpaceAfter=No
-15	einen	ein	DET	ART	Case=Acc|Definite=Ind|Gender=Masc|Number=Sing|PronType=Art	19	det	_	_
-16	personellen	personell	ADJ	ADJA	Case=Acc|Gender=Masc|Number=Sing	19	amod	_	_
-17	und	und	CCONJ	KON	_	18	cc	_	_
-18	inhaltlichen	inhaltlich	ADJ	ADJA	Case=Acc|Gender=Masc|Number=Sing	16	conj	_	_
-19	Linksruck	Linksruck	NOUN	NN	Case=Acc|Gender=Masc|Number=Sing	13	obj	_	_
-20	dar	dar	ADV	PTKVZ	_	13	compound:prt	_	SpaceAfter=No
-21	''	''	PUNCT	$(	_	19	punct	_	SpaceAfter=No
-22	.	.	PUNCT	$.	_	4	punct	_	_
+# text = CSU-Generalsekretär Bernd Protzner betonte, der Machtwechsel an der SPD-Spitze stelle ``einen personellen und inhaltlichen Linksruck dar''.
+1	CSU	CSU	NOUN	NN	Case=Nom|Gender=Masc|Number=Sing	3	compound	_	SpaceAfter=No
+2	-	-	PUNCT	_	_	3	punct	_	SpaceAfter=No
+3	Generalsekretär	Generalsekretär	NOUN	NN	Case=Nom|Gender=Masc|Number=Sing	6	nsubj	_	_
+4	Bernd	Bernd	PROPN	NE	Case=Nom|Gender=Masc|Number=Sing	1	appos	_	_
+5	Protzner	Protzner	PROPN	NE	Case=Nom|Gender=Masc|Number=Sing	4	flat	_	_
+6	betonte	betonen	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	0	root	_	SpaceAfter=No
+7	,	,	PUNCT	$,	_	6	punct	_	_
+8	der	der	DET	ART	Case=Nom|Definite=Def|Gender=Masc|Number=Sing|PronType=Art	9	det	_	_
+9	Machtwechsel	Machtwechsel	NOUN	NN	Case=Nom|Gender=Masc|Number=Sing	15	nsubj	_	_
+10	an	an	ADP	APPR	_	12	case	_	_
+11	der	der	DET	ART	Case=Dat|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	12	det	_	_
+12	SPD	SPD	PROPN	NN	Case=Dat|Gender=Fem|Number=Sing	14	compound	_	SpaceAfter=No
+13	-	-	PUNCT	$(	_	12	punct	_	SpaceAfter=No
+14	Spitze	Spitze	NOUN	NN	Case=Dat|Gender=Fem|Number=Sing	9	nmod	_	_
+15	stelle	stellen	VERB	VVFIN	Mood=Sub|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	6	ccomp	_	_
+16	``	``	PUNCT	$(	_	21	punct	_	SpaceAfter=No
+17	einen	ein	DET	ART	Case=Acc|Definite=Ind|Gender=Masc|Number=Sing|PronType=Art	21	det	_	_
+18	personellen	personell	ADJ	ADJA	Case=Acc|Gender=Masc|Number=Sing	21	amod	_	_
+19	und	und	CCONJ	KON	_	20	cc	_	_
+20	inhaltlichen	inhaltlich	ADJ	ADJA	Case=Acc|Gender=Masc|Number=Sing	18	conj	_	_
+21	Linksruck	Linksruck	NOUN	NN	Case=Acc|Gender=Masc|Number=Sing	15	obj	_	_
+22	dar	dar	ADV	PTKVZ	_	15	compound:prt	_	SpaceAfter=No
+23	''	''	PUNCT	$(	_	21	punct	_	SpaceAfter=No
+24	.	.	PUNCT	$.	_	6	punct	_	_
 
 # sent_id = dev-s787
-# text = Lennons zänkische Witwe Yoko Ono, die jahrelang mit Paul McCartney über Copyrights gestritten hatte, überreichte den ``Fab Three'' das unvollständige Archivmaterial, das bereits auf illegalen Raubpressungen unter Fans kursierte.
-1	Lennons	Lennons	PROPN	NE	Case=Gen|Number=Sing	3	nmod	_	_
-2	zänkische	zänkisch	ADJ	ADJA	Case=Nom|Gender=Fem|Number=Sing	3	amod	_	_
-3	Witwe	Witwe	NOUN	NN	Case=Nom|Gender=Fem|Number=Sing	17	nsubj	_	_
-4	Yoko	Yoko	PROPN	NE	Case=Nom|Gender=Fem|Number=Sing	3	appos	_	_
-5	Ono	Ono	PROPN	NE	Case=Nom|Gender=Fem|Number=Sing	4	flat	_	SpaceAfter=No
-6	,	,	PUNCT	$,	_	17	punct	_	_
-7	die	der	DET	PRELS	Case=Nom|Gender=Fem|Number=Sing|PronType=Rel	14	det	_	_
-8	jahrelang	jahrelang	ADV	ADJD	_	14	advmod	_	_
-9	mit	mit	ADP	APPR	_	10	case	_	_
-10	Paul	Paul	PROPN	NE	Case=Nom|Gender=Masc|Number=Sing	14	obl	_	_
-11	McCartney	McCartney	PROPN	NE	Case=Dat|Gender=Masc|Number=Sing	10	flat	_	_
-12	über	über	ADP	APPR	_	13	case	_	_
-13	Copyrights	Copyright	NOUN	NN	Case=Acc|Gender=Neut|Number=Plur	14	obl	_	_
-14	gestritten	streiten	VERB	VVPP	VerbForm=Part	3	acl	_	_
-15	hatte	haben	AUX	VAFIN	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	14	aux	_	SpaceAfter=No
-16	,	,	PUNCT	$,	_	17	punct	_	_
-17	überreichte	überreichen	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	0	root	_	_
-18	den	der	DET	ART	Case=Dat|Definite=Def|Number=Plur|PronType=Art	20	det	_	_
-19	``	``	PUNCT	$(	_	20	punct	_	SpaceAfter=No
-20	Fab	Fab	PROPN	NE	_	17	iobj	_	_
-21	Three	Three	PROPN	NE	Case=Dat|Number=Plur	20	flat	_	SpaceAfter=No
-22	''	''	PUNCT	$(	_	20	punct	_	_
-23	das	der	DET	ART	Case=Acc|Definite=Def|Gender=Neut|Number=Sing|PronType=Art	25	det	_	_
-24	unvollständige	unvollständig	ADJ	ADJA	Case=Acc|Gender=Neut|Number=Sing	25	amod	_	_
-25	Archivmaterial	Archivmaterial	NOUN	NN	Case=Acc|Gender=Neut|Number=Sing	17	obj	_	SpaceAfter=No
-26	,	,	PUNCT	$,	_	17	punct	_	_
-27	das	der	PRON	PRELS	Case=Nom|Gender=Neut|Number=Sing|PronType=Rel	34	nsubj	_	_
-28	bereits	bereits	ADV	ADV	_	34	advmod	_	_
-29	auf	auf	ADP	APPR	_	31	case	_	_
-30	illegalen	illegal	ADJ	ADJA	Case=Dat|Gender=Fem|Number=Plur	31	amod	_	_
-31	Raubpressungen	Raubpressung	NOUN	NN	Case=Dat|Gender=Fem|Number=Plur	34	obl	_	_
-32	unter	unter	ADP	APPR	_	33	case	_	_
-33	Fans	Fan	NOUN	NN	Case=Dat|Gender=Masc|Number=Plur	34	obl	_	_
-34	kursierte	kursieren	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	25	acl	_	SpaceAfter=No
-35	.	.	PUNCT	$.	_	17	punct	_	_
+# text = Ausgerechnet Lennons zänkische Witwe Yoko Ono, die jahrelang mit Paul McCartney über Copyrights gestritten hatte, überreichte den ``Fab Three'' das unvollständige Archivmaterial, das bereits auf illegalen Raubpressungen unter Fans kursierte.
+1	Ausgerechnet	ausgerechnet	ADV	ADV	_	2	dep	_	FixTigerDep=Yes
+2	Lennons	Lennon	PROPN	NE	Case=Gen|Number=Sing	4	nmod	_	_
+3	zänkische	zänkisch	ADJ	ADJA	Case=Nom|Gender=Fem|Number=Sing	4	amod	_	_
+4	Witwe	Witwe	NOUN	NN	Case=Nom|Gender=Fem|Number=Sing	18	nsubj	_	_
+5	Yoko	Yoko	PROPN	NE	Case=Nom|Gender=Fem|Number=Sing	4	appos	_	_
+6	Ono	Ono	PROPN	NE	Case=Nom|Gender=Fem|Number=Sing	5	flat	_	SpaceAfter=No
+7	,	,	PUNCT	$,	_	18	punct	_	_
+8	die	der	DET	PRELS	Case=Nom|Gender=Fem|Number=Sing|PronType=Rel	15	det	_	_
+9	jahrelang	jahrelang	ADV	ADJD	_	15	advmod	_	_
+10	mit	mit	ADP	APPR	_	11	case	_	_
+11	Paul	Paul	PROPN	NE	Case=Nom|Gender=Masc|Number=Sing	15	obl	_	_
+12	McCartney	McCartney	PROPN	NE	Case=Dat|Gender=Masc|Number=Sing	11	flat	_	_
+13	über	über	ADP	APPR	_	14	case	_	_
+14	Copyrights	Copyright	NOUN	NN	Case=Acc|Gender=Neut|Number=Plur	15	obl	_	_
+15	gestritten	streiten	VERB	VVPP	VerbForm=Part	4	acl	_	_
+16	hatte	haben	AUX	VAFIN	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	15	aux	_	SpaceAfter=No
+17	,	,	PUNCT	$,	_	18	punct	_	_
+18	überreichte	überreichen	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	0	root	_	_
+19	den	der	DET	ART	Case=Dat|Definite=Def|Number=Plur|PronType=Art	21	det	_	_
+20	``	``	PUNCT	$(	_	21	punct	_	SpaceAfter=No
+21	Fab	Fab	PROPN	NE	_	18	iobj	_	_
+22	Three	Three	PROPN	NE	Case=Dat|Number=Plur	21	flat	_	SpaceAfter=No
+23	''	''	PUNCT	$(	_	21	punct	_	_
+24	das	der	DET	ART	Case=Acc|Definite=Def|Gender=Neut|Number=Sing|PronType=Art	26	det	_	_
+25	unvollständige	unvollständig	ADJ	ADJA	Case=Acc|Gender=Neut|Number=Sing	26	amod	_	_
+26	Archivmaterial	Archivmaterial	NOUN	NN	Case=Acc|Gender=Neut|Number=Sing	18	obj	_	SpaceAfter=No
+27	,	,	PUNCT	$,	_	18	punct	_	_
+28	das	der	PRON	PRELS	Case=Nom|Gender=Neut|Number=Sing|PronType=Rel	35	nsubj	_	_
+29	bereits	bereits	ADV	ADV	_	35	advmod	_	_
+30	auf	auf	ADP	APPR	_	32	case	_	_
+31	illegalen	illegal	ADJ	ADJA	Case=Dat|Gender=Fem|Number=Plur	32	amod	_	_
+32	Raubpressungen	Raubpressung	NOUN	NN	Case=Dat|Gender=Fem|Number=Plur	35	obl	_	_
+33	unter	unter	ADP	APPR	_	34	case	_	_
+34	Fans	Fan	NOUN	NN	Case=Dat|Gender=Masc|Number=Plur	35	obl	_	_
+35	kursierte	kursieren	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	26	acl	_	SpaceAfter=No
+36	.	.	PUNCT	$.	_	18	punct	_	_
 
 # sent_id = dev-s788
 # text = Die TV-Werkschau kommt 1996 auch als Video auf den Markt.
@@ -14698,43 +14842,45 @@
 20	.	.	PUNCT	$.	_	19	punct	_	_
 
 # sent_id = dev-s790
-# text = Dazu besteht keine wirtschaftliche Notwendigkeit, man will in Stuttgart die AEG einfach nicht mehr.''
-1	Dazu	Dazu	ADV	PAV	_	2	advmod	_	_
-2	besteht	bestehen	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	0	root	_	_
-3	keine	kein	PRON	PIAT	Case=Nom|Definite=Ind|Gender=Fem|Number=Sing|Polarity=Neg|PronType=Neg	5	advmod	_	_
-4	wirtschaftliche	wirtschaftlich	ADJ	ADJA	Case=Nom|Gender=Fem|Number=Sing	5	amod	_	_
-5	Notwendigkeit	Notwendigkeit	NOUN	NN	Case=Nom|Gender=Fem|Number=Sing	2	nsubj	_	SpaceAfter=No
-6	,	,	PUNCT	$,	_	2	punct	_	_
-7	man	man	PRON	PIS	Case=Nom|Definite=Ind|Number=Sing|PronType=Ind	8	nsubj	_	_
-8	will	wollen	VERB	VMFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	2	parataxis	_	_
-9	in	in	ADP	APPR	_	10	case	_	_
-10	Stuttgart	Stuttgart	PROPN	NE	Case=Dat|Gender=Neut|Number=Sing	8	obl	_	_
-11	die	der	DET	ART	Case=Acc|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	12	det	_	_
-12	AEG	AEG	PROPN	NE	Case=Acc|Gender=Fem|Number=Sing	8	obj	_	_
-13	einfach	einfach	ADV	ADV	_	14	advmod	_	_
-14	nicht	nicht	PART	PTKNEG	Polarity=Neg	15	advmod	_	_
-15	mehr	mehr	ADV	ADV	_	8	advmod	_	SpaceAfter=No
-16	.	.	PUNCT	$.	_	2	punct	_	SpaceAfter=No
-17	''	''	PUNCT	$(	_	2	punct	_	_
+# text = ``Dazu besteht keine wirtschaftliche Notwendigkeit, man will in Stuttgart die AEG einfach nicht mehr.''
+1	``	``	PUNCT	$(	_	2	punct	_	FixTigerDep=Yes|SpaceAfter=No
+2	Dazu	Dazu	ADV	PAV	_	3	advmod	_	_
+3	besteht	bestehen	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	0	root	_	_
+4	keine	kein	PRON	PIAT	Case=Nom|Definite=Ind|Gender=Fem|Number=Sing|Polarity=Neg|PronType=Neg	6	advmod	_	_
+5	wirtschaftliche	wirtschaftlich	ADJ	ADJA	Case=Nom|Gender=Fem|Number=Sing	6	amod	_	_
+6	Notwendigkeit	Notwendigkeit	NOUN	NN	Case=Nom|Gender=Fem|Number=Sing	3	nsubj	_	SpaceAfter=No
+7	,	,	PUNCT	$,	_	3	punct	_	_
+8	man	man	PRON	PIS	Case=Nom|Definite=Ind|Number=Sing|PronType=Ind	9	nsubj	_	_
+9	will	wollen	VERB	VMFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	3	parataxis	_	_
+10	in	in	ADP	APPR	_	11	case	_	_
+11	Stuttgart	Stuttgart	PROPN	NE	Case=Dat|Gender=Neut|Number=Sing	9	obl	_	_
+12	die	der	DET	ART	Case=Acc|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	13	det	_	_
+13	AEG	AEG	PROPN	NE	Case=Acc|Gender=Fem|Number=Sing	9	obj	_	_
+14	einfach	einfach	ADV	ADV	_	15	advmod	_	_
+15	nicht	nicht	PART	PTKNEG	Polarity=Neg	16	advmod	_	_
+16	mehr	mehr	ADV	ADV	_	9	advmod	_	SpaceAfter=No
+17	.	.	PUNCT	$.	_	3	punct	_	SpaceAfter=No
+18	''	''	PUNCT	$(	_	3	punct	_	_
 
 # sent_id = dev-s791
-# text = Ministerpräsident Manfred Stolpe (SPD) forderte Lafontaine auf, möglichst bald in Ostdeutschland aufzutreten.
-1	Ministerpräsident	Ministerpräsident	NOUN	NN	Case=Nom|Gender=Masc|Number=Sing	7	nsubj	_	_
-2	Manfred	Manfred	PROPN	NE	Case=Nom|Gender=Masc|Number=Sing	1	appos	_	_
-3	Stolpe	Stolpe	PROPN	NE	Case=Nom|Gender=Masc|Number=Sing	2	flat	_	_
-4	(	(	PUNCT	$(	_	5	punct	_	SpaceAfter=No
-5	SPD	SPD	PROPN	NE	Case=Nom|Gender=Fem|Number=Sing	2	appos	_	SpaceAfter=No
-6	)	)	PUNCT	$(	_	5	punct	_	_
-7	forderte	fordern	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	0	root	_	_
-8	Lafontaine	Lafontaine	PROPN	NE	Case=Acc|Number=Sing	7	obj	_	_
-9	auf	auf	ADP	PTKVZ	_	7	compound:prt	_	SpaceAfter=No
-10	,	,	PUNCT	$,	_	7	punct	_	_
-11	möglichst	möglichst	ADV	ADV	_	12	advmod	_	_
-12	bald	bald	ADV	ADV	_	15	advmod	_	_
-13	in	in	ADP	APPR	_	14	case	_	_
-14	Ostdeutschland	Ostdeutschland	PROPN	NN	Case=Dat|Gender=Neut|Number=Sing	15	obl	_	_
-15	aufzutreten	auftreten	VERB	VVIZU	VerbForm=Inf	7	xcomp	_	SpaceAfter=No
-16	.	.	PUNCT	$.	_	7	punct	_	_
+# text = Brandenburgs Ministerpräsident Manfred Stolpe (SPD) forderte Lafontaine auf, möglichst bald in Ostdeutschland aufzutreten.
+1	Brandenburgs	Brandenburg	PROPN	NE	Case=Gen|Gender=Neut|Number=Sing	2	dep	_	FixTigerDep=Yes
+2	Ministerpräsident	Ministerpräsident	NOUN	NN	Case=Nom|Gender=Masc|Number=Sing	8	nsubj	_	_
+3	Manfred	Manfred	PROPN	NE	Case=Nom|Gender=Masc|Number=Sing	2	appos	_	_
+4	Stolpe	Stolpe	PROPN	NE	Case=Nom|Gender=Masc|Number=Sing	3	flat	_	_
+5	(	(	PUNCT	$(	_	6	punct	_	SpaceAfter=No
+6	SPD	SPD	PROPN	NE	Case=Nom|Gender=Fem|Number=Sing	3	appos	_	SpaceAfter=No
+7	)	)	PUNCT	$(	_	6	punct	_	_
+8	forderte	fordern	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	0	root	_	_
+9	Lafontaine	Lafontaine	PROPN	NE	Case=Acc|Number=Sing	8	obj	_	_
+10	auf	auf	ADP	PTKVZ	_	8	compound:prt	_	SpaceAfter=No
+11	,	,	PUNCT	$,	_	8	punct	_	_
+12	möglichst	möglichst	ADV	ADV	_	13	advmod	_	_
+13	bald	bald	ADV	ADV	_	16	advmod	_	_
+14	in	in	ADP	APPR	_	15	case	_	_
+15	Ostdeutschland	Ostdeutschland	PROPN	NN	Case=Dat|Gender=Neut|Number=Sing	16	obl	_	_
+16	aufzutreten	auftreten	VERB	VVIZU	VerbForm=Inf	8	xcomp	_	SpaceAfter=No
+17	.	.	PUNCT	$.	_	8	punct	_	_
 
 # sent_id = dev-s792
 # text = Es fehlt ein System umfassender sozialer Sicherung.
@@ -14853,20 +14999,21 @@
 21	.	.	PUNCT	$.	_	10	punct	_	_
 
 # sent_id = dev-s798
-# text = 88 Rebellen und Soldaten sollen nach Angaben eines Armeesprechers getötet worden sein.
-1	88	88	NUM	CARD	NumType=Card	2	nummod	_	_
-2	Rebellen	Rebell	NOUN	NN	Case=Nom|Gender=Masc|Number=Plur	10	nsubj:pass	_	_
-3	und	und	CCONJ	KON	_	4	cc	_	_
-4	Soldaten	Soldat	NOUN	NN	Case=Nom|Gender=Masc|Number=Plur	2	conj	_	_
-5	sollen	sollen	AUX	VMFIN	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	10	aux	_	_
-6	nach	nach	ADP	APPR	_	7	case	_	_
-7	Angaben	Angabe	NOUN	NN	Case=Dat|Gender=Fem|Number=Plur	10	obl	_	_
-8	eines	ein	DET	ART	Case=Gen|Definite=Ind|Gender=Masc|Number=Sing|PronType=Art	9	det	_	_
-9	Armeesprechers	Armeesprecher	NOUN	NN	Case=Gen|Gender=Masc|Number=Sing	7	nmod	_	_
-10	getötet	töten	VERB	VVPP	VerbForm=Part	0	root	_	_
-11	worden	werden	AUX	VAPP	VerbForm=Part|Voice=Pass	10	aux:pass	_	_
-12	sein	sein	AUX	VAINF	VerbForm=Inf	10	aux	_	SpaceAfter=No
-13	.	.	PUNCT	$.	_	10	punct	_	_
+# text = Mindestens 88 Rebellen und Soldaten sollen nach Angaben eines Armeesprechers getötet worden sein.
+1	Mindestens	mindestens	ADV	ADV	_	2	dep	_	FixTigerDep=Yes
+2	88	88	NUM	CARD	NumType=Card	3	nummod	_	_
+3	Rebellen	Rebell	NOUN	NN	Case=Nom|Gender=Masc|Number=Plur	11	nsubj:pass	_	_
+4	und	und	CCONJ	KON	_	5	cc	_	_
+5	Soldaten	Soldat	NOUN	NN	Case=Nom|Gender=Masc|Number=Plur	3	conj	_	_
+6	sollen	sollen	AUX	VMFIN	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	11	aux	_	_
+7	nach	nach	ADP	APPR	_	8	case	_	_
+8	Angaben	Angabe	NOUN	NN	Case=Dat|Gender=Fem|Number=Plur	11	obl	_	_
+9	eines	ein	DET	ART	Case=Gen|Definite=Ind|Gender=Masc|Number=Sing|PronType=Art	10	det	_	_
+10	Armeesprechers	Armeesprecher	NOUN	NN	Case=Gen|Gender=Masc|Number=Sing	8	nmod	_	_
+11	getötet	töten	VERB	VVPP	VerbForm=Part	0	root	_	_
+12	worden	werden	AUX	VAPP	VerbForm=Part|Voice=Pass	11	aux:pass	_	_
+13	sein	sein	AUX	VAINF	VerbForm=Inf	11	aux	_	SpaceAfter=No
+14	.	.	PUNCT	$.	_	11	punct	_	_
 
 # sent_id = dev-s799
 # text = Ein arbeitsloser argentinischer Kriegsveteran hat am Samstag erfolglos versucht, die Schulgebühren seines Sohnes mit drei Tapferkeitsmedaillen aus dem Falklandkrieg von 1982 zu bezahlen.

--- a/de_gsd-ud-test.conllu
+++ b/de_gsd-ud-test.conllu
@@ -8358,14 +8358,14 @@
 18	.	.	PUNCT	$.	_	4	punct	_	_
 
 # sent_id = test-s437
-# text = Informationen sind erhältlich bei Tel Dor -- Projekt, Erika und Walter Haury, Doninikus -- Zimmermann -- Str. 9, 88299 Leutkirch, Tel. und Fax 07561 / 3128.
+# text = Informationen sind erhältlich bei Tel Dor-Projekt, Erika und Walter Haury, Doninikus-Zimmermann-Str. 9, 88299 Leutkirch, Tel. und Fax 07561 / 3128.
 1	Informationen	Information	NOUN	NN	Case=Nom|Gender=Fem|Number=Plur	3	nsubj	_	_
 2	sind	sein	AUX	VAFIN	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	3	cop	_	_
 3	erhältlich	erhältlich	ADJ	ADJD	_	0	root	_	_
 4	bei	bei	ADP	APPR	_	5	case	_	_
 5	Tel	Tel	PROPN	NE	_	3	nmod	_	_
-6	Dor	Dor	PROPN	NN	Case=Dat|Gender=Neut|Number=Sing	5	flat	_	_
-7	--	--	PUNCT	$(	_	5	punct	_	_
+6	Dor	Dor	PROPN	NN	Case=Dat|Gender=Neut|Number=Sing	5	flat	_	SpaceAfter=No
+7	-	-	PUNCT	$(	_	5	punct	_	SpaceAfter=No
 8	Projekt	Projekt	NOUN	NN	Case=Dat|Gender=Neut|Number=Sing	5	flat	_	SpaceAfter=No
 9	,	,	PUNCT	$,	_	3	punct	_	_
 10	Erika	Erika	PROPN	NE	Case=Nom|Gender=Fem|Number=Sing	5	appos	_	_
@@ -8373,11 +8373,11 @@
 12	Walter	Walter	PROPN	NE	Case=Nom|Gender=Masc|Number=Sing	10	conj	_	_
 13	Haury	Haury	PROPN	NE	Case=Nom|Number=Sing	10	flat	_	SpaceAfter=No
 14	,	,	PUNCT	$,	_	10	punct	_	_
-15	Doninikus	Doninikus	PROPN	NN	Case=Nom|Gender=Masc|Number=Sing	10	appos	_	_
-16	--	--	PUNCT	$(	_	15	punct	_	_
-17	Zimmermann	Zimmermann	PROPN	NN	Case=Nom|Gender=Masc|Number=Sing	15	flat	_	_
-18	--	--	PUNCT	$(	_	15	punct	_	_
-19	Str	Str	PROPN	NN	Case=Nom|Gender=Masc|Number=Sing	15	flat	_	SpaceAfter=No
+15	Doninikus	Doninikus	PROPN	NN	Case=Nom|Gender=Fem|Number=Sing	10	appos	_	SpaceAfter=No
+16	-	-	PUNCT	$(	_	15	punct	_	SpaceAfter=No
+17	Zimmermann	Zimmermann	PROPN	NN	Case=Nom|Gender=Fem|Number=Sing	15	flat	_	SpaceAfter=No
+18	-	-	PUNCT	$(	_	15	punct	_	SpaceAfter=No
+19	Str	Str	PROPN	NN	Case=Nom|Gender=Fem|Number=Sing	15	flat	_	SpaceAfter=No
 20	.	.	PUNCT	$.	_	19	punct	_	_
 21	9	9	NUM	CARD	NumType=Card	15	flat	_	SpaceAfter=No
 22	,	,	PUNCT	$,	_	3	punct	_	_
@@ -18971,8 +18971,8 @@
 51	und	und	CCONJ	KON	_	50	conj	_	_
 52	durch	durch	ADP	ADV	_	51	case	_	_
 53	filmische	filmisch	ADJ	ADJA	Case=Nom|Gender=Fem|Number=Sing	50	fixed	_	_
-54	Musil	Musil	NOUN	NN	Case=Acc|Gender=Fem|Number=Sing	56	compound	_	_
-55	-	-	PUNCT	$(	_	56	punct	_	_
+54	Musil	Musil	NOUN	NN	Case=Acc|Gender=Fem|Number=Sing	56	compound	_	SpaceAfter=No
+55	-	-	PUNCT	$(	_	56	punct	_	SpaceAfter=No
 56	Paraphrase	Paraphrase	NOUN	NN	Case=Acc|Gender=Fem|Number=Sing	18	appos	_	SpaceAfter=No
 57	,	,	PUNCT	$,	_	56	punct	_	_
 58	lyrisch	lyrisch	ADJ	ADJD	_	18	appos	_	SpaceAfter=No

--- a/de_gsd-ud-test.conllu
+++ b/de_gsd-ud-test.conllu
@@ -5569,8 +5569,8 @@
 18	"	"	PUNCT	$(	_	6	punct	_	_
 
 # sent_id = test-s320
-# text = "Staatsanwaltschaft wirft dem ehemaligen Baulöwen (Kredit-) Betrug und Bankrott vor.
-1	"	"	PUNCT	$(	_	3	punct	_	SpaceAfter=No
+# text = Die Staatsanwaltschaft wirft dem ehemaligen Baulöwen (Kredit-) Betrug und Bankrott vor.
+1	Die	der	DET	ART	Case=Nom|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	2	dep	_	FixTigerDep=Yes
 2	Staatsanwaltschaft	Staatsanwaltschaft	NOUN	NN	Case=Nom|Gender=Fem|Number=Sing	3	nsubj	_	_
 3	wirft	werfen	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	0	root	_	_
 4	dem	der	DET	ART	Case=Dat|Definite=Def|Gender=Masc|Number=Sing|PronType=Art	6	det	_	_
@@ -5587,346 +5587,364 @@
 15	.	.	PUNCT	$.	_	3	punct	_	_
 
 # sent_id = test-s321
-# text = ``sehr unbefriedigende'' Schadensentwicklung auch beim Haftpflicht- und Transportschutz hatte schon 1991 die versicherungstechnische Rechnung der Schaden- und Unfallzweige mit minus 38 (27) Millionen Mark tiefer in die rote Zone gedrückt.
-1	``	``	PUNCT	$(	_	5	punct	_	SpaceAfter=No
-2	sehr	sehr	ADV	ADV	_	3	advmod	_	_
-3	unbefriedigende	unbefriedigend	ADJ	ADJA	Case=Nom|Gender=Fem|Number=Sing	5	amod	_	SpaceAfter=No
-4	''	''	PUNCT	$(	_	5	punct	_	_
-5	Schadensentwicklung	Schadensentwicklung	NOUN	NN	Case=Nom|Gender=Fem|Number=Sing	37	nsubj	_	_
-6	auch	auch	ADV	ADV	_	9	advmod	_	_
-7-8	beim	_	_	_	_	_	_	_	_
-7	bei	bei	ADP	APPR	_	9	case	_	_
-8	dem	der	DET	ART	Case=Dat|Definite=Def|Gender=Neut|Number=Sing|PronType=Art	9	det	_	_
-9	Haftpflicht	Haftpflicht	NOUN	NN	Case=Dat|Gender=Masc|Number=Sing	5	compound	_	SpaceAfter=No
-10	-	-	PUNCT	$(	_	12	punct	_	_
-11	und	und	CCONJ	KON	_	12	cc	_	_
-12	Transportschutz	Transportschutz	NOUN	NN	Case=Dat|Gender=Masc|Number=Sing	9	conj	_	_
-13	hatte	haben	AUX	VAFIN	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	37	aux	_	_
-14	schon	schon	ADV	ADV	_	15	advmod	_	_
-15	1991	1991	NUM	CARD	NumType=Card	37	obl	_	_
-16	die	der	DET	ART	Case=Acc|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	18	det	_	_
-17	versicherungstechnische	versicherungstechnisch	ADJ	ADJA	Case=Acc|Gender=Fem|Number=Sing	18	amod	_	_
-18	Rechnung	Rechnung	NOUN	NN	Case=Acc|Gender=Fem|Number=Sing	37	obj	_	_
-19	der	der	DET	ART	Case=Gen|Definite=Def|Gender=Masc|Number=Plur|PronType=Art	20	det	_	_
-20	Schaden	Schaden	NOUN	TRUNC	Case=Gen|Gender=Masc|Number=Plur	18	compound	_	SpaceAfter=No
-21	-	-	PUNCT	$(	_	23	punct	_	_
-22	und	und	CCONJ	KON	_	23	cc	_	_
-23	Unfallzweige	Unfallzweig	NOUN	NN	Case=Gen|Gender=Masc|Number=Plur	20	conj	_	_
-24	mit	mit	ADP	APPR	_	31	case	_	_
-25	minus	minus	ADV	ADV	_	26	advmod	_	_
-26	38	38	NUM	CARD	NumType=Card	30	nummod	_	_
-27	(	(	PUNCT	$(	_	28	punct	_	SpaceAfter=No
-28	27	27	NUM	CARD	NumType=Card	26	conj	_	SpaceAfter=No
-29	)	)	PUNCT	$(	_	26	punct	_	_
-30	Millionen	Million	NOUN	NN	Case=Dat|Gender=Fem|Number=Plur	31	nummod	_	_
-31	Mark	Mark	NOUN	NN	Gender=Fem	37	obl	_	_
-32	tiefer	tief	ADV	ADJD	_	37	advmod	_	_
-33	in	in	ADP	APPR	_	36	case	_	_
-34	die	der	DET	ART	Case=Acc|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	36	det	_	_
-35	rote	rot	ADJ	ADJA	Case=Acc|Gender=Fem|Number=Sing	36	amod	_	_
-36	Zone	Zone	NOUN	NN	Case=Acc|Gender=Fem|Number=Sing	37	obl	_	_
-37	gedrückt	drücken	VERB	VVPP	VerbForm=Part	0	root	_	SpaceAfter=No
-38	.	.	PUNCT	$.	_	37	punct	_	_
+# text = Die ``sehr unbefriedigende'' Schadensentwicklung auch beim Haftpflicht- und Transportschutz hatte schon 1991 die versicherungstechnische Rechnung der Schaden- und Unfallzweige mit minus 38 (27) Millionen Mark tiefer in die rote Zone gedrückt.
+1	Die	der	DET	ART	Case=Nom|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	2	dep	_	FixTigerDep=Yes
+2	``	``	PUNCT	$(	_	6	punct	_	SpaceAfter=No
+3	sehr	sehr	ADV	ADV	_	4	advmod	_	_
+4	unbefriedigende	unbefriedigend	ADJ	ADJA	Case=Nom|Gender=Fem|Number=Sing	6	amod	_	SpaceAfter=No
+5	''	''	PUNCT	$(	_	6	punct	_	_
+6	Schadensentwicklung	Schadensentwicklung	NOUN	NN	Case=Nom|Gender=Fem|Number=Sing	38	nsubj	_	_
+7	auch	auch	ADV	ADV	_	10	advmod	_	_
+8-9	beim	_	_	_	_	_	_	_	_
+8	bei	bei	ADP	APPR	_	10	case	_	_
+9	dem	der	DET	ART	Case=Dat|Definite=Def|Gender=Neut|Number=Sing|PronType=Art	10	det	_	_
+10	Haftpflicht	Haftpflicht	NOUN	NN	Case=Dat|Gender=Masc|Number=Sing	6	compound	_	SpaceAfter=No
+11	-	-	PUNCT	$(	_	13	punct	_	_
+12	und	und	CCONJ	KON	_	13	cc	_	_
+13	Transportschutz	Transportschutz	NOUN	NN	Case=Dat|Gender=Masc|Number=Sing	10	conj	_	_
+14	hatte	haben	AUX	VAFIN	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	38	aux	_	_
+15	schon	schon	ADV	ADV	_	16	advmod	_	_
+16	1991	1991	NUM	CARD	NumType=Card	38	obl	_	_
+17	die	der	DET	ART	Case=Acc|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	19	det	_	_
+18	versicherungstechnische	versicherungstechnisch	ADJ	ADJA	Case=Acc|Gender=Fem|Number=Sing	19	amod	_	_
+19	Rechnung	Rechnung	NOUN	NN	Case=Acc|Gender=Fem|Number=Sing	38	obj	_	_
+20	der	der	DET	ART	Case=Gen|Definite=Def|Gender=Masc|Number=Plur|PronType=Art	21	det	_	_
+21	Schaden	Schaden	NOUN	TRUNC	Case=Gen|Gender=Masc|Number=Plur	19	compound	_	SpaceAfter=No
+22	-	-	PUNCT	$(	_	24	punct	_	_
+23	und	und	CCONJ	KON	_	24	cc	_	_
+24	Unfallzweige	Unfallzweig	NOUN	NN	Case=Gen|Gender=Masc|Number=Plur	21	conj	_	_
+25	mit	mit	ADP	APPR	_	32	case	_	_
+26	minus	minus	ADV	ADV	_	27	advmod	_	_
+27	38	38	NUM	CARD	NumType=Card	31	nummod	_	_
+28	(	(	PUNCT	$(	_	29	punct	_	SpaceAfter=No
+29	27	27	NUM	CARD	NumType=Card	27	conj	_	SpaceAfter=No
+30	)	)	PUNCT	$(	_	27	punct	_	_
+31	Millionen	Million	NOUN	NN	Case=Dat|Gender=Fem|Number=Plur	32	nummod	_	_
+32	Mark	Mark	NOUN	NN	Gender=Fem	38	obl	_	_
+33	tiefer	tief	ADV	ADJD	_	38	advmod	_	_
+34	in	in	ADP	APPR	_	37	case	_	_
+35	die	der	DET	ART	Case=Acc|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	37	det	_	_
+36	rote	rot	ADJ	ADJA	Case=Acc|Gender=Fem|Number=Sing	37	amod	_	_
+37	Zone	Zone	NOUN	NN	Case=Acc|Gender=Fem|Number=Sing	38	obl	_	_
+38	gedrückt	drücken	VERB	VVPP	VerbForm=Part	0	root	_	SpaceAfter=No
+39	.	.	PUNCT	$.	_	38	punct	_	_
 
 # sent_id = test-s322
-# text = 1929 ist keine Schrift Bachtins unter seinem eigenen Namen erschienen.
-1	1929	1929	NUM	CARD	NumType=Card	10	obl	_	_
-2	ist	sein	AUX	VAFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	10	aux	_	_
-3	keine	kein	PRON	PIAT	Case=Nom|Definite=Ind|Gender=Fem|Number=Sing|Polarity=Neg|PronType=Neg	4	advmod	_	_
-4	Schrift	Schrift	NOUN	NN	Case=Nom|Gender=Fem|Number=Sing	10	nsubj	_	_
-5	Bachtins	Bachtins	PROPN	NE	Case=Gen|Gender=Masc|Number=Sing	4	nmod	_	_
-6	unter	unter	ADP	APPR	_	9	case	_	_
-7	seinem	sein	PRON	PPOSAT	Case=Dat|Gender=Masc|Number=Sing|Poss=Yes	9	det:poss	_	_
-8	eigenen	eigen	ADJ	ADJA	Case=Dat|Gender=Masc|Number=Sing	9	amod	_	_
-9	Namen	Namen	NOUN	NN	Case=Dat|Gender=Masc|Number=Sing	10	obl	_	_
-10	erschienen	erscheinen	VERB	VVPP	VerbForm=Part	0	root	_	SpaceAfter=No
-11	.	.	PUNCT	$.	_	10	punct	_	_
+# text = Bis 1929 ist keine Schrift Bachtins unter seinem eigenen Namen erschienen.
+1	Bis	bis	ADP	APPR	_	2	dep	_	FixTigerDep=Yes
+2	1929	1929	NUM	CARD	NumType=Card	11	obl	_	_
+3	ist	sein	AUX	VAFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	11	aux	_	_
+4	keine	kein	PRON	PIAT	Case=Nom|Definite=Ind|Gender=Fem|Number=Sing|Polarity=Neg|PronType=Neg	5	advmod	_	_
+5	Schrift	Schrift	NOUN	NN	Case=Nom|Gender=Fem|Number=Sing	11	nsubj	_	_
+6	Bachtins	Bachtins	PROPN	NE	Case=Gen|Gender=Masc|Number=Sing	5	nmod	_	_
+7	unter	unter	ADP	APPR	_	10	case	_	_
+8	seinem	sein	PRON	PPOSAT	Case=Dat|Gender=Masc|Number=Sing|Poss=Yes	10	det:poss	_	_
+9	eigenen	eigen	ADJ	ADJA	Case=Dat|Gender=Masc|Number=Sing	10	amod	_	_
+10	Namen	Namen	NOUN	NN	Case=Dat|Gender=Masc|Number=Sing	11	obl	_	_
+11	erschienen	erscheinen	VERB	VVPP	VerbForm=Part	0	root	_	SpaceAfter=No
+12	.	.	PUNCT	$.	_	11	punct	_	_
 
 # sent_id = test-s323
-# text = 250 Aussteller erwarten 7000 Fachbesucher.
-1	250	250	NUM	CARD	NumType=Card	2	nummod	_	_
-2	Aussteller	Aussteller	NOUN	NN	Case=Nom|Gender=Masc|Number=Plur	3	nsubj	_	_
-3	erwarten	erwarten	VERB	VVFIN	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	0	root	_	_
-4	7000	7000	NUM	CARD	NumType=Card	5	nummod	_	_
-5	Fachbesucher	Fachbesucher	NOUN	NN	Case=Acc|Gender=Masc|Number=Plur	3	obj	_	SpaceAfter=No
-6	.	.	PUNCT	$.	_	3	punct	_	_
+# text = Die 250 Aussteller erwarten 7000 Fachbesucher.
+1	Die	der	DET	ART	Case=Nom|Definite=Def|Gender=Masc|Number=Plur|PronType=Art	2	dep	_	FixTigerDep=Yes
+2	250	250	NUM	CARD	NumType=Card	3	nummod	_	_
+3	Aussteller	Aussteller	NOUN	NN	Case=Nom|Gender=Masc|Number=Plur	4	nsubj	_	_
+4	erwarten	erwarten	VERB	VVFIN	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	0	root	_	_
+5	7000	7000	NUM	CARD	NumType=Card	6	nummod	_	_
+6	Fachbesucher	Fachbesucher	NOUN	NN	Case=Acc|Gender=Masc|Number=Plur	4	obj	_	SpaceAfter=No
+7	.	.	PUNCT	$.	_	4	punct	_	_
 
 # sent_id = test-s324
-# text = 27. Große Strafkammer beriet zunächst hinter verschlossenen Türen, dann eröffnete Bräutigam das Verfahren 527-1 / 95 dennoch.
-1	27.	27	ADJ	ADJA	Case=Nom|Gender=Fem|Number=Sing	2	compound	_	_
-2	Große	groß	PROPN	ADJA	Case=Nom|Gender=Fem|Number=Sing	4	nsubj	_	_
-3	Strafkammer	Strafkammer	PROPN	NN	Case=Nom|Gender=Fem|Number=Sing	2	flat	_	_
-4	beriet	beraten	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	0	root	_	_
-5	zunächst	zunächst	ADV	ADV	_	4	advmod	_	_
-6	hinter	hinter	ADP	APPR	_	8	case	_	_
-7	verschlossenen	verschlossen	ADJ	ADJA	Case=Dat|Gender=Fem|Number=Plur	8	amod	_	_
-8	Türen	Tür	NOUN	NN	Case=Dat|Gender=Fem|Number=Plur	4	obl	_	SpaceAfter=No
-9	,	,	PUNCT	$,	_	4	punct	_	_
-10	dann	dann	ADV	ADV	_	11	advmod	_	_
-11	eröffnete	eröffnen	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	4	ccomp	_	_
-12	Bräutigam	Bräutigam	NOUN	NE	Case=Nom|Number=Sing	11	nsubj	_	_
-13	das	der	DET	ART	Case=Acc|Definite=Def|Gender=Neut|Number=Sing|PronType=Art	14	det	_	_
-14	Verfahren	Verfahren	NOUN	NN	Case=Acc|Gender=Neut|Number=Sing	11	obj	_	_
-15	527-1	527-1	NUM	CARD	NumType=Card	17	compound	_	_
-16	/	/	PUNCT	$(	_	17	punct	_	_
-17	95	95	NUM	CARD	NumType=Card	14	appos	_	_
-18	dennoch	dennoch	ADV	ADV	_	11	advmod	_	SpaceAfter=No
-19	.	.	PUNCT	$.	_	4	punct	_	_
+# text = Die 27. Große Strafkammer beriet zunächst hinter verschlossenen Türen, dann eröffnete Bräutigam das Verfahren 527-1 / 95 dennoch.
+1	Die	der	DET	ART	Case=Nom|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	2	dep	_	FixTigerDep=Yes
+2	27.	27	ADJ	ADJA	Case=Nom|Gender=Fem|Number=Sing	3	compound	_	_
+3	Große	groß	PROPN	ADJA	Case=Nom|Gender=Fem|Number=Sing	5	nsubj	_	_
+4	Strafkammer	Strafkammer	PROPN	NN	Case=Nom|Gender=Fem|Number=Sing	3	flat	_	_
+5	beriet	beraten	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	0	root	_	_
+6	zunächst	zunächst	ADV	ADV	_	5	advmod	_	_
+7	hinter	hinter	ADP	APPR	_	9	case	_	_
+8	verschlossenen	verschlossen	ADJ	ADJA	Case=Dat|Gender=Fem|Number=Plur	9	amod	_	_
+9	Türen	Tür	NOUN	NN	Case=Dat|Gender=Fem|Number=Plur	5	obl	_	SpaceAfter=No
+10	,	,	PUNCT	$,	_	5	punct	_	_
+11	dann	dann	ADV	ADV	_	12	advmod	_	_
+12	eröffnete	eröffnen	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	5	ccomp	_	_
+13	Bräutigam	Bräutigam	NOUN	NE	Case=Nom|Number=Sing	12	nsubj	_	_
+14	das	der	DET	ART	Case=Acc|Definite=Def|Gender=Neut|Number=Sing|PronType=Art	15	det	_	_
+15	Verfahren	Verfahren	NOUN	NN	Case=Acc|Gender=Neut|Number=Sing	12	obj	_	_
+16	527-1	527-1	NUM	CARD	NumType=Card	18	compound	_	_
+17	/	/	PUNCT	$(	_	18	punct	_	_
+18	95	95	NUM	CARD	NumType=Card	15	appos	_	_
+19	dennoch	dennoch	ADV	ADV	_	12	advmod	_	SpaceAfter=No
+20	.	.	PUNCT	$.	_	5	punct	_	_
 
 # sent_id = test-s325
-# text = 60 Prozent werden für Direktzahlungen ausgegeben, für Flächenprämien, für Umweltprogramme, für die Unterstützung von Bergbauern, benachteiligte Gebiete und ähnliches.
-1	60	60	NUM	CARD	NumType=Card	2	nummod	_	_
-2	Prozent	Prozent	NOUN	NN	Gender=Neut	6	nsubj:pass	_	_
-3	werden	werden	AUX	VAFIN	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin|Voice=Pass	6	aux:pass	_	_
-4	für	für	ADP	APPR	_	5	case	_	_
-5	Direktzahlungen	Direktzahlung	NOUN	NN	Case=Acc|Gender=Fem|Number=Plur	6	obl	_	_
-6	ausgegeben	ausgeben	VERB	VVPP	VerbForm=Part	0	root	_	SpaceAfter=No
-7	,	,	PUNCT	$,	_	6	punct	_	_
-8	für	für	ADP	APPR	_	9	case	_	_
-9	Flächenprämien	Flächenprämie	NOUN	NN	Case=Acc|Gender=Fem|Number=Plur	5	conj	_	SpaceAfter=No
-10	,	,	PUNCT	$,	_	12	punct	_	_
-11	für	für	ADP	APPR	_	12	case	_	_
-12	Umweltprogramme	Umweltprogramm	NOUN	NN	Case=Acc|Gender=Neut|Number=Plur	5	conj	_	SpaceAfter=No
-13	,	,	PUNCT	$,	_	16	punct	_	_
-14	für	für	ADP	APPR	_	16	case	_	_
-15	die	der	DET	ART	Case=Acc|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	16	det	_	_
-16	Unterstützung	Unterstützung	NOUN	NN	Case=Acc|Gender=Fem|Number=Sing	5	conj	_	_
-17	von	von	ADP	APPR	_	18	case	_	_
-18	Bergbauern	Bergbauer	NOUN	NN	Case=Dat|Gender=Masc|Number=Plur	16	nmod	_	SpaceAfter=No
-19	,	,	PUNCT	$,	_	21	punct	_	_
-20	benachteiligte	benachteiligt	ADJ	ADJA	Case=Acc|Gender=Neut|Number=Plur	21	amod	_	_
-21	Gebiete	Gebiet	NOUN	NN	Case=Acc|Gender=Neut|Number=Plur	16	conj	_	_
-22	und	und	CCONJ	KON	_	23	cc	_	_
-23	ähnliches	Ähnlich	NOUN	ADJA	Case=Acc|Gender=Neut|Number=Sing	16	conj	_	SpaceAfter=No
-24	.	.	PUNCT	$.	_	6	punct	_	_
+# text = Über 60 Prozent werden für Direktzahlungen ausgegeben, für Flächenprämien, für Umweltprogramme, für die Unterstützung von Bergbauern, benachteiligte Gebiete und ähnliches.
+1	Über	über	ADV	ADV	_	2	dep	_	FixTigerDep=Yes
+2	60	60	NUM	CARD	NumType=Card	3	nummod	_	_
+3	Prozent	Prozent	NOUN	NN	Gender=Neut	7	nsubj:pass	_	_
+4	werden	werden	AUX	VAFIN	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin|Voice=Pass	7	aux:pass	_	_
+5	für	für	ADP	APPR	_	6	case	_	_
+6	Direktzahlungen	Direktzahlung	NOUN	NN	Case=Acc|Gender=Fem|Number=Plur	7	obl	_	_
+7	ausgegeben	ausgeben	VERB	VVPP	VerbForm=Part	0	root	_	SpaceAfter=No
+8	,	,	PUNCT	$,	_	7	punct	_	_
+9	für	für	ADP	APPR	_	10	case	_	_
+10	Flächenprämien	Flächenprämie	NOUN	NN	Case=Acc|Gender=Fem|Number=Plur	6	conj	_	SpaceAfter=No
+11	,	,	PUNCT	$,	_	13	punct	_	_
+12	für	für	ADP	APPR	_	13	case	_	_
+13	Umweltprogramme	Umweltprogramm	NOUN	NN	Case=Acc|Gender=Neut|Number=Plur	6	conj	_	SpaceAfter=No
+14	,	,	PUNCT	$,	_	17	punct	_	_
+15	für	für	ADP	APPR	_	17	case	_	_
+16	die	der	DET	ART	Case=Acc|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	17	det	_	_
+17	Unterstützung	Unterstützung	NOUN	NN	Case=Acc|Gender=Fem|Number=Sing	6	conj	_	_
+18	von	von	ADP	APPR	_	19	case	_	_
+19	Bergbauern	Bergbauer	NOUN	NN	Case=Dat|Gender=Masc|Number=Plur	17	nmod	_	SpaceAfter=No
+20	,	,	PUNCT	$,	_	22	punct	_	_
+21	benachteiligte	benachteiligt	ADJ	ADJA	Case=Acc|Gender=Neut|Number=Plur	22	amod	_	_
+22	Gebiete	Gebiet	NOUN	NN	Case=Acc|Gender=Neut|Number=Plur	17	conj	_	_
+23	und	und	CCONJ	KON	_	24	cc	_	_
+24	ähnliches	Ähnlich	NOUN	ADJA	Case=Acc|Gender=Neut|Number=Sing	17	conj	_	SpaceAfter=No
+25	.	.	PUNCT	$.	_	7	punct	_	_
 
 # sent_id = test-s326
-# text = Abfälliges ist über den Fünfakter geschrieben worden, dessen Zeit vielleicht erst jetzt gekommen ist.
-1	Abfälliges	Abfällige	NOUN	NN	Case=Nom|Gender=Neut|Number=Sing	6	nsubj:pass	_	_
-2	ist	sein	AUX	VAFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	6	aux	_	_
-3	über	über	ADP	APPR	_	5	case	_	_
-4	den	der	DET	ART	Case=Acc|Definite=Def|Gender=Masc|Number=Sing|PronType=Art	5	det	_	_
-5	Fünfakter	Fünfakter	NOUN	NN	Case=Acc|Gender=Masc|Number=Sing	6	obl	_	_
-6	geschrieben	schreiben	VERB	VVPP	VerbForm=Part	0	root	_	_
-7	worden	werden	AUX	VAPP	VerbForm=Part|Voice=Pass	6	aux:pass	_	SpaceAfter=No
-8	,	,	PUNCT	$,	_	6	punct	_	_
-9	dessen	der	PRON	PRELAT	Case=Gen|Gender=Masc|Number=Sing|PronType=Rel	10	det	_	_
-10	Zeit	Zeit	NOUN	NN	Case=Nom|Gender=Fem|Number=Sing	14	nsubj	_	_
-11	vielleicht	vielleicht	ADV	ADV	_	14	advmod	_	_
-12	erst	erst	ADV	ADV	_	14	advmod	_	_
-13	jetzt	jetzt	ADV	ADV	_	12	advmod	_	_
-14	gekommen	kommen	VERB	VVPP	VerbForm=Part	5	acl	_	_
-15	ist	sein	AUX	VAFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	14	aux	_	SpaceAfter=No
-16	.	.	PUNCT	$.	_	6	punct	_	_
+# text = Mancherlei Abfälliges ist über den Fünfakter geschrieben worden, dessen Zeit vielleicht erst jetzt gekommen ist.
+1	Mancherlei	mancherlei	DET	PIAT	Definite=Ind|PronType=Ind	2	dep	_	FixTigerDep=Yes
+2	Abfälliges	Abfällige	NOUN	NN	Case=Nom|Gender=Neut|Number=Sing	7	nsubj:pass	_	_
+3	ist	sein	AUX	VAFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	7	aux	_	_
+4	über	über	ADP	APPR	_	6	case	_	_
+5	den	der	DET	ART	Case=Acc|Definite=Def|Gender=Masc|Number=Sing|PronType=Art	6	det	_	_
+6	Fünfakter	Fünfakter	NOUN	NN	Case=Acc|Gender=Masc|Number=Sing	7	obl	_	_
+7	geschrieben	schreiben	VERB	VVPP	VerbForm=Part	0	root	_	_
+8	worden	werden	AUX	VAPP	VerbForm=Part|Voice=Pass	7	aux:pass	_	SpaceAfter=No
+9	,	,	PUNCT	$,	_	7	punct	_	_
+10	dessen	der	PRON	PRELAT	Case=Gen|Gender=Masc|Number=Sing|PronType=Rel	11	det	_	_
+11	Zeit	Zeit	NOUN	NN	Case=Nom|Gender=Fem|Number=Sing	15	nsubj	_	_
+12	vielleicht	vielleicht	ADV	ADV	_	15	advmod	_	_
+13	erst	erst	ADV	ADV	_	15	advmod	_	_
+14	jetzt	jetzt	ADV	ADV	_	13	advmod	_	_
+15	gekommen	kommen	VERB	VVPP	VerbForm=Part	6	acl	_	_
+16	ist	sein	AUX	VAFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	15	aux	_	SpaceAfter=No
+17	.	.	PUNCT	$.	_	7	punct	_	_
 
 # sent_id = test-s327
-# text = Abgeordnetenhaus, sonst ein Ort scharfer, aber peinlich auf gute Formen achtender Debatten, flogen die Fetzen auf niedrigstem Niveau.
-1	Abgeordnetenhaus	Abgeordnetenhaus	NOUN	NN	Case=Dat|Gender=Neut|Number=Sing	16	dep	_	SpaceAfter=No
-2	,	,	PUNCT	$,	_	16	punct	_	_
-3	sonst	sonst	ADV	ADV	_	5	advmod	_	_
-4	ein	ein	DET	ART	Case=Nom|Definite=Ind|Gender=Masc|Number=Sing|PronType=Art	5	det	_	_
-5	Ort	Ort	NOUN	NN	Case=Nom|Gender=Masc|Number=Sing	1	appos	_	_
-6	scharfer	scharf	ADJ	ADJA	Case=Gen|Gender=Fem|Number=Plur	14	amod	_	SpaceAfter=No
-7	,	,	PUNCT	$,	_	13	punct	_	_
-8	aber	aber	ADV	KON	_	13	cc	_	_
-9	peinlich	peinlich	ADV	ADJD	_	13	advmod	_	_
-10	auf	auf	ADP	APPR	_	12	case	_	_
-11	gute	gut	ADJ	ADJA	Case=Acc|Gender=Fem|Number=Plur	12	amod	_	_
-12	Formen	Form	NOUN	NN	Case=Acc|Gender=Fem|Number=Plur	13	nmod	_	_
-13	achtender	achtend	ADJ	ADJA	Case=Gen|Gender=Fem|Number=Plur	6	conj	_	_
-14	Debatten	Debatte	NOUN	NN	Case=Gen|Gender=Fem|Number=Plur	5	nmod	_	SpaceAfter=No
-15	,	,	PUNCT	$,	_	16	punct	_	_
-16	flogen	fliegen	VERB	VVFIN	Mood=Ind|Number=Plur|Person=3|Tense=Past|VerbForm=Fin	0	root	_	_
-17	die	der	DET	ART	Case=Nom|Definite=Def|Gender=Masc|Number=Plur|PronType=Art	18	det	_	_
-18	Fetzen	Fetzen	NOUN	NN	Case=Nom|Gender=Masc|Number=Plur	16	nsubj	_	_
-19	auf	auf	ADP	APPR	_	21	case	_	_
-20	niedrigstem	niedrig	ADJ	ADJA	Case=Dat|Gender=Neut|Number=Sing	21	amod	_	_
-21	Niveau	Niveau	NOUN	NN	Case=Dat|Gender=Neut|Number=Sing	16	obl	_	SpaceAfter=No
-22	.	.	PUNCT	$.	_	16	punct	_	_
+# text = Im Abgeordnetenhaus, sonst ein Ort scharfer, aber peinlich auf gute Formen achtender Debatten, flogen die Fetzen auf niedrigstem Niveau.
+1-2	Im	_	_	_	_	_	_	_	_
+1	In	in	ADP	APPR	_	3	case	_	FixTigerDep=Yes
+2	dem	der	DET	ART	Case=Dat|Gender=Neut|Number=Sing	3	det	_	_
+3	Abgeordnetenhaus	Abgeordnetenhaus	NOUN	NN	Case=Dat|Gender=Neut|Number=Sing	18	dep	_	SpaceAfter=No
+4	,	,	PUNCT	$,	_	18	punct	_	_
+5	sonst	sonst	ADV	ADV	_	7	advmod	_	_
+6	ein	ein	DET	ART	Case=Nom|Definite=Ind|Gender=Masc|Number=Sing|PronType=Art	7	det	_	_
+7	Ort	Ort	NOUN	NN	Case=Nom|Gender=Masc|Number=Sing	3	appos	_	_
+8	scharfer	scharf	ADJ	ADJA	Case=Gen|Gender=Fem|Number=Plur	16	amod	_	SpaceAfter=No
+9	,	,	PUNCT	$,	_	15	punct	_	_
+10	aber	aber	ADV	KON	_	15	cc	_	_
+11	peinlich	peinlich	ADV	ADJD	_	15	advmod	_	_
+12	auf	auf	ADP	APPR	_	14	case	_	_
+13	gute	gut	ADJ	ADJA	Case=Acc|Gender=Fem|Number=Plur	14	amod	_	_
+14	Formen	Form	NOUN	NN	Case=Acc|Gender=Fem|Number=Plur	15	nmod	_	_
+15	achtender	achtend	ADJ	ADJA	Case=Gen|Gender=Fem|Number=Plur	8	conj	_	_
+16	Debatten	Debatte	NOUN	NN	Case=Gen|Gender=Fem|Number=Plur	7	nmod	_	SpaceAfter=No
+17	,	,	PUNCT	$,	_	18	punct	_	_
+18	flogen	fliegen	VERB	VVFIN	Mood=Ind|Number=Plur|Person=3|Tense=Past|VerbForm=Fin	0	root	_	_
+19	die	der	DET	ART	Case=Nom|Definite=Def|Gender=Masc|Number=Plur|PronType=Art	20	det	_	_
+20	Fetzen	Fetzen	NOUN	NN	Case=Nom|Gender=Masc|Number=Plur	18	nsubj	_	_
+21	auf	auf	ADP	APPR	_	23	case	_	_
+22	niedrigstem	niedrig	ADJ	ADJA	Case=Dat|Gender=Neut|Number=Sing	23	amod	_	_
+23	Niveau	Niveau	NOUN	NN	Case=Dat|Gender=Neut|Number=Sing	18	obl	_	SpaceAfter=No
+24	.	.	PUNCT	$.	_	18	punct	_	_
 
 # sent_id = test-s328
-# text = Aerospace-Gruppe des Triebwerkherstellers Rolls-Royce hat mit dem amerikanischen EDV-Dienstleister Electronic Data Systems (EDS) einen Zehnjahresvertrag abgeschlossen.
-1	Aerospace	Aerospace	PROPN	NN	Case=Nom|Gender=Fem|Number=Sing	3	compound	_	SpaceAfter=No
-2	-	-	PUNCT	$(	_	1	punct	_	SpaceAfter=No
-3	Gruppe	Gruppe	NOUN	NN	Case=Nom|Gender=Fem|Number=Sing	24	nsubj	_	_
-4	des	der	DET	ART	Case=Gen|Definite=Def|Gender=Masc|Number=Sing|PronType=Art	5	det	_	_
-5	Triebwerkherstellers	Triebwerkhersteller	NOUN	NN	Case=Gen|Gender=Masc|Number=Sing	1	nmod	_	_
-6	Rolls	Rolls	PROPN	NN	Case=Nom|Gender=Masc|Number=Sing	8	compound	_	SpaceAfter=No
-7	-	-	PUNCT	$(	_	6	punct	_	SpaceAfter=No
-8	Royce	Royce	PROPN	NN	Case=Nom|Gender=Masc|Number=Sing	5	appos	_	_
-9	hat	haben	AUX	VAFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	24	aux	_	_
-10	mit	mit	ADP	APPR	_	13	case	_	_
-11	dem	der	DET	ART	Case=Dat|Definite=Def|Gender=Masc|Number=Sing|PronType=Art	13	det	_	_
-12	amerikanischen	amerikanisch	ADJ	ADJA	Case=Dat|Gender=Masc|Number=Sing	13	amod	_	_
-13	EDV	EDV	PROPN	NN	Case=Dat|Gender=Masc|Number=Sing	15	compound	_	SpaceAfter=No
-14	-	-	PUNCT	$(	_	13	punct	_	SpaceAfter=No
-15	Dienstleister	Dienstleister	NOUN	NN	Case=Dat|Gender=Masc|Number=Sing	24	obl	_	_
-16	Electronic	Electronic	PROPN	NE	_	13	appos	_	_
-17	Data	Data	PROPN	NE	_	16	flat	_	_
-18	Systems	System	PROPN	NE	Case=Nom|Number=Sing	16	flat	_	_
-19	(	(	PUNCT	$(	_	16	punct	_	SpaceAfter=No
-20	EDS	EDS	NOUN	NE	Case=Nom|Number=Sing	16	appos	_	SpaceAfter=No
-21	)	)	PUNCT	$(	_	16	punct	_	_
-22	einen	ein	DET	ART	Case=Acc|Definite=Ind|Gender=Masc|Number=Sing|PronType=Art	23	det	_	_
-23	Zehnjahresvertrag	Zehnjahresvertrag	NOUN	NN	Case=Acc|Gender=Masc|Number=Sing	24	obj	_	_
-24	abgeschlossen	abschließen	VERB	VVPP	VerbForm=Part	0	root	_	SpaceAfter=No
-25	.	.	PUNCT	$.	_	24	punct	_	_
+# text = Die Aerospace-Gruppe des Triebwerkherstellers Rolls-Royce hat mit dem amerikanischen EDV-Dienstleister Electronic Data Systems (EDS) einen Zehnjahresvertrag abgeschlossen.
+1	Die	der	DET	ART	Case=Nom|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	2	dep	_	FixTigerDep=Yes
+2	Aerospace	Aerospace	PROPN	NN	Case=Nom|Gender=Fem|Number=Sing	4	compound	_	SpaceAfter=No
+3	-	-	PUNCT	$(	_	2	punct	_	SpaceAfter=No
+4	Gruppe	Gruppe	NOUN	NN	Case=Nom|Gender=Fem|Number=Sing	25	nsubj	_	_
+5	des	der	DET	ART	Case=Gen|Definite=Def|Gender=Masc|Number=Sing|PronType=Art	6	det	_	_
+6	Triebwerkherstellers	Triebwerkhersteller	NOUN	NN	Case=Gen|Gender=Masc|Number=Sing	2	nmod	_	_
+7	Rolls	Rolls	PROPN	NN	Case=Nom|Gender=Masc|Number=Sing	9	compound	_	SpaceAfter=No
+8	-	-	PUNCT	$(	_	7	punct	_	SpaceAfter=No
+9	Royce	Royce	PROPN	NN	Case=Nom|Gender=Masc|Number=Sing	6	appos	_	_
+10	hat	haben	AUX	VAFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	25	aux	_	_
+11	mit	mit	ADP	APPR	_	14	case	_	_
+12	dem	der	DET	ART	Case=Dat|Definite=Def|Gender=Masc|Number=Sing|PronType=Art	14	det	_	_
+13	amerikanischen	amerikanisch	ADJ	ADJA	Case=Dat|Gender=Masc|Number=Sing	14	amod	_	_
+14	EDV	EDV	PROPN	NN	Case=Dat|Gender=Masc|Number=Sing	16	compound	_	SpaceAfter=No
+15	-	-	PUNCT	$(	_	14	punct	_	SpaceAfter=No
+16	Dienstleister	Dienstleister	NOUN	NN	Case=Dat|Gender=Masc|Number=Sing	25	obl	_	_
+17	Electronic	Electronic	PROPN	NE	_	14	appos	_	_
+18	Data	Data	PROPN	NE	_	17	flat	_	_
+19	Systems	Systems	PROPN	NE	Case=Nom|Number=Sing	17	flat	_	_
+20	(	(	PUNCT	$(	_	17	punct	_	SpaceAfter=No
+21	EDS	EDS	NOUN	NE	Case=Nom|Number=Sing	17	appos	_	SpaceAfter=No
+22	)	)	PUNCT	$(	_	17	punct	_	_
+23	einen	ein	DET	ART	Case=Acc|Definite=Ind|Gender=Masc|Number=Sing|PronType=Art	24	det	_	_
+24	Zehnjahresvertrag	Zehnjahresvertrag	NOUN	NN	Case=Acc|Gender=Masc|Number=Sing	25	obj	_	_
+25	abgeschlossen	abschließen	VERB	VVPP	VerbForm=Part	0	root	_	SpaceAfter=No
+26	.	.	PUNCT	$.	_	25	punct	_	_
 
 # sent_id = test-s329
-# text = Alles, was die Aufmerksamkeit auf den Mund lenkt ist gut'', lautet ihr erstes Mode- und Schminkgebot.
-1	Alles	alle	PRON	PIS	Case=Nom|Definite=Ind|Gender=Neut|Number=Sing|PronType=Ind	11	nsubj	_	SpaceAfter=No
-2	,	,	PUNCT	$,	_	14	punct	_	_
-3	was	was	PRON	PRELS	Case=Nom|Gender=Neut|Number=Sing|PronType=Rel	9	nsubj	_	_
-4	die	der	DET	ART	Case=Acc|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	5	det	_	_
-5	Aufmerksamkeit	Aufmerksamkeit	NOUN	NN	Case=Acc|Gender=Fem|Number=Sing	9	obj	_	_
-6	auf	auf	ADP	APPR	_	8	case	_	_
-7	den	der	DET	ART	Case=Acc|Definite=Def|Gender=Masc|Number=Sing|PronType=Art	8	det	_	_
-8	Mund	Mund	NOUN	NN	Case=Acc|Gender=Masc|Number=Sing	9	obl	_	_
-9	lenkt	lenken	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	1	acl	_	_
-10	ist	sein	AUX	VAFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	11	cop	_	_
-11	gut	gut	ADJ	ADJD	_	14	ccomp	_	SpaceAfter=No
-12	''	''	PUNCT	$(	_	14	punct	_	SpaceAfter=No
-13	,	,	PUNCT	$,	_	14	punct	_	_
-14	lautet	lauten	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	0	root	_	_
-15	ihr	ihr	PRON	PPOSAT	Case=Nom|Gender=Neut|Number=Sing|Poss=Yes	17	det:poss	_	_
-16	erstes	erster	ADJ	ADJA	Case=Nom|Gender=Neut|Number=Sing	17	amod	_	_
-17	Mode	Mode	NOUN	TRUNC	Case=Nom|Gender=Neut|Number=Sing	14	compound	_	SpaceAfter=No
-18	-	-	PUNCT	$(	_	20	punct	_	_
-19	und	und	CCONJ	KON	_	20	cc	_	_
-20	Schminkgebot	Schminkgebot	NOUN	NN	Case=Nom|Gender=Neut|Number=Sing	17	conj	_	SpaceAfter=No
-21	.	.	PUNCT	$.	_	14	punct	_	_
+# text = ``Alles, was die Aufmerksamkeit auf den Mund lenkt ist gut'', lautet ihr erstes Mode- und Schminkgebot.
+1	``	``	PUNCT	$(	_	2	punct	_	FixTigerDep=Yes|SpaceAfter=No
+2	Alles	alle	PRON	PIS	Case=Nom|Definite=Ind|Gender=Neut|Number=Sing|PronType=Ind	12	nsubj	_	SpaceAfter=No
+3	,	,	PUNCT	$,	_	15	punct	_	_
+4	was	was	PRON	PRELS	Case=Nom|Gender=Neut|Number=Sing|PronType=Rel	10	nsubj	_	_
+5	die	der	DET	ART	Case=Acc|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	6	det	_	_
+6	Aufmerksamkeit	Aufmerksamkeit	NOUN	NN	Case=Acc|Gender=Fem|Number=Sing	10	obj	_	_
+7	auf	auf	ADP	APPR	_	9	case	_	_
+8	den	der	DET	ART	Case=Acc|Definite=Def|Gender=Masc|Number=Sing|PronType=Art	9	det	_	_
+9	Mund	Mund	NOUN	NN	Case=Acc|Gender=Masc|Number=Sing	10	obl	_	_
+10	lenkt	lenken	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	2	acl	_	_
+11	ist	sein	AUX	VAFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	12	cop	_	_
+12	gut	gut	ADJ	ADJD	_	15	ccomp	_	SpaceAfter=No
+13	''	''	PUNCT	$(	_	15	punct	_	SpaceAfter=No
+14	,	,	PUNCT	$,	_	15	punct	_	_
+15	lautet	lauten	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	0	root	_	_
+16	ihr	ihr	PRON	PPOSAT	Case=Nom|Gender=Neut|Number=Sing|Poss=Yes	18	det:poss	_	_
+17	erstes	erster	ADJ	ADJA	Case=Nom|Gender=Neut|Number=Sing	18	amod	_	_
+18	Mode	Mode	NOUN	TRUNC	Case=Nom|Gender=Neut|Number=Sing	15	compound	_	SpaceAfter=No
+19	-	-	PUNCT	$(	_	21	punct	_	_
+20	und	und	CCONJ	KON	_	21	cc	_	_
+21	Schminkgebot	Schminkgebot	NOUN	NN	Case=Nom|Gender=Neut|Number=Sing	18	conj	_	SpaceAfter=No
+22	.	.	PUNCT	$.	_	15	punct	_	_
 
 # sent_id = test-s330
-# text = als Sahlin, die nach den höchsten Ämtern in Partei und Regierung strebte, wegen des Mißbrauchs staatlicher Kreditkarten für private Zwecke zur Rechenschaft gezogen wurde, nutzte sie ihren hektischen Alltag als Politikerin und Mutter von drei Kindern wirkungsvoll zu ihrer Verteidigung:
-1	als	als	SCONJ	KOUS	_	26	mark	_	_
-2	Sahlin	Sahlin	PROPN	NE	Case=Nom|Gender=Fem|Number=Sing	26	nsubj:pass	_	SpaceAfter=No
-3	,	,	PUNCT	$,	_	29	punct	_	_
-4	die	der	PRON	PRELS	Case=Nom|Gender=Fem|Number=Sing|PronType=Rel	13	nsubj	_	_
-5	nach	nach	ADP	APPR	_	8	case	_	_
-6	den	der	DET	ART	Case=Dat|Definite=Def|Gender=Neut|Number=Plur|PronType=Art	8	det	_	_
-7	höchsten	hoch	ADJ	ADJA	Case=Dat|Gender=Neut|Number=Plur	8	amod	_	_
-8	Ämtern	Amt	NOUN	NN	Case=Dat|Gender=Neut|Number=Plur	13	obl	_	_
-9	in	in	ADP	APPR	_	10	case	_	_
-10	Partei	Partei	NOUN	NN	Case=Dat|Gender=Fem|Number=Sing	8	nmod	_	_
-11	und	und	CCONJ	KON	_	12	cc	_	_
-12	Regierung	Regierung	NOUN	NN	Case=Dat|Gender=Fem|Number=Sing	10	conj	_	_
-13	strebte	streben	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	2	acl	_	SpaceAfter=No
-14	,	,	PUNCT	$,	_	29	punct	_	_
-15	wegen	wegen	ADP	APPR	_	17	case	_	_
-16	des	der	DET	ART	Case=Gen|Definite=Def|Gender=Masc|Number=Sing|PronType=Art	17	det	_	_
-17	Mißbrauchs	Mißbrauch	NOUN	NN	Case=Gen|Gender=Masc|Number=Sing	26	obl	_	_
-18	staatlicher	staatlich	ADJ	ADJA	Case=Gen|Gender=Fem|Number=Plur	19	amod	_	_
-19	Kreditkarten	Kreditkarte	NOUN	NN	Case=Gen|Gender=Fem|Number=Plur	17	nmod	_	_
-20	für	für	ADP	APPR	_	22	case	_	_
-21	private	privat	ADJ	ADJA	Case=Acc|Gender=Masc|Number=Plur	22	amod	_	_
-22	Zwecke	Zweck	NOUN	NN	Case=Acc|Gender=Masc|Number=Plur	17	nmod	_	_
-23-24	zur	_	_	_	_	_	_	_	_
-23	zu	zu	ADP	APPR	_	25	case	_	_
-24	der	der	DET	ART	Case=Dat|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	25	det	_	_
-25	Rechenschaft	Rechenschaft	NOUN	NN	Case=Dat|Gender=Fem|Number=Sing	26	obl	_	_
-26	gezogen	ziehen	VERB	VVPP	VerbForm=Part	29	advcl	_	_
-27	wurde	werden	AUX	VAFIN	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin|Voice=Pass	26	aux:pass	_	SpaceAfter=No
-28	,	,	PUNCT	$,	_	29	punct	_	_
-29	nutzte	nutzen	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	0	root	_	_
-30	sie	sie	PRON	PPER	Case=Nom|Gender=Fem|Number=Sing|Person=3|PronType=Prs	29	nsubj	_	_
-31	ihren	ihr	PRON	PPOSAT	Case=Acc|Gender=Masc|Number=Sing|Poss=Yes	33	det:poss	_	_
-32	hektischen	hektisch	ADJ	ADJA	Case=Acc|Gender=Masc|Number=Sing	33	amod	_	_
-33	Alltag	Alltag	NOUN	NN	Case=Acc|Gender=Masc|Number=Sing	29	obj	_	_
-34	als	als	ADP	APPR	_	35	case	_	_
-35	Politikerin	Politikerin	NOUN	NN	Case=Nom|Gender=Fem|Number=Sing	33	nmod	_	_
-36	und	und	CCONJ	KON	_	37	cc	_	_
-37	Mutter	Mutter	NOUN	NN	Case=Nom|Gender=Fem|Number=Sing	35	conj	_	_
-38	von	von	ADP	APPR	_	40	case	_	_
-39	drei	drei	NUM	CARD	NumType=Card	40	nummod	_	_
-40	Kindern	Kind	NOUN	NN	Case=Dat|Gender=Neut|Number=Plur	37	nmod	_	_
-41	wirkungsvoll	wirkungsvoll	ADV	ADJD	_	29	advmod	_	_
-42	zu	zu	ADP	APPR	_	44	case	_	_
-43	ihrer	ihr	PRON	PPOSAT	Case=Dat|Gender=Fem|Number=Sing|Poss=Yes	44	det:poss	_	_
-44	Verteidigung	Verteidigung	NOUN	NN	Case=Dat|Gender=Fem|Number=Sing	29	obl	_	SpaceAfter=No
-45	:	:	PUNCT	$.	_	29	punct	_	_
+# text = Denn als Sahlin, die nach den höchsten Ämtern in Partei und Regierung strebte, wegen des Mißbrauchs staatlicher Kreditkarten für private Zwecke zur Rechenschaft gezogen wurde, nutzte sie ihren hektischen Alltag als Politikerin und Mutter von drei Kindern wirkungsvoll zu ihrer Verteidigung:
+1	Denn	denn	CCONJ	KON	_	2	dep	_	FixTigerDep=Yes
+2	als	als	SCONJ	KOUS	_	27	mark	_	_
+3	Sahlin	Sahlin	PROPN	NE	Case=Nom|Gender=Fem|Number=Sing	27	nsubj:pass	_	SpaceAfter=No
+4	,	,	PUNCT	$,	_	30	punct	_	_
+5	die	der	PRON	PRELS	Case=Nom|Gender=Fem|Number=Sing|PronType=Rel	14	nsubj	_	_
+6	nach	nach	ADP	APPR	_	9	case	_	_
+7	den	der	DET	ART	Case=Dat|Definite=Def|Gender=Neut|Number=Plur|PronType=Art	9	det	_	_
+8	höchsten	hoch	ADJ	ADJA	Case=Dat|Gender=Neut|Number=Plur	9	amod	_	_
+9	Ämtern	Amt	NOUN	NN	Case=Dat|Gender=Neut|Number=Plur	14	obl	_	_
+10	in	in	ADP	APPR	_	11	case	_	_
+11	Partei	Partei	NOUN	NN	Case=Dat|Gender=Fem|Number=Sing	9	nmod	_	_
+12	und	und	CCONJ	KON	_	13	cc	_	_
+13	Regierung	Regierung	NOUN	NN	Case=Dat|Gender=Fem|Number=Sing	11	conj	_	_
+14	strebte	streben	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	3	acl	_	SpaceAfter=No
+15	,	,	PUNCT	$,	_	30	punct	_	_
+16	wegen	wegen	ADP	APPR	_	18	case	_	_
+17	des	der	DET	ART	Case=Gen|Definite=Def|Gender=Masc|Number=Sing|PronType=Art	18	det	_	_
+18	Mißbrauchs	Mißbrauch	NOUN	NN	Case=Gen|Gender=Masc|Number=Sing	27	obl	_	_
+19	staatlicher	staatlich	ADJ	ADJA	Case=Gen|Gender=Fem|Number=Plur	20	amod	_	_
+20	Kreditkarten	Kreditkarte	NOUN	NN	Case=Gen|Gender=Fem|Number=Plur	18	nmod	_	_
+21	für	für	ADP	APPR	_	23	case	_	_
+22	private	privat	ADJ	ADJA	Case=Acc|Gender=Masc|Number=Plur	23	amod	_	_
+23	Zwecke	Zweck	NOUN	NN	Case=Acc|Gender=Masc|Number=Plur	18	nmod	_	_
+24-25	zur	_	_	_	_	_	_	_	_
+24	zu	zu	ADP	APPR	_	26	case	_	_
+25	der	der	DET	ART	Case=Dat|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	26	det	_	_
+26	Rechenschaft	Rechenschaft	NOUN	NN	Case=Dat|Gender=Fem|Number=Sing	27	obl	_	_
+27	gezogen	ziehen	VERB	VVPP	VerbForm=Part	30	advcl	_	_
+28	wurde	werden	AUX	VAFIN	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin|Voice=Pass	27	aux:pass	_	SpaceAfter=No
+29	,	,	PUNCT	$,	_	30	punct	_	_
+30	nutzte	nutzen	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	0	root	_	_
+31	sie	sie	PRON	PPER	Case=Nom|Gender=Fem|Number=Sing|Person=3|PronType=Prs	30	nsubj	_	_
+32	ihren	ihr	PRON	PPOSAT	Case=Acc|Gender=Masc|Number=Sing|Poss=Yes	34	det:poss	_	_
+33	hektischen	hektisch	ADJ	ADJA	Case=Acc|Gender=Masc|Number=Sing	34	amod	_	_
+34	Alltag	Alltag	NOUN	NN	Case=Acc|Gender=Masc|Number=Sing	30	obj	_	_
+35	als	als	ADP	APPR	_	36	case	_	_
+36	Politikerin	Politikerin	NOUN	NN	Case=Nom|Gender=Fem|Number=Sing	34	nmod	_	_
+37	und	und	CCONJ	KON	_	38	cc	_	_
+38	Mutter	Mutter	NOUN	NN	Case=Nom|Gender=Fem|Number=Sing	36	conj	_	_
+39	von	von	ADP	APPR	_	41	case	_	_
+40	drei	drei	NUM	CARD	NumType=Card	41	nummod	_	_
+41	Kindern	Kind	NOUN	NN	Case=Dat|Gender=Neut|Number=Plur	38	nmod	_	_
+42	wirkungsvoll	wirkungsvoll	ADV	ADJD	_	30	advmod	_	_
+43	zu	zu	ADP	APPR	_	45	case	_	_
+44	ihrer	ihr	PRON	PPOSAT	Case=Dat|Gender=Fem|Number=Sing|Poss=Yes	45	det:poss	_	_
+45	Verteidigung	Verteidigung	NOUN	NN	Case=Dat|Gender=Fem|Number=Sing	30	obl	_	SpaceAfter=No
+46	:	:	PUNCT	$.	_	30	punct	_	_
 
 # sent_id = test-s331
-# text = Alteigentümer kündigten damals ihre Mitgliedschaft in der LPG auf:
-1	Alteigentümer	Alteigentümer	NOUN	NN	Case=Nom|Gender=Masc|Number=Plur	2	nsubj	_	_
-2	kündigten	kündigen	VERB	VVFIN	Mood=Ind|Number=Plur|Person=3|Tense=Past|VerbForm=Fin	0	root	_	_
-3	damals	damals	ADV	ADV	_	2	advmod	_	_
-4	ihre	ihr	PRON	PPOSAT	Case=Acc|Gender=Fem|Number=Sing|Poss=Yes	5	det:poss	_	_
-5	Mitgliedschaft	Mitgliedschaft	NOUN	NN	Case=Acc|Gender=Fem|Number=Sing	2	obj	_	_
-6	in	in	ADP	APPR	_	8	case	_	_
-7	der	der	DET	ART	Case=Dat|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	8	det	_	_
-8	LPG	LPG	PROPN	NN	Case=Dat|Gender=Fem|Number=Sing	2	obl	_	_
-9	auf	auf	ADP	PTKVZ	_	2	compound:prt	_	SpaceAfter=No
-10	:	:	PUNCT	$.	_	2	punct	_	_
+# text = 60 Alteigentümer kündigten damals ihre Mitgliedschaft in der LPG auf:
+1	60	60	NUM	CARD	NumType=Card	2	dep	_	FixTigerDep=Yes
+2	Alteigentümer	Alteigentümer	NOUN	NN	Case=Nom|Gender=Masc|Number=Plur	3	nsubj	_	_
+3	kündigten	kündigen	VERB	VVFIN	Mood=Ind|Number=Plur|Person=3|Tense=Past|VerbForm=Fin	0	root	_	_
+4	damals	damals	ADV	ADV	_	3	advmod	_	_
+5	ihre	ihr	PRON	PPOSAT	Case=Acc|Gender=Fem|Number=Sing|Poss=Yes	6	det:poss	_	_
+6	Mitgliedschaft	Mitgliedschaft	NOUN	NN	Case=Acc|Gender=Fem|Number=Sing	3	obj	_	_
+7	in	in	ADP	APPR	_	9	case	_	_
+8	der	der	DET	ART	Case=Dat|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	9	det	_	_
+9	LPG	LPG	PROPN	NN	Case=Dat|Gender=Fem|Number=Sing	3	obl	_	_
+10	auf	auf	ADP	PTKVZ	_	3	compound:prt	_	SpaceAfter=No
+11	:	:	PUNCT	$.	_	3	punct	_	_
 
 # sent_id = test-s332
-# text = Amerikaner müssen hart arbeiten, um das Land wieder auf den richtigen Kurs zu bringen.
-1	Amerikaner	Amerikaner	NOUN	NN	Case=Nom|Gender=Masc|Number=Plur	4	nsubj	_	_
-2	müssen	müssen	AUX	VMFIN	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	4	aux	_	_
-3	hart	hart	ADV	ADJD	_	4	advmod	_	_
-4	arbeiten	arbeiten	VERB	VVINF	VerbForm=Inf	0	root	_	SpaceAfter=No
-5	,	,	PUNCT	$,	_	4	punct	_	_
-6	um	um	ADP	KOUI	_	15	mark	_	_
-7	das	der	DET	ART	Case=Acc|Definite=Def|Gender=Neut|Number=Sing|PronType=Art	8	det	_	_
-8	Land	Land	NOUN	NN	Case=Acc|Gender=Neut|Number=Sing	15	obj	_	_
-9	wieder	wieder	ADV	ADV	_	15	advmod	_	_
-10	auf	auf	ADP	APPR	_	13	case	_	_
-11	den	der	DET	ART	Case=Acc|Definite=Def|Gender=Masc|Number=Sing|PronType=Art	13	det	_	_
-12	richtigen	richtig	ADJ	ADJA	Case=Acc|Gender=Masc|Number=Sing	13	amod	_	_
-13	Kurs	Kurs	NOUN	NN	Case=Acc|Gender=Masc|Number=Sing	15	obl	_	_
-14	zu	zu	PART	PTKZU	_	15	mark	_	_
-15	bringen	bringen	VERB	VVINF	VerbForm=Inf	4	advcl	_	SpaceAfter=No
-16	.	.	PUNCT	$.	_	4	punct	_	_
+# text = Die Amerikaner müssen hart arbeiten, um das Land wieder auf den richtigen Kurs zu bringen.
+1	Die	der	DET	ART	Case=Nom|Definite=Def|Gender=Masc|Number=Plur|PronType=Art	2	dep	_	FixTigerDep=Yes
+2	Amerikaner	Amerikaner	NOUN	NN	Case=Nom|Gender=Masc|Number=Plur	5	nsubj	_	_
+3	müssen	müssen	AUX	VMFIN	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	5	aux	_	_
+4	hart	hart	ADV	ADJD	_	5	advmod	_	_
+5	arbeiten	arbeiten	VERB	VVINF	VerbForm=Inf	0	root	_	SpaceAfter=No
+6	,	,	PUNCT	$,	_	5	punct	_	_
+7	um	um	ADP	KOUI	_	16	mark	_	_
+8	das	der	DET	ART	Case=Acc|Definite=Def|Gender=Neut|Number=Sing|PronType=Art	9	det	_	_
+9	Land	Land	NOUN	NN	Case=Acc|Gender=Neut|Number=Sing	16	obj	_	_
+10	wieder	wieder	ADV	ADV	_	16	advmod	_	_
+11	auf	auf	ADP	APPR	_	14	case	_	_
+12	den	der	DET	ART	Case=Acc|Definite=Def|Gender=Masc|Number=Sing|PronType=Art	14	det	_	_
+13	richtigen	richtig	ADJ	ADJA	Case=Acc|Gender=Masc|Number=Sing	14	amod	_	_
+14	Kurs	Kurs	NOUN	NN	Case=Acc|Gender=Masc|Number=Sing	16	obl	_	_
+15	zu	zu	PART	PTKZU	_	16	mark	_	_
+16	bringen	bringen	VERB	VVINF	VerbForm=Inf	5	advcl	_	SpaceAfter=No
+17	.	.	PUNCT	$.	_	5	punct	_	_
 
 # sent_id = test-s333
-# text = Anfang eines Films steht immer die Musikalität, der Rhythmus.
-1	Anfang	Anfang	NOUN	NN	Case=Dat|Gender=Masc|Number=Sing	4	dep	_	_
-2	eines	ein	DET	ART	Case=Gen|Definite=Ind|Gender=Masc|Number=Sing|PronType=Art	3	det	_	_
-3	Films	Film	NOUN	NN	Case=Gen|Gender=Masc|Number=Sing	1	nmod	_	_
-4	steht	stehen	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	0	root	_	_
-5	immer	immer	ADV	ADV	_	4	advmod	_	_
-6	die	der	DET	ART	Case=Nom|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	7	det	_	_
-7	Musikalität	Musikalität	NOUN	NN	Case=Nom|Gender=Fem|Number=Sing	4	nsubj	_	SpaceAfter=No
-8	,	,	PUNCT	$,	_	10	punct	_	_
-9	der	der	DET	ART	Case=Nom|Definite=Def|Gender=Masc|Number=Sing|PronType=Art	10	det	_	_
-10	Rhythmus	Rhythmus	NOUN	NN	Case=Nom|Gender=Masc|Number=Sing	7	conj	_	SpaceAfter=No
-11	.	.	PUNCT	$.	_	4	punct	_	_
+# text = Am Anfang eines Films steht immer die Musikalität, der Rhythmus.
+1-2	Am	_	_	_	_	_	_	_	_
+1	An	an	ADP	APPR	_	3	case	_	FixTigerDep=Yes
+2	dem	der	DET	ART	Case=Dat|Gender=Masc|Number=Sing	3	det	_	_
+3	Anfang	Anfang	NOUN	NN	Case=Dat|Gender=Masc|Number=Sing	6	dep	_	_
+4	eines	ein	DET	ART	Case=Gen|Definite=Ind|Gender=Masc|Number=Sing|PronType=Art	5	det	_	_
+5	Films	Film	NOUN	NN	Case=Gen|Gender=Masc|Number=Sing	3	nmod	_	_
+6	steht	stehen	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	0	root	_	_
+7	immer	immer	ADV	ADV	_	6	advmod	_	_
+8	die	der	DET	ART	Case=Nom|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	9	det	_	_
+9	Musikalität	Musikalität	NOUN	NN	Case=Nom|Gender=Fem|Number=Sing	6	nsubj	_	SpaceAfter=No
+10	,	,	PUNCT	$,	_	12	punct	_	_
+11	der	der	DET	ART	Case=Nom|Definite=Def|Gender=Masc|Number=Sing|PronType=Art	12	det	_	_
+12	Rhythmus	Rhythmus	NOUN	NN	Case=Nom|Gender=Masc|Number=Sing	9	conj	_	SpaceAfter=No
+13	.	.	PUNCT	$.	_	6	punct	_	_
 
 # sent_id = test-s334
-# text = Angaben von Bundesbildungsminister Jürgen Rüttgers haben seither 55 000 Gesellen, Facharbeiter und andere Interessenten einen Antrag auf finanzielle Förderung ihrer Weiterbildung zum Meister, Techniker oder für vergleichbare Qualifikationen gestellt.
-1	Angaben	Angabe	NOUN	NN	Case=Dat|Gender=Fem|Number=Plur	32	dep	_	_
-2	von	von	ADP	APPR	_	4	case	_	_
-3	Bundesbildungsminister	Bundesbildungsminister	NOUN	NN	Case=Nom|Gender=Masc|Number=Sing	4	compound	_	_
-4	Jürgen	Jürgen	PROPN	NE	Case=Nom|Gender=Masc|Number=Sing	1	nmod	_	_
-5	Rüttgers	Rüttgers	PROPN	NE	Case=Dat|Gender=Masc|Number=Sing	4	flat	_	_
-6	haben	haben	AUX	VAFIN	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	32	aux	_	_
-7	seither	seither	ADV	ADV	_	32	advmod	_	_
-8	55	55	NUM	CARD	NumType=Card	9	nummod	_	_
-9	000	000	NUM	CARD	NumType=Card	10	nummod	_	_
-10	Gesellen	Geselle	NOUN	NN	Case=Nom|Gender=Masc|Number=Plur	32	nsubj	_	SpaceAfter=No
-11	,	,	PUNCT	$,	_	12	punct	_	_
-12	Facharbeiter	Facharbeiter	NOUN	NN	Case=Nom|Gender=Masc|Number=Plur	10	conj	_	_
-13	und	und	CCONJ	KON	_	15	cc	_	_
-14	andere	anderer	ADJ	ADJA	Case=Nom|Gender=Masc|Number=Plur	15	amod	_	_
-15	Interessenten	Interessent	NOUN	NN	Case=Nom|Gender=Masc|Number=Plur	10	conj	_	_
-16	einen	ein	DET	ART	Case=Acc|Definite=Ind|Gender=Masc|Number=Sing|PronType=Art	17	det	_	_
-17	Antrag	Antrag	NOUN	NN	Case=Acc|Gender=Masc|Number=Sing	32	obj	_	_
-18	auf	auf	ADP	APPR	_	20	case	_	_
-19	finanzielle	finanziell	ADJ	ADJA	Case=Acc|Gender=Fem|Number=Sing	20	amod	_	_
-20	Förderung	Förderung	NOUN	NN	Case=Acc|Gender=Fem|Number=Sing	17	nmod	_	_
-21	ihrer	ihr	PRON	PPOSAT	Case=Gen|Gender=Fem|Number=Sing|Poss=Yes	22	det:poss	_	_
-22	Weiterbildung	Weiterbildung	NOUN	NN	Case=Gen|Gender=Fem|Number=Sing	20	nmod	_	_
-23-24	zum	_	_	_	_	_	_	_	_
-23	zu	zu	ADP	APPR	_	22	case	_	_
-24	dem	der	DET	ART	Case=Dat|Definite=Def|Gender=Masc|Number=Sing|PronType=Art	22	det	_	_
-25	Meister	Meister	NOUN	NN	Case=Dat|Gender=Masc|Number=Sing	23	compound	_	SpaceAfter=No
-26	,	,	PUNCT	$,	_	25	punct	_	_
-27	Techniker	Techniker	NOUN	NN	Case=Dat|Gender=Masc|Number=Sing	25	nmod	_	_
-28	oder	oder	CCONJ	KON	_	22	cc	_	_
-29	für	für	ADP	APPR	_	31	case	_	_
-30	vergleichbare	vergleichbar	ADJ	ADJA	Case=Acc|Gender=Fem|Number=Plur	31	amod	_	_
-31	Qualifikationen	Qualifikation	NOUN	NN	Case=Acc|Gender=Fem|Number=Plur	22	nmod	_	_
-32	gestellt	stellen	VERB	VVPP	VerbForm=Part	0	root	_	SpaceAfter=No
-33	.	.	PUNCT	$.	_	32	punct	_	_
+# text = Nach Angaben von Bundesbildungsminister Jürgen Rüttgers haben seither 55 000 Gesellen, Facharbeiter und andere Interessenten einen Antrag auf finanzielle Förderung ihrer Weiterbildung zum Meister, Techniker oder für vergleichbare Qualifikationen gestellt.
+1	Nach	nach	ADP	APPR	_	2	dep	_	FixTigerDep=Yes
+2	Angaben	Angabe	NOUN	NN	Case=Dat|Gender=Fem|Number=Plur	33	dep	_	_
+3	von	von	ADP	APPR	_	5	case	_	_
+4	Bundesbildungsminister	Bundesbildungsminister	NOUN	NN	Case=Nom|Gender=Masc|Number=Sing	5	compound	_	_
+5	Jürgen	Jürgen	PROPN	NE	Case=Nom|Gender=Masc|Number=Sing	2	nmod	_	_
+6	Rüttgers	Rüttgers	PROPN	NE	Case=Dat|Gender=Masc|Number=Sing	5	flat	_	_
+7	haben	haben	AUX	VAFIN	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	33	aux	_	_
+8	seither	seither	ADV	ADV	_	33	advmod	_	_
+9	55	55	NUM	CARD	NumType=Card	10	nummod	_	_
+10	000	000	NUM	CARD	NumType=Card	11	nummod	_	_
+11	Gesellen	Geselle	NOUN	NN	Case=Nom|Gender=Masc|Number=Plur	33	nsubj	_	SpaceAfter=No
+12	,	,	PUNCT	$,	_	13	punct	_	_
+13	Facharbeiter	Facharbeiter	NOUN	NN	Case=Nom|Gender=Masc|Number=Plur	11	conj	_	_
+14	und	und	CCONJ	KON	_	16	cc	_	_
+15	andere	anderer	ADJ	ADJA	Case=Nom|Gender=Masc|Number=Plur	16	amod	_	_
+16	Interessenten	Interessent	NOUN	NN	Case=Nom|Gender=Masc|Number=Plur	11	conj	_	_
+17	einen	ein	DET	ART	Case=Acc|Definite=Ind|Gender=Masc|Number=Sing|PronType=Art	18	det	_	_
+18	Antrag	Antrag	NOUN	NN	Case=Acc|Gender=Masc|Number=Sing	33	obj	_	_
+19	auf	auf	ADP	APPR	_	21	case	_	_
+20	finanzielle	finanziell	ADJ	ADJA	Case=Acc|Gender=Fem|Number=Sing	21	amod	_	_
+21	Förderung	Förderung	NOUN	NN	Case=Acc|Gender=Fem|Number=Sing	18	nmod	_	_
+22	ihrer	ihr	PRON	PPOSAT	Case=Gen|Gender=Fem|Number=Sing|Poss=Yes	23	det:poss	_	_
+23	Weiterbildung	Weiterbildung	NOUN	NN	Case=Gen|Gender=Fem|Number=Sing	21	nmod	_	_
+24-25	zum	_	_	_	_	_	_	_	_
+24	zu	zu	ADP	APPR	_	23	case	_	_
+25	dem	der	DET	ART	Case=Dat|Definite=Def|Gender=Masc|Number=Sing|PronType=Art	23	det	_	_
+26	Meister	Meister	NOUN	NN	Case=Dat|Gender=Masc|Number=Sing	24	compound	_	SpaceAfter=No
+27	,	,	PUNCT	$,	_	26	punct	_	_
+28	Techniker	Techniker	NOUN	NN	Case=Dat|Gender=Masc|Number=Sing	26	nmod	_	_
+29	oder	oder	CCONJ	KON	_	23	cc	_	_
+30	für	für	ADP	APPR	_	32	case	_	_
+31	vergleichbare	vergleichbar	ADJ	ADJA	Case=Acc|Gender=Fem|Number=Plur	32	amod	_	_
+32	Qualifikationen	Qualifikation	NOUN	NN	Case=Acc|Gender=Fem|Number=Plur	23	nmod	_	_
+33	gestellt	stellen	VERB	VVPP	VerbForm=Part	0	root	_	SpaceAfter=No
+34	.	.	PUNCT	$.	_	33	punct	_	_
 
 # sent_id = test-s335
 # text = Angola erhält von der Europäischen Gemeinschaft rund vier Millionen Mark zur Vorbereitung der für Ende 1992 geplanten freien Wahlen.
@@ -5954,67 +5972,69 @@
 21	.	.	PUNCT	$.	_	2	punct	_	_
 
 # sent_id = test-s336
-# text = Angriff führte die Regierung vor allem auf dem Feld, auf dem sie selbst nach dem Massaker in Boipatong am ärgsten in Bedrängnis geraten war: der anhaltenden Gewalt.
-1	Angriff	Angriff	NOUN	NN	Case=Acc|Gender=Masc|Number=Sing	2	obj	_	_
-2	führte	führen	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	0	root	_	_
-3	die	der	DET	ART	Case=Nom|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	4	det	_	_
-4	Regierung	Regierung	NOUN	NN	Case=Nom|Gender=Fem|Number=Sing	2	nsubj	_	_
-5	vor	vor	ADP	APPR	_	2	fixed	_	_
-6	allem	alle	ADV	PIS	Case=Dat|Definite=Ind|Gender=Neut|Number=Sing|PronType=Ind	5	advmod	_	_
-7	auf	auf	ADP	APPR	_	9	case	_	_
-8	dem	der	DET	ART	Case=Dat|Definite=Def|Gender=Neut|Number=Sing|PronType=Art	9	det	_	_
-9	Feld	Feld	NOUN	NN	Case=Dat|Gender=Neut|Number=Sing	2	obl	_	SpaceAfter=No
-10	,	,	PUNCT	$,	_	2	punct	_	_
-11	auf	auf	ADP	APPR	_	12	case	_	_
-12	dem	der	PRON	PRELS	Case=Dat|Gender=Neut|Number=Sing|PronType=Rel	25	obl	_	_
-13	sie	sie	PRON	PPER	Case=Nom|Gender=Fem|Number=Sing|Person=3|PronType=Prs	25	nsubj	_	_
-14	selbst	selbst	ADV	ADV	_	13	advmod	_	_
-15	nach	nach	ADP	APPR	_	17	case	_	_
-16	dem	der	DET	ART	Case=Dat|Definite=Def|Gender=Neut|Number=Sing|PronType=Art	17	det	_	_
-17	Massaker	Massaker	NOUN	NN	Case=Dat|Gender=Neut|Number=Sing	25	obl	_	_
-18	in	in	ADP	APPR	_	19	case	_	_
-19	Boipatong	Boipatong	PROPN	NE	Case=Dat|Gender=Neut|Number=Sing	17	nmod	_	_
-20-21	am	_	_	_	_	_	_	_	_
-20	an	an	ADP	APPR	_	22	case	_	_
-21	dem	der	DET	ART	Case=Dat|Definite=Def|Gender=Masc|Number=Sing|PronType=Art	22	det	_	_
-22	ärgsten	arg	ADJ	ADJD	_	25	amod	_	_
-23	in	in	ADP	APPR	_	24	case	_	_
-24	Bedrängnis	Bedrängnis	NOUN	NN	Case=Acc|Gender=Fem|Number=Sing	25	obl	_	_
-25	geraten	geraten	VERB	VVPP	VerbForm=Part	9	acl	_	_
-26	war	sein	AUX	VAFIN	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	25	aux	_	SpaceAfter=No
-27	:	:	PUNCT	$.	_	2	punct	_	_
-28	der	der	DET	ART	Case=Gen|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	30	det	_	_
-29	anhaltenden	anhaltend	ADJ	ADJA	Case=Gen|Gender=Fem|Number=Sing	30	amod	_	_
-30	Gewalt	Gewalt	NOUN	NN	Case=Gen|Gender=Fem|Number=Sing	9	nmod	_	SpaceAfter=No
-31	.	.	PUNCT	$.	_	2	punct	_	_
+# text = Den Angriff führte die Regierung vor allem auf dem Feld, auf dem sie selbst nach dem Massaker in Boipatong am ärgsten in Bedrängnis geraten war: der anhaltenden Gewalt.
+1	Den	der	DET	ART	Case=Acc|Definite=Def|Gender=Masc|Number=Sing|PronType=Art	2	dep	_	FixTigerDep=Yes
+2	Angriff	Angriff	NOUN	NN	Case=Acc|Gender=Masc|Number=Sing	3	obj	_	_
+3	führte	führen	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	0	root	_	_
+4	die	der	DET	ART	Case=Nom|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	5	det	_	_
+5	Regierung	Regierung	NOUN	NN	Case=Nom|Gender=Fem|Number=Sing	3	nsubj	_	_
+6	vor	vor	ADP	APPR	_	3	fixed	_	_
+7	allem	alle	ADV	PIS	Case=Dat|Definite=Ind|Gender=Neut|Number=Sing|PronType=Ind	6	advmod	_	_
+8	auf	auf	ADP	APPR	_	10	case	_	_
+9	dem	der	DET	ART	Case=Dat|Definite=Def|Gender=Neut|Number=Sing|PronType=Art	10	det	_	_
+10	Feld	Feld	NOUN	NN	Case=Dat|Gender=Neut|Number=Sing	3	obl	_	SpaceAfter=No
+11	,	,	PUNCT	$,	_	3	punct	_	_
+12	auf	auf	ADP	APPR	_	13	case	_	_
+13	dem	der	PRON	PRELS	Case=Dat|Gender=Neut|Number=Sing|PronType=Rel	26	obl	_	_
+14	sie	sie	PRON	PPER	Case=Nom|Gender=Fem|Number=Sing|Person=3|PronType=Prs	26	nsubj	_	_
+15	selbst	selbst	ADV	ADV	_	14	advmod	_	_
+16	nach	nach	ADP	APPR	_	18	case	_	_
+17	dem	der	DET	ART	Case=Dat|Definite=Def|Gender=Neut|Number=Sing|PronType=Art	18	det	_	_
+18	Massaker	Massaker	NOUN	NN	Case=Dat|Gender=Neut|Number=Sing	26	obl	_	_
+19	in	in	ADP	APPR	_	20	case	_	_
+20	Boipatong	Boipatong	PROPN	NE	Case=Dat|Gender=Neut|Number=Sing	18	nmod	_	_
+21-22	am	_	_	_	_	_	_	_	_
+21	an	an	ADP	APPR	_	23	case	_	_
+22	dem	der	DET	ART	Case=Dat|Definite=Def|Gender=Masc|Number=Sing|PronType=Art	23	det	_	_
+23	ärgsten	arg	ADJ	ADJD	_	26	amod	_	_
+24	in	in	ADP	APPR	_	25	case	_	_
+25	Bedrängnis	Bedrängnis	NOUN	NN	Case=Acc|Gender=Fem|Number=Sing	26	obl	_	_
+26	geraten	geraten	VERB	VVPP	VerbForm=Part	10	acl	_	_
+27	war	sein	AUX	VAFIN	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	26	aux	_	SpaceAfter=No
+28	:	:	PUNCT	$.	_	3	punct	_	_
+29	der	der	DET	ART	Case=Gen|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	31	det	_	_
+30	anhaltenden	anhaltend	ADJ	ADJA	Case=Gen|Gender=Fem|Number=Sing	31	amod	_	_
+31	Gewalt	Gewalt	NOUN	NN	Case=Gen|Gender=Fem|Number=Sing	10	nmod	_	SpaceAfter=No
+32	.	.	PUNCT	$.	_	3	punct	_	_
 
 # sent_id = test-s337
-# text = Anhänger Nichtwalesas schreckt die Vision, daß ein ihrer Meinung nach unberechenbarer Elektriker mit ungeschliffener Sprache Polen ins Jahr 2000 führen könnte;
-1	Anhänger	Anhänger	NOUN	NN	Case=Acc|Gender=Masc|Number=Plur	3	obj	_	_
-2	Nichtwalesas	Nichtwalesas	PROPN	NN	Case=Gen|Number=Sing	1	nmod	_	_
-3	schreckt	schrecken	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	0	root	_	_
-4	die	der	DET	ART	Case=Nom|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	5	det	_	_
-5	Vision	Vision	NOUN	NN	Case=Nom|Gender=Fem|Number=Sing	3	nsubj	_	SpaceAfter=No
-6	,	,	PUNCT	$,	_	3	punct	_	_
-7	daß	daß	SCONJ	KOUS	_	22	mark	_	_
-8	ein	ein	DET	ART	Case=Nom|Definite=Ind|Gender=Masc|Number=Sing|PronType=Art	13	det	_	_
-9	ihrer	ihr	PRON	PPOSAT	Case=Dat|Gender=Fem|Number=Sing|Poss=Yes	10	det:poss	_	_
-10	Meinung	Meinung	NOUN	NN	Case=Dat|Gender=Fem|Number=Sing	12	nmod	_	_
-11	nach	nach	ADP	APPO	Case=Dat	10	case	_	_
-12	unberechenbarer	unberechenbar	ADJ	ADJA	Case=Nom|Gender=Masc|Number=Sing	13	amod	_	_
-13	Elektriker	Elektriker	NOUN	NN	Case=Nom|Gender=Masc|Number=Sing	22	nsubj	_	_
-14	mit	mit	ADP	APPR	_	16	case	_	_
-15	ungeschliffener	ungeschliffen	ADJ	ADJA	Case=Dat|Gender=Fem|Number=Sing	16	amod	_	_
-16	Sprache	Sprache	NOUN	NN	Case=Dat|Gender=Fem|Number=Sing	13	nmod	_	_
-17	Polen	Polen	PROPN	NE	Case=Acc|Gender=Neut|Number=Sing	22	obj	_	_
-18-19	ins	_	_	_	_	_	_	_	_
-18	in	in	ADP	APPR	_	20	case	_	_
-19	das	der	DET	ART	Case=Acc|Definite=Def|Gender=Neut|Number=Sing|PronType=Art	20	det	_	_
-20	Jahr	Jahr	NOUN	NN	Case=Acc|Gender=Neut|Number=Sing	22	obl	_	_
-21	2000	2000	NUM	CARD	NumType=Card	20	nummod	_	_
-22	führen	führen	VERB	VVINF	VerbForm=Inf	3	ccomp	_	_
-23	könnte	können	AUX	VMFIN	Mood=Sub|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	22	aux	_	SpaceAfter=No
-24	;	;	PUNCT	$.	_	3	punct	_	_
+# text = Die Anhänger Nichtwalesas schreckt die Vision, daß ein ihrer Meinung nach unberechenbarer Elektriker mit ungeschliffener Sprache Polen ins Jahr 2000 führen könnte;
+1	Die	der	DET	ART	Case=Acc|Definite=Def|Gender=Masc|Number=Plur|PronType=Art	2	dep	_	FixTigerDep=Yes
+2	Anhänger	Anhänger	NOUN	NN	Case=Acc|Gender=Masc|Number=Plur	4	obj	_	_
+3	Nichtwalesas	Nichtwalesa	PROPN	NN	Case=Gen|Number=Sing	2	nmod	_	_
+4	schreckt	schrecken	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	0	root	_	_
+5	die	der	DET	ART	Case=Nom|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	6	det	_	_
+6	Vision	Vision	NOUN	NN	Case=Nom|Gender=Fem|Number=Sing	4	nsubj	_	SpaceAfter=No
+7	,	,	PUNCT	$,	_	4	punct	_	_
+8	daß	daß	SCONJ	KOUS	_	23	mark	_	_
+9	ein	ein	DET	ART	Case=Nom|Definite=Ind|Gender=Masc|Number=Sing|PronType=Art	14	det	_	_
+10	ihrer	ihr	PRON	PPOSAT	Case=Dat|Gender=Fem|Number=Sing|Poss=Yes	11	det:poss	_	_
+11	Meinung	Meinung	NOUN	NN	Case=Dat|Gender=Fem|Number=Sing	13	nmod	_	_
+12	nach	nach	ADP	APPO	Case=Dat	11	case	_	_
+13	unberechenbarer	unberechenbar	ADJ	ADJA	Case=Nom|Gender=Masc|Number=Sing	14	amod	_	_
+14	Elektriker	Elektriker	NOUN	NN	Case=Nom|Gender=Masc|Number=Sing	23	nsubj	_	_
+15	mit	mit	ADP	APPR	_	17	case	_	_
+16	ungeschliffener	ungeschliffen	ADJ	ADJA	Case=Dat|Gender=Fem|Number=Sing	17	amod	_	_
+17	Sprache	Sprache	NOUN	NN	Case=Dat|Gender=Fem|Number=Sing	14	nmod	_	_
+18	Polen	Polen	PROPN	NE	Case=Acc|Gender=Neut|Number=Sing	23	obj	_	_
+19-20	ins	_	_	_	_	_	_	_	_
+19	in	in	ADP	APPR	_	21	case	_	_
+20	das	der	DET	ART	Case=Acc|Definite=Def|Gender=Neut|Number=Sing|PronType=Art	21	det	_	_
+21	Jahr	Jahr	NOUN	NN	Case=Acc|Gender=Neut|Number=Sing	23	obl	_	_
+22	2000	2000	NUM	CARD	NumType=Card	21	nummod	_	_
+23	führen	führen	VERB	VVINF	VerbForm=Inf	4	ccomp	_	_
+24	könnte	können	AUX	VMFIN	Mood=Sub|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	23	aux	_	SpaceAfter=No
+25	;	;	PUNCT	$.	_	4	punct	_	_
 
 # sent_id = test-s338
 # text = Ankündigung von Bundeswirtschaftsminister Jürgen Möllemann (FDP,) er wolle die Möglichkeit zur untertariflichen Bezahlung von Beschäftigten schaffen, hat in den fünf neuen Ländern bereits zu Nachteilen für Arbeitnehmer geführt.
@@ -6055,118 +6075,121 @@
 34	.	.	PUNCT	$.	_	33	punct	_	_
 
 # sent_id = test-s339
-# text = Anstieg der Rohstoffpreise wird sich nach Einschätzung des Münchner Ifo-Instituts 1996 deutlich abschwächen.
-1	Anstieg	Anstieg	NOUN	NN	Case=Nom|Gender=Masc|Number=Sing	15	nsubj	_	_
-2	der	der	DET	ART	Case=Gen|Definite=Def|Gender=Masc|Number=Plur|PronType=Art	3	det	_	_
-3	Rohstoffpreise	Rohstoffpreis	NOUN	NN	Case=Gen|Gender=Masc|Number=Plur	1	nmod	_	_
-4	wird	werden	AUX	VAFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	15	aux	_	_
-5	sich	er|es|sie	PRON	PRF	Case=Acc|Number=Sing|Person=3|PronType=Prs|Reflex=Yes	15	obj	_	_
-6	nach	nach	ADP	APPR	_	7	case	_	_
-7	Einschätzung	Einschätzung	NOUN	NN	Case=Dat|Gender=Fem|Number=Sing	15	obl	_	_
-8	des	der	DET	ART	Case=Gen|Definite=Def|Gender=Neut|Number=Sing|PronType=Art	10	det	_	_
-9	Münchner	Münchner	ADJ	ADJA	_	10	amod	_	_
-10	Ifo	Ifo	PROPN	NN	Case=Gen|Gender=Neut|Number=Sing	12	compound	_	SpaceAfter=No
-11	-	-	PUNCT	$(	_	10	punct	_	SpaceAfter=No
-12	Instituts	Institut	NOUN	NN	Case=Gen|Gender=Neut|Number=Sing	7	nmod	_	_
-13	1996	1996	NUM	CARD	NumType=Card	15	obl	_	_
-14	deutlich	deutlich	ADV	ADJD	_	15	advmod	_	_
-15	abschwächen	abschwächen	VERB	VVINF	VerbForm=Inf	0	root	_	SpaceAfter=No
-16	.	.	PUNCT	$.	_	15	punct	_	_
+# text = Der Anstieg der Rohstoffpreise wird sich nach Einschätzung des Münchner Ifo-Instituts 1996 deutlich abschwächen.
+1	Der	der	DET	ART	Case=Nom|Definite=Def|Gender=Masc|Number=Sing|PronType=Art	2	dep	_	FixTigerDep=Yes
+2	Anstieg	Anstieg	NOUN	NN	Case=Nom|Gender=Masc|Number=Sing	16	nsubj	_	_
+3	der	der	DET	ART	Case=Gen|Definite=Def|Gender=Masc|Number=Plur|PronType=Art	4	det	_	_
+4	Rohstoffpreise	Rohstoffpreis	NOUN	NN	Case=Gen|Gender=Masc|Number=Plur	2	nmod	_	_
+5	wird	werden	AUX	VAFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	16	aux	_	_
+6	sich	er|es|sie	PRON	PRF	Case=Acc|Number=Sing|Person=3|PronType=Prs|Reflex=Yes	16	obj	_	_
+7	nach	nach	ADP	APPR	_	8	case	_	_
+8	Einschätzung	Einschätzung	NOUN	NN	Case=Dat|Gender=Fem|Number=Sing	16	obl	_	_
+9	des	der	DET	ART	Case=Gen|Definite=Def|Gender=Neut|Number=Sing|PronType=Art	11	det	_	_
+10	Münchner	Münchner	ADJ	ADJA	_	11	amod	_	_
+11	Ifo	Ifo	PROPN	NN	Case=Gen|Gender=Neut|Number=Sing	13	compound	_	SpaceAfter=No
+12	-	-	PUNCT	$(	_	11	punct	_	SpaceAfter=No
+13	Instituts	Institut	NOUN	NN	Case=Gen|Gender=Neut|Number=Sing	8	nmod	_	_
+14	1996	1996	NUM	CARD	NumType=Card	16	obl	_	_
+15	deutlich	deutlich	ADV	ADJD	_	16	advmod	_	_
+16	abschwächen	abschwächen	VERB	VVINF	VerbForm=Inf	0	root	_	SpaceAfter=No
+17	.	.	PUNCT	$.	_	16	punct	_	_
 
 # sent_id = test-s340
-# text = Antwort auf die Frage, warum es nicht rechtzeitig gelungen ist, den Flughafen von Sarajewo zur humanitären Versorgung der Stadt freizubekommen -- das heißt auch notfalls freizukämpfen -- wird es in künftigen Fällen nicht mehr ausreichen, wie heute auf das Grundgesetz zu verweisen.
-1	Antwort	Antwort	NOUN	NN	Case=Acc|Gender=Fem|Number=Sing	38	dep	_	_
-2	auf	auf	ADP	APPR	_	4	case	_	_
-3	die	der	DET	ART	Case=Acc|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	4	det	_	_
-4	Frage	Frage	NOUN	NN	Case=Acc|Gender=Fem|Number=Sing	1	nmod	_	SpaceAfter=No
-5	,	,	PUNCT	$,	_	38	punct	_	_
-6	warum	warum	SCONJ	PWAV	PronType=Int	10	mark	_	_
-7	es	es	PRON	PPER	Case=Nom|Gender=Neut|Number=Sing|Person=3|PronType=Prs	10	nsubj	_	_
-8	nicht	nicht	PART	PTKNEG	Polarity=Neg	10	advmod	_	_
-9	rechtzeitig	rechtzeitig	ADV	ADJD	_	10	advmod	_	_
-10	gelungen	gelingen	VERB	VVPP	VerbForm=Part	4	advcl	_	_
-11	ist	sein	AUX	VAFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	10	aux	_	SpaceAfter=No
-12	,	,	PUNCT	$,	_	38	punct	_	_
-13	den	der	DET	ART	Case=Acc|Definite=Def|Gender=Masc|Number=Sing|PronType=Art	14	det	_	_
-14	Flughafen	Flughafen	NOUN	NN	Case=Acc|Gender=Masc|Number=Sing	23	obj	_	_
-15	von	von	ADP	APPR	_	16	case	_	_
-16	Sarajewo	Sarajewo	PROPN	NE	Case=Dat|Gender=Neut|Number=Sing	14	nmod	_	_
-17-18	zur	_	_	_	_	_	_	_	_
-17	zu	zu	ADP	APPR	_	20	case	_	_
-18	der	der	DET	ART	Case=Dat|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	20	det	_	_
-19	humanitären	humanitär	ADJ	ADJA	Case=Dat|Gender=Fem|Number=Sing	20	amod	_	_
-20	Versorgung	Versorgung	NOUN	NN	Case=Dat|Gender=Fem|Number=Sing	23	obl	_	_
-21	der	der	DET	ART	Case=Gen|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	22	det	_	_
-22	Stadt	Stadt	NOUN	NN	Case=Gen|Gender=Fem|Number=Sing	20	nmod	_	_
-23	freizubekommen	freibekommen	VERB	VVIZU	VerbForm=Inf	10	xcomp	_	_
-24	--	--	PUNCT	$(	_	26	punct	_	_
-25	das	der	PRON	PDS	Case=Nom|Gender=Neut|Number=Sing|PronType=Dem	26	det	_	_
-26	heißt	heißen	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	23	parataxis	_	_
-27	auch	auch	ADV	ADV	_	26	advmod	_	_
-28	notfalls	notfalls	ADV	ADV	_	29	advmod	_	_
-29	freizukämpfen	freikämpfen	VERB	VVIZU	VerbForm=Inf	26	xcomp	_	_
-30	--	--	PUNCT	$(	_	26	punct	_	_
-31	wird	werden	AUX	VAFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	38	aux	_	_
-32	es	es	PRON	PPER	Case=Nom|Gender=Neut|Number=Sing|Person=3|PronType=Prs	38	nsubj	_	_
-33	in	in	ADP	APPR	_	35	case	_	_
-34	künftigen	künftig	ADJ	ADJA	Case=Dat|Gender=Masc|Number=Plur	35	amod	_	_
-35	Fällen	Fall	NOUN	NN	Case=Dat|Gender=Masc|Number=Plur	38	obl	_	_
-36	nicht	nicht	PART	PTKNEG	Polarity=Neg	38	advmod	_	_
-37	mehr	mehr	ADV	ADV	_	36	advmod	_	_
-38	ausreichen	ausreichen	VERB	VVINF	VerbForm=Inf	0	root	_	SpaceAfter=No
-39	,	,	PUNCT	$,	_	38	punct	_	_
-40	wie	wie	CCONJ	KOKOM	_	41	case	_	_
-41	heute	heute	ADV	ADV	_	46	advmod	_	_
-42	auf	auf	ADP	APPR	_	44	case	_	_
-43	das	der	DET	ART	Case=Acc|Definite=Def|Gender=Neut|Number=Sing|PronType=Art	44	det	_	_
-44	Grundgesetz	Grundgesetz	NOUN	NN	Case=Acc|Gender=Neut|Number=Sing	46	obl	_	_
-45	zu	zu	PART	PTKZU	_	46	mark	_	_
-46	verweisen	verweisen	VERB	VVINF	VerbForm=Inf	38	xcomp	_	SpaceAfter=No
-47	.	.	PUNCT	$.	_	38	punct	_	_
+# text = Als Antwort auf die Frage, warum es nicht rechtzeitig gelungen ist, den Flughafen von Sarajewo zur humanitären Versorgung der Stadt freizubekommen -- das heißt auch notfalls freizukämpfen -- wird es in künftigen Fällen nicht mehr ausreichen, wie heute auf das Grundgesetz zu verweisen.
+1	Als	als	ADP	APPR	_	2	dep	_	FixTigerDep=Yes
+2	Antwort	Antwort	NOUN	NN	Case=Acc|Gender=Fem|Number=Sing	39	dep	_	_
+3	auf	auf	ADP	APPR	_	5	case	_	_
+4	die	der	DET	ART	Case=Acc|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	5	det	_	_
+5	Frage	Frage	NOUN	NN	Case=Acc|Gender=Fem|Number=Sing	2	nmod	_	SpaceAfter=No
+6	,	,	PUNCT	$,	_	39	punct	_	_
+7	warum	warum	SCONJ	PWAV	PronType=Int	11	mark	_	_
+8	es	es	PRON	PPER	Case=Nom|Gender=Neut|Number=Sing|Person=3|PronType=Prs	11	nsubj	_	_
+9	nicht	nicht	PART	PTKNEG	Polarity=Neg	11	advmod	_	_
+10	rechtzeitig	rechtzeitig	ADV	ADJD	_	11	advmod	_	_
+11	gelungen	gelingen	VERB	VVPP	VerbForm=Part	5	advcl	_	_
+12	ist	sein	AUX	VAFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	11	aux	_	SpaceAfter=No
+13	,	,	PUNCT	$,	_	39	punct	_	_
+14	den	der	DET	ART	Case=Acc|Definite=Def|Gender=Masc|Number=Sing|PronType=Art	15	det	_	_
+15	Flughafen	Flughafen	NOUN	NN	Case=Acc|Gender=Masc|Number=Sing	24	obj	_	_
+16	von	von	ADP	APPR	_	17	case	_	_
+17	Sarajewo	Sarajewo	PROPN	NE	Case=Dat|Gender=Neut|Number=Sing	15	nmod	_	_
+18-19	zur	_	_	_	_	_	_	_	_
+18	zu	zu	ADP	APPR	_	21	case	_	_
+19	der	der	DET	ART	Case=Dat|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	21	det	_	_
+20	humanitären	humanitär	ADJ	ADJA	Case=Dat|Gender=Fem|Number=Sing	21	amod	_	_
+21	Versorgung	Versorgung	NOUN	NN	Case=Dat|Gender=Fem|Number=Sing	24	obl	_	_
+22	der	der	DET	ART	Case=Gen|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	23	det	_	_
+23	Stadt	Stadt	NOUN	NN	Case=Gen|Gender=Fem|Number=Sing	21	nmod	_	_
+24	freizubekommen	freibekommen	VERB	VVIZU	VerbForm=Inf	11	xcomp	_	_
+25	--	--	PUNCT	$(	_	27	punct	_	_
+26	das	der	PRON	PDS	Case=Nom|Gender=Neut|Number=Sing|PronType=Dem	27	det	_	_
+27	heißt	heißen	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	24	parataxis	_	_
+28	auch	auch	ADV	ADV	_	27	advmod	_	_
+29	notfalls	notfalls	ADV	ADV	_	30	advmod	_	_
+30	freizukämpfen	freikämpfen	VERB	VVIZU	VerbForm=Inf	27	xcomp	_	_
+31	--	--	PUNCT	$(	_	27	punct	_	_
+32	wird	werden	AUX	VAFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	39	aux	_	_
+33	es	es	PRON	PPER	Case=Nom|Gender=Neut|Number=Sing|Person=3|PronType=Prs	39	nsubj	_	_
+34	in	in	ADP	APPR	_	36	case	_	_
+35	künftigen	künftig	ADJ	ADJA	Case=Dat|Gender=Masc|Number=Plur	36	amod	_	_
+36	Fällen	Fall	NOUN	NN	Case=Dat|Gender=Masc|Number=Plur	39	obl	_	_
+37	nicht	nicht	PART	PTKNEG	Polarity=Neg	39	advmod	_	_
+38	mehr	mehr	ADV	ADV	_	37	advmod	_	_
+39	ausreichen	ausreichen	VERB	VVINF	VerbForm=Inf	0	root	_	SpaceAfter=No
+40	,	,	PUNCT	$,	_	39	punct	_	_
+41	wie	wie	CCONJ	KOKOM	_	42	case	_	_
+42	heute	heute	ADV	ADV	_	47	advmod	_	_
+43	auf	auf	ADP	APPR	_	45	case	_	_
+44	das	der	DET	ART	Case=Acc|Definite=Def|Gender=Neut|Number=Sing|PronType=Art	45	det	_	_
+45	Grundgesetz	Grundgesetz	NOUN	NN	Case=Acc|Gender=Neut|Number=Sing	47	obl	_	_
+46	zu	zu	PART	PTKZU	_	47	mark	_	_
+47	verweisen	verweisen	VERB	VVINF	VerbForm=Inf	39	xcomp	_	SpaceAfter=No
+48	.	.	PUNCT	$.	_	39	punct	_	_
 
 # sent_id = test-s341
-# text = Arbeitsgruppen werden sich anschließend Politiker und rund 300 Experten mit vier Themenkomplexen befassen: Demokratie, Menschenrechte und Islam, islamische Wirtschaftsstrategien, gemeinsame Bemühungen um einen Frieden auf dem Balkan sowie die Rolle der Moslems in Deutschland und Europa.
-1	Arbeitsgruppen	Arbeitsgruppe	NOUN	NN	Case=Dat|Gender=Fem|Number=Plur	13	dep	_	_
-2	werden	werden	AUX	VAFIN	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	13	aux	_	_
-3	sich	er|es|sie	PRON	PRF	Case=Acc|Number=Plur|Person=3|PronType=Prs|Reflex=Yes	13	obj	_	_
-4	anschließend	anschließend	ADV	ADJD	_	13	advmod	_	_
-5	Politiker	Politiker	NOUN	NN	Case=Nom|Gender=Masc|Number=Plur	13	nsubj	_	_
-6	und	und	CCONJ	KON	_	9	cc	_	_
-7	rund	rund	ADV	ADJD	_	8	advmod	_	_
-8	300	300	NUM	CARD	NumType=Card	9	nummod	_	_
-9	Experten	Experte	NOUN	NN	Case=Nom|Gender=Masc|Number=Plur	5	conj	_	_
-10	mit	mit	ADP	APPR	_	12	case	_	_
-11	vier	vier	NUM	CARD	NumType=Card	12	nummod	_	_
-12	Themenkomplexen	Themenkomplex	NOUN	NN	Case=Dat|Gender=Masc|Number=Plur	13	obl	_	_
-13	befassen	befassen	VERB	VVINF	VerbForm=Inf	0	root	_	SpaceAfter=No
-14	:	:	PUNCT	$.	_	13	punct	_	_
-15	Demokratie	Demokratie	NOUN	NN	Case=Nom|Gender=Fem|Number=Sing	13	parataxis	_	SpaceAfter=No
-16	,	,	PUNCT	$,	_	17	punct	_	_
-17	Menschenrechte	Menschenrecht	NOUN	NN	Case=Nom|Gender=Neut|Number=Sing	15	conj	_	_
-18	und	und	CCONJ	KON	_	19	cc	_	_
-19	Islam	Islam	NOUN	NN	Case=Nom|Gender=Masc|Number=Sing	17	conj	_	SpaceAfter=No
-20	,	,	PUNCT	$,	_	22	punct	_	_
-21	islamische	islamisch	ADJ	ADJA	Case=Nom|Gender=Fem|Number=Sing	22	amod	_	_
-22	Wirtschaftsstrategien	Wirtschaftsstrategie	NOUN	NN	Case=Nom|Gender=Fem|Number=Plur	15	conj	_	SpaceAfter=No
-23	,	,	PUNCT	$,	_	25	punct	_	_
-24	gemeinsame	gemeinsam	ADJ	ADJA	Case=Nom|Gender=Fem|Number=Plur	25	amod	_	_
-25	Bemühungen	Bemühung	NOUN	NN	Case=Nom|Gender=Fem|Number=Plur	15	conj	_	_
-26	um	um	ADP	APPR	_	28	case	_	_
-27	einen	ein	DET	ART	Case=Acc|Definite=Ind|Gender=Masc|Number=Sing|PronType=Art	28	det	_	_
-28	Frieden	Frieden	NOUN	NN	Case=Acc|Gender=Masc|Number=Sing	25	nmod	_	_
-29	auf	auf	ADP	APPR	_	31	case	_	_
-30	dem	der	DET	ART	Case=Dat|Definite=Def|Gender=Masc|Number=Sing|PronType=Art	31	det	_	_
-31	Balkan	Balkan	PROPN	NE	Case=Dat|Gender=Masc|Number=Sing	28	nmod	_	_
-32	sowie	sowie	CCONJ	KON	_	34	cc	_	_
-33	die	der	DET	ART	Case=Nom|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	34	det	_	_
-34	Rolle	Rolle	NOUN	NN	Case=Nom|Gender=Fem|Number=Sing	15	conj	_	_
-35	der	der	DET	ART	Case=Gen|Definite=Def|Gender=Masc|Number=Plur|PronType=Art	36	det	_	_
-36	Moslems	Moslem	NOUN	NN	Case=Gen|Gender=Masc|Number=Plur	34	nmod	_	_
-37	in	in	ADP	APPR	_	38	case	_	_
-38	Deutschland	Deutschland	PROPN	NE	Case=Dat|Gender=Neut|Number=Sing	36	nmod	_	_
-39	und	und	CCONJ	KON	_	40	cc	_	_
-40	Europa	Europa	PROPN	NE	Case=Dat|Gender=Neut|Number=Sing	38	conj	_	SpaceAfter=No
-41	.	.	PUNCT	$.	_	13	punct	_	_
+# text = In Arbeitsgruppen werden sich anschließend Politiker und rund 300 Experten mit vier Themenkomplexen befassen: Demokratie, Menschenrechte und Islam, islamische Wirtschaftsstrategien, gemeinsame Bemühungen um einen Frieden auf dem Balkan sowie die Rolle der Moslems in Deutschland und Europa.
+1	In	in	ADP	APPR	_	2	dep	_	FixTigerDep=Yes
+2	Arbeitsgruppen	Arbeitsgruppe	NOUN	NN	Case=Dat|Gender=Fem|Number=Plur	14	dep	_	_
+3	werden	werden	AUX	VAFIN	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	14	aux	_	_
+4	sich	er|es|sie	PRON	PRF	Case=Acc|Number=Plur|Person=3|PronType=Prs|Reflex=Yes	14	obj	_	_
+5	anschließend	anschließend	ADV	ADJD	_	14	advmod	_	_
+6	Politiker	Politiker	NOUN	NN	Case=Nom|Gender=Masc|Number=Plur	14	nsubj	_	_
+7	und	und	CCONJ	KON	_	10	cc	_	_
+8	rund	rund	ADV	ADJD	_	9	advmod	_	_
+9	300	300	NUM	CARD	NumType=Card	10	nummod	_	_
+10	Experten	Experte	NOUN	NN	Case=Nom|Gender=Masc|Number=Plur	6	conj	_	_
+11	mit	mit	ADP	APPR	_	13	case	_	_
+12	vier	vier	NUM	CARD	NumType=Card	13	nummod	_	_
+13	Themenkomplexen	Themenkomplex	NOUN	NN	Case=Dat|Gender=Masc|Number=Plur	14	obl	_	_
+14	befassen	befassen	VERB	VVINF	VerbForm=Inf	0	root	_	SpaceAfter=No
+15	:	:	PUNCT	$.	_	14	punct	_	_
+16	Demokratie	Demokratie	NOUN	NN	Case=Nom|Gender=Fem|Number=Sing	14	parataxis	_	SpaceAfter=No
+17	,	,	PUNCT	$,	_	18	punct	_	_
+18	Menschenrechte	Menschenrecht	NOUN	NN	Case=Nom|Gender=Neut|Number=Sing	16	conj	_	_
+19	und	und	CCONJ	KON	_	20	cc	_	_
+20	Islam	Islam	NOUN	NN	Case=Nom|Gender=Masc|Number=Sing	18	conj	_	SpaceAfter=No
+21	,	,	PUNCT	$,	_	23	punct	_	_
+22	islamische	islamisch	ADJ	ADJA	Case=Nom|Gender=Fem|Number=Sing	23	amod	_	_
+23	Wirtschaftsstrategien	Wirtschaftsstrategie	NOUN	NN	Case=Nom|Gender=Fem|Number=Plur	16	conj	_	SpaceAfter=No
+24	,	,	PUNCT	$,	_	26	punct	_	_
+25	gemeinsame	gemeinsam	ADJ	ADJA	Case=Nom|Gender=Fem|Number=Plur	26	amod	_	_
+26	Bemühungen	Bemühung	NOUN	NN	Case=Nom|Gender=Fem|Number=Plur	16	conj	_	_
+27	um	um	ADP	APPR	_	29	case	_	_
+28	einen	ein	DET	ART	Case=Acc|Definite=Ind|Gender=Masc|Number=Sing|PronType=Art	29	det	_	_
+29	Frieden	Frieden	NOUN	NN	Case=Acc|Gender=Masc|Number=Sing	26	nmod	_	_
+30	auf	auf	ADP	APPR	_	32	case	_	_
+31	dem	der	DET	ART	Case=Dat|Definite=Def|Gender=Masc|Number=Sing|PronType=Art	32	det	_	_
+32	Balkan	Balkan	PROPN	NE	Case=Dat|Gender=Masc|Number=Sing	29	nmod	_	_
+33	sowie	sowie	CCONJ	KON	_	35	cc	_	_
+34	die	der	DET	ART	Case=Nom|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	35	det	_	_
+35	Rolle	Rolle	NOUN	NN	Case=Nom|Gender=Fem|Number=Sing	16	conj	_	_
+36	der	der	DET	ART	Case=Gen|Definite=Def|Gender=Masc|Number=Plur|PronType=Art	37	det	_	_
+37	Moslems	Moslem	NOUN	NN	Case=Gen|Gender=Masc|Number=Plur	35	nmod	_	_
+38	in	in	ADP	APPR	_	39	case	_	_
+39	Deutschland	Deutschland	PROPN	NE	Case=Dat|Gender=Neut|Number=Sing	37	nmod	_	_
+40	und	und	CCONJ	KON	_	41	cc	_	_
+41	Europa	Europa	PROPN	NE	Case=Dat|Gender=Neut|Number=Sing	39	conj	_	SpaceAfter=No
+42	.	.	PUNCT	$.	_	14	punct	_	_
 
 # sent_id = test-s342
 # text = Auf professioneller Grundlage sind die Kontakte nie abgerissen
@@ -6180,253 +6203,267 @@
 8	abgerissen	abreißen	VERB	VVPP	VerbForm=Part	0	root	_	_
 
 # sent_id = test-s343
-# text = Aufgabe von Literatur sei es, durch diese Schicht zu den ursprünglichen Empfindungen hindurchzudringen und gleichzeitig die Distanz dazu zu beschreiben.
-1	Aufgabe	Aufgabe	NOUN	NN	Case=Nom|Gender=Fem|Number=Sing	0	root	_	_
-2	von	von	ADP	APPR	_	3	case	_	_
-3	Literatur	Literatur	NOUN	NN	Case=Dat|Gender=Fem|Number=Sing	1	nmod	_	_
-4	sei	sein	AUX	VAFIN	Mood=Sub|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	1	cop	_	_
-5	es	es	PRON	PPER	Case=Nom|Gender=Neut|Number=Sing|Person=3|PronType=Prs	1	nsubj	_	SpaceAfter=No
-6	,	,	PUNCT	$,	_	1	punct	_	_
-7	durch	durch	ADP	APPR	_	9	case	_	_
-8	diese	dies	PRON	PDAT	Case=Acc|Gender=Fem|Number=Sing|PronType=Dem	9	det	_	_
-9	Schicht	Schicht	NOUN	NN	Case=Acc|Gender=Fem|Number=Sing	14	obl	_	_
-10	zu	zu	ADP	APPR	_	13	case	_	_
-11	den	der	DET	ART	Case=Dat|Definite=Def|Gender=Fem|Number=Plur|PronType=Art	13	det	_	_
-12	ursprünglichen	ursprünglich	ADJ	ADJA	Case=Dat|Gender=Fem|Number=Plur	13	amod	_	_
-13	Empfindungen	Empfindung	NOUN	NN	Case=Dat|Gender=Fem|Number=Plur	14	obl	_	_
-14	hindurchzudringen	hindurchdringen	VERB	VVIZU	VerbForm=Inf	1	acl	_	_
-15	und	und	CCONJ	KON	_	21	cc	_	_
-16	gleichzeitig	gleichzeitig	ADV	ADJD	_	21	advmod	_	_
-17	die	der	DET	ART	Case=Acc|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	18	det	_	_
-18	Distanz	Distanz	NOUN	NN	Case=Acc|Gender=Fem|Number=Sing	21	obj	_	_
-19	dazu	dazu	ADV	PAV	_	21	advmod	_	_
-20	zu	zu	PART	PTKZU	_	21	mark	_	_
-21	beschreiben	beschreiben	VERB	VVINF	VerbForm=Inf	14	conj	_	SpaceAfter=No
-22	.	.	PUNCT	$.	_	1	punct	_	_
-
-# sent_id = test-s344
-# text = Auftritt Jacksons in ``Wetten, daß'' im ZDF am Samstag abend war der erste Auftritt des Popstars in einer TV-Show außerhalb der USA.
-1	Auftritt	Auftritt	NOUN	NN	Case=Nom|Gender=Masc|Number=Sing	19	nsubj	_	_
-2	Jacksons	Jacksons	PROPN	NE	Case=Gen|Number=Sing	1	nmod	_	_
-3	in	in	ADP	APPR	_	5	case	_	_
-4	``	``	PUNCT	$(	_	5	punct	_	SpaceAfter=No
-5	Wetten	Wette|Wetten	PROPN	VVINF	VerbForm=Inf	1	nmod	_	SpaceAfter=No
-6	,	,	PUNCT	$,	_	5	punct	_	_
-7	daß	daß	PROPN	KOUS	_	5	flat	_	SpaceAfter=No
-8	''	''	PUNCT	$(	_	5	punct	_	_
-9-10	im	_	_	_	_	_	_	_	_
-9	in	in	ADP	APPR	_	11	case	_	_
-10	dem	der	DET	ART	Case=Dat|Definite=Def|Gender=Neut|Number=Sing|PronType=Art	11	det	_	_
-11	ZDF	ZDF	PROPN	NE	Case=Dat|Gender=Neut|Number=Sing	1	nmod	_	_
-12-13	am	_	_	_	_	_	_	_	_
-12	an	an	ADP	APPR	_	14	case	_	_
-13	dem	der	DET	ART	Case=Dat|Definite=Def|Gender=Masc|Number=Sing|PronType=Art	14	det	_	_
-14	Samstag	Samstag	PROPN	NN	Case=Dat|Gender=Masc|Number=Sing	1	nmod	_	_
-15	abend	abend	ADV	ADV	_	14	advmod	_	_
-16	war	sein	AUX	VAFIN	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	19	cop	_	_
-17	der	der	DET	ART	Case=Nom|Definite=Def|Gender=Masc|Number=Sing|PronType=Art	19	det	_	_
-18	erste	erster	ADJ	ADJA	Case=Nom|Gender=Masc|Number=Sing	19	amod	_	_
-19	Auftritt	Auftritt	NOUN	NN	Case=Nom|Gender=Masc|Number=Sing	0	root	_	_
-20	des	der	DET	ART	Case=Gen|Definite=Def|Gender=Masc|Number=Sing|PronType=Art	21	det	_	_
-21	Popstars	Popstar	NOUN	NN	Case=Gen|Gender=Masc|Number=Sing	19	nmod	_	_
-22	in	in	ADP	APPR	_	26	case	_	_
-23	einer	ein	DET	ART	Case=Dat|Definite=Ind|Gender=Fem|Number=Sing|PronType=Art	26	det	_	_
-24	TV	TV	NOUN	NN	Case=Dat|Gender=Fem|Number=Sing	26	compound	_	SpaceAfter=No
-25	-	-	PUNCT	$(	_	24	punct	_	SpaceAfter=No
-26	Show	Show	NOUN	NN	Case=Dat|Gender=Fem|Number=Sing	19	nmod	_	_
-27	außerhalb	außerhalb	ADP	APPR	_	29	case	_	_
-28	der	der	DET	ART	Case=Gen|Definite=Def|Number=Plur|PronType=Art	29	det	_	_
-29	USA	USA	PROPN	NE	Case=Gen|Number=Plur	26	nmod	_	SpaceAfter=No
-30	.	.	PUNCT	$.	_	19	punct	_	_
-
-# sent_id = test-s345
-# text = Auftritte zur Cebit in Hannover
-1	Auftritte	Auftritt	NOUN	NN	Case=Nom|Gender=Masc|Number=Plur	0	root	_	_
-2-3	zur	_	_	_	_	_	_	_	_
-2	zu	zu	ADP	APPR	_	4	case	_	_
-3	der	der	DET	ART	Case=Dat|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	4	det	_	_
-4	Cebit	Cebit	PROPN	NE	Case=Dat|Gender=Fem|Number=Sing	1	nmod	_	_
-5	in	in	ADP	APPR	_	6	case	_	_
-6	Hannover	Hannover	PROPN	NE	Case=Dat|Gender=Neut|Number=Sing	4	nmod	_	_
-
-# sent_id = test-s346
-# text = Aussagen des japanischen Verwaltungsministers Takami Eto zur Kolonialherrschaft in Südkorea belasten die Beziehungen zwischen beiden Staaten.
-1	Aussagen	Aussage	NOUN	NN	Case=Nom|Gender=Fem|Number=Plur	12	nsubj	_	_
-2	des	der	DET	ART	Case=Gen|Definite=Def|Gender=Masc|Number=Sing|PronType=Art	4	det	_	_
-3	japanischen	japanisch	ADJ	ADJA	Case=Gen|Gender=Masc|Number=Sing	4	amod	_	_
-4	Verwaltungsministers	Verwaltungsminister	NOUN	NN	Case=Gen|Gender=Masc|Number=Sing	1	nmod	_	_
-5	Takami	Takami	PROPN	NE	Case=Nom|Gender=Masc|Number=Sing	4	appos	_	_
-6	Eto	Eto	PROPN	NE	Case=Nom|Gender=Masc|Number=Sing	5	flat	_	_
-7-8	zur	_	_	_	_	_	_	_	_
-7	zu	zu	ADP	APPR	_	9	case	_	_
-8	der	der	DET	ART	Case=Dat|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	9	det	_	_
-9	Kolonialherrschaft	Kolonialherrschaft	NOUN	NN	Case=Dat|Gender=Fem|Number=Sing	1	nmod	_	_
-10	in	in	ADP	APPR	_	11	case	_	_
-11	Südkorea	Südkorea	PROPN	NE	Case=Dat|Gender=Neut|Number=Sing	9	nmod	_	_
-12	belasten	belasten	VERB	VVFIN	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	0	root	_	_
-13	die	der	DET	ART	Case=Acc|Definite=Def|Gender=Fem|Number=Plur|PronType=Art	14	det	_	_
-14	Beziehungen	Beziehung	NOUN	NN	Case=Acc|Gender=Fem|Number=Plur	12	obj	_	_
-15	zwischen	zwischen	ADP	APPR	_	17	case	_	_
-16	beiden	beide	PRON	PIAT	Case=Dat|Definite=Ind|Gender=Masc|Number=Plur|PronType=Ind	17	det	_	_
-17	Staaten	Staat	NOUN	NN	Case=Dat|Gender=Masc|Number=Plur	14	nmod	_	SpaceAfter=No
-18	.	.	PUNCT	$.	_	12	punct	_	_
-
-# sent_id = test-s347
-# text = Bahn fehlten in den nächsten zehn Jahren bis zu 400 Milliarden Mark, für die Waigel nicht ausreichend Vorsorge getroffen habe.
-1	Bahn	Bahn	NOUN	NN	Case=Dat|Gender=Fem|Number=Sing	2	iobj	_	_
-2	fehlten	fehlen	VERB	VVFIN	Mood=Sub|Number=Plur|Person=3|Tense=Past|VerbForm=Fin	0	root	_	_
-3	in	in	ADP	APPR	_	7	case	_	_
-4	den	der	DET	ART	Case=Dat|Definite=Def|Gender=Neut|Number=Plur|PronType=Art	7	det	_	_
-5	nächsten	nächster	ADJ	ADJA	Case=Dat|Gender=Neut|Number=Plur	7	amod	_	_
-6	zehn	zehn	NUM	CARD	NumType=Card	7	nummod	_	_
-7	Jahren	Jahr	NOUN	NN	Case=Dat|Gender=Neut|Number=Plur	2	obl	_	_
-8	bis	bis	ADP	ADV	_	10	case	_	_
-9	zu	zu	ADP	ADV	_	8	fixed	_	_
-10	400	400	NUM	CARD	NumType=Card	11	nummod	_	_
-11	Milliarden	Milliarde	NOUN	NN	Case=Nom|Gender=Fem|Number=Plur	12	nummod	_	_
-12	Mark	Mark	NOUN	NN	Gender=Fem	2	nsubj	_	SpaceAfter=No
-13	,	,	PUNCT	$,	_	2	punct	_	_
-14	für	für	ADP	APPR	_	15	case	_	_
-15	die	der	DET	PRELS	Case=Acc|Gender=Fem|Number=Plur|PronType=Rel	20	obl	_	_
-16	Waigel	Waigel	PROPN	NE	Case=Nom|Number=Sing	20	nsubj	_	_
-17	nicht	nicht	PART	PTKNEG	Polarity=Neg	20	advmod	_	_
-18	ausreichend	ausreichend	ADV	ADJD	_	17	advmod	_	_
-19	Vorsorge	Vorsorge	NOUN	NN	Case=Acc|Gender=Fem|Number=Sing	20	obj	_	_
-20	getroffen	treffen	VERB	VVPP	VerbForm=Part	12	acl	_	_
-21	habe	haben	AUX	VAFIN	Mood=Sub|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	20	aux	_	SpaceAfter=No
-22	.	.	PUNCT	$.	_	2	punct	_	_
-
-# sent_id = test-s348
-# text = BAU propagiert ``Bündnis Arbeit und Natur''
-1	BAU	bauen	PROPN	NE	Case=Nom|Number=Sing	2	nsubj	_	_
-2	propagiert	propagieren	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	0	root	_	_
-3	``	``	PUNCT	$(	_	4	punct	_	SpaceAfter=No
-4	Bündnis	Bündnis	PROPN	NN	Case=Acc|Gender=Neut|Number=Sing	2	obj	_	_
-5	Arbeit	Arbeit	PROPN	NN	Case=Nom|Gender=Fem|Number=Sing	4	flat	_	_
-6	und	und	CCONJ	KON	_	4	compound	_	_
-7	Natur	Natur	PROPN	NN	Case=Nom|Gender=Fem|Number=Sing	4	flat	_	SpaceAfter=No
-8	''	''	PUNCT	$(	_	4	punct	_	_
-
-# sent_id = test-s349
-# text = Bereitschaftspolizei rückte an mehreren zentralen Sperren massiv und mit Panzerfahrzeugen gegen Lkw vor.
-1	Bereitschaftspolizei	Bereitschaftspolizei	NOUN	NN	Case=Nom|Gender=Fem|Number=Sing	2	nsubj	_	_
-2	rückte	rücken	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	0	root	_	_
-3	an	an	ADP	APPR	_	6	case	_	_
-4	mehreren	mehrere	PRON	PIAT	Case=Dat|Definite=Ind|Gender=Fem|Number=Plur|PronType=Ind	6	amod	_	_
-5	zentralen	zentral	ADJ	ADJA	Case=Dat|Gender=Fem|Number=Plur	6	amod	_	_
-6	Sperren	Sperre	NOUN	NN	Case=Dat|Gender=Fem|Number=Plur	2	obl	_	_
-7	massiv	massiv	ADV	ADJD	_	2	advmod	_	_
-8	und	und	CCONJ	KON	_	10	cc	_	_
-9	mit	mit	ADP	APPR	_	10	case	_	_
-10	Panzerfahrzeugen	Panzerfahrzeug	NOUN	NN	Case=Dat|Gender=Neut|Number=Plur	7	conj	_	_
-11	gegen	gegen	ADP	APPR	_	12	case	_	_
-12	Lkw	Lkw	NOUN	NN	Case=Acc|Gender=Masc|Number=Plur	2	obl	_	_
-13	vor	vor	ADP	PTKVZ	_	2	compound:prt	_	SpaceAfter=No
-14	.	.	PUNCT	$.	_	2	punct	_	_
-
-# sent_id = test-s350
-# text = Bielefelder veräußern den Nuß- und Knabberartikelhersteller zu einem nicht genannten Preis an Maria May aus der Eigentümerfamilie der May-Werke.
-1	Bielefelder	Bielefelder	PROPN	NN	Case=Nom|Gender=Masc|Number=Plur	2	nsubj	_	_
-2	veräußern	veräußern	VERB	VVFIN	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	0	root	_	_
-3	den	der	DET	ART	Case=Acc|Definite=Def|Gender=Masc|Number=Sing|PronType=Art	4	det	_	_
-4	Nuß	Nuß	NOUN	TRUNC	Case=Acc|Gender=Masc|Number=Sing	2	compound	_	SpaceAfter=No
-5	-	-	PUNCT	$(	_	7	punct	_	_
-6	und	und	CCONJ	KON	_	4	compound	_	_
-7	Knabberartikelhersteller	Knabberartikelhersteller	NOUN	NN	Case=Acc|Gender=Masc|Number=Sing	4	conj	_	_
-8	zu	zu	ADP	APPR	_	12	case	_	_
-9	einem	ein	DET	ART	Case=Dat|Definite=Ind|Gender=Masc|Number=Sing|PronType=Art	12	det	_	_
-10	nicht	nicht	PART	PTKNEG	Polarity=Neg	11	advmod	_	_
-11	genannten	genannt	ADJ	ADJA	Case=Dat|Gender=Masc|Number=Sing	12	amod	_	_
-12	Preis	Preis	NOUN	NN	Case=Dat|Gender=Masc|Number=Sing	2	obl	_	_
-13	an	an	ADP	APPR	_	14	case	_	_
-14	Maria	Maria	PROPN	NE	Case=Nom|Gender=Fem|Number=Sing	2	obl	_	_
-15	May	May	PROPN	NE	Case=Acc|Gender=Fem|Number=Sing	14	flat	_	_
-16	aus	aus	ADP	APPR	_	18	case	_	_
-17	der	der	DET	ART	Case=Dat|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	18	det	_	_
-18	Eigentümerfamilie	Eigentümerfamilie	NOUN	NN	Case=Dat|Gender=Fem|Number=Sing	14	nmod	_	_
-19	der	der	DET	ART	Case=Gen|Definite=Def|Gender=Neut|Number=Plur|PronType=Art	20	det	_	_
-20	May	May	PROPN	NN	Case=Gen|Gender=Neut|Number=Plur	22	compound	_	SpaceAfter=No
-21	-	-	PUNCT	$(	_	20	punct	_	SpaceAfter=No
-22	Werke	Werk	NOUN	NN	Case=Gen|Gender=Neut|Number=Plur	18	nmod	_	SpaceAfter=No
+# text = Die Aufgabe von Literatur sei es, durch diese Schicht zu den ursprünglichen Empfindungen hindurchzudringen und gleichzeitig die Distanz dazu zu beschreiben.
+1	Die	der	DET	ART	Case=Nom|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	2	dep	_	FixTigerDep=Yes
+2	Aufgabe	Aufgabe	NOUN	NN	Case=Nom|Gender=Fem|Number=Sing	0	root	_	_
+3	von	von	ADP	APPR	_	4	case	_	_
+4	Literatur	Literatur	NOUN	NN	Case=Dat|Gender=Fem|Number=Sing	2	nmod	_	_
+5	sei	sein	AUX	VAFIN	Mood=Sub|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	2	cop	_	_
+6	es	es	PRON	PPER	Case=Nom|Gender=Neut|Number=Sing|Person=3|PronType=Prs	2	nsubj	_	SpaceAfter=No
+7	,	,	PUNCT	$,	_	2	punct	_	_
+8	durch	durch	ADP	APPR	_	10	case	_	_
+9	diese	dies	PRON	PDAT	Case=Acc|Gender=Fem|Number=Sing|PronType=Dem	10	det	_	_
+10	Schicht	Schicht	NOUN	NN	Case=Acc|Gender=Fem|Number=Sing	15	obl	_	_
+11	zu	zu	ADP	APPR	_	14	case	_	_
+12	den	der	DET	ART	Case=Dat|Definite=Def|Gender=Fem|Number=Plur|PronType=Art	14	det	_	_
+13	ursprünglichen	ursprünglich	ADJ	ADJA	Case=Dat|Gender=Fem|Number=Plur	14	amod	_	_
+14	Empfindungen	Empfindung	NOUN	NN	Case=Dat|Gender=Fem|Number=Plur	15	obl	_	_
+15	hindurchzudringen	hindurchdringen	VERB	VVIZU	VerbForm=Inf	2	acl	_	_
+16	und	und	CCONJ	KON	_	22	cc	_	_
+17	gleichzeitig	gleichzeitig	ADV	ADJD	_	22	advmod	_	_
+18	die	der	DET	ART	Case=Acc|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	19	det	_	_
+19	Distanz	Distanz	NOUN	NN	Case=Acc|Gender=Fem|Number=Sing	22	obj	_	_
+20	dazu	dazu	ADV	PAV	_	22	advmod	_	_
+21	zu	zu	PART	PTKZU	_	22	mark	_	_
+22	beschreiben	beschreiben	VERB	VVINF	VerbForm=Inf	15	conj	_	SpaceAfter=No
 23	.	.	PUNCT	$.	_	2	punct	_	_
 
+# sent_id = test-s344
+# text = Der Auftritt Jacksons in ``Wetten, daß'' im ZDF am Samstag abend war der erste Auftritt des Popstars in einer TV-Show außerhalb der USA.
+1	Der	der	DET	ART	Case=Nom|Definite=Def|Gender=Masc|Number=Sing|PronType=Art	2	dep	_	FixTigerDep=Yes
+2	Auftritt	Auftritt	NOUN	NN	Case=Nom|Gender=Masc|Number=Sing	20	nsubj	_	_
+3	Jacksons	Jackson	PROPN	NE	Case=Gen|Number=Sing	2	nmod	_	_
+4	in	in	ADP	APPR	_	6	case	_	_
+5	``	``	PUNCT	$(	_	6	punct	_	SpaceAfter=No
+6	Wetten	wetten	PROPN	VVINF	VerbForm=Inf	2	nmod	_	SpaceAfter=No
+7	,	,	PUNCT	$,	_	6	punct	_	_
+8	daß	daß	PROPN	KOUS	_	6	flat	_	SpaceAfter=No
+9	''	''	PUNCT	$(	_	6	punct	_	_
+10-11	im	_	_	_	_	_	_	_	_
+10	in	in	ADP	APPR	_	12	case	_	_
+11	dem	der	DET	ART	Case=Dat|Definite=Def|Gender=Neut|Number=Sing|PronType=Art	12	det	_	_
+12	ZDF	ZDF	PROPN	NE	Case=Dat|Gender=Neut|Number=Sing	2	nmod	_	_
+13-14	am	_	_	_	_	_	_	_	_
+13	an	an	ADP	APPR	_	15	case	_	_
+14	dem	der	DET	ART	Case=Dat|Definite=Def|Gender=Masc|Number=Sing|PronType=Art	15	det	_	_
+15	Samstag	Samstag	PROPN	NN	Case=Dat|Gender=Masc|Number=Sing	2	nmod	_	_
+16	abend	abend	ADV	ADV	_	15	advmod	_	_
+17	war	sein	AUX	VAFIN	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	20	cop	_	_
+18	der	der	DET	ART	Case=Nom|Definite=Def|Gender=Masc|Number=Sing|PronType=Art	20	det	_	_
+19	erste	erster	ADJ	ADJA	Case=Nom|Gender=Masc|Number=Sing	20	amod	_	_
+20	Auftritt	Auftritt	NOUN	NN	Case=Nom|Gender=Masc|Number=Sing	0	root	_	_
+21	des	der	DET	ART	Case=Gen|Definite=Def|Gender=Masc|Number=Sing|PronType=Art	22	det	_	_
+22	Popstars	Popstar	NOUN	NN	Case=Gen|Gender=Masc|Number=Sing	20	nmod	_	_
+23	in	in	ADP	APPR	_	27	case	_	_
+24	einer	ein	DET	ART	Case=Dat|Definite=Ind|Gender=Fem|Number=Sing|PronType=Art	27	det	_	_
+25	TV	TV	NOUN	NN	Case=Dat|Gender=Fem|Number=Sing	27	compound	_	SpaceAfter=No
+26	-	-	PUNCT	$(	_	25	punct	_	SpaceAfter=No
+27	Show	Show	NOUN	NN	Case=Dat|Gender=Fem|Number=Sing	20	nmod	_	_
+28	außerhalb	außerhalb	ADP	APPR	_	30	case	_	_
+29	der	der	DET	ART	Case=Gen|Definite=Def|Number=Plur|PronType=Art	30	det	_	_
+30	USA	USA	PROPN	NE	Case=Gen|Number=Plur	27	nmod	_	SpaceAfter=No
+31	.	.	PUNCT	$.	_	20	punct	_	_
+
+# sent_id = test-s345
+# text = Virtuelle Auftritte zur Cebit in Hannover
+1	Virtuelle	virtuell	ADJ	ADJA	Case=Nom|Gender=Masc|Number=Plur	2	dep	_	FixTigerDep=Yes
+2	Auftritte	Auftritt	NOUN	NN	Case=Nom|Gender=Masc|Number=Plur	0	root	_	_
+3-4	zur	_	_	_	_	_	_	_	_
+3	zu	zu	ADP	APPR	_	5	case	_	_
+4	der	der	DET	ART	Case=Dat|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	5	det	_	_
+5	Cebit	Cebit	PROPN	NE	Case=Dat|Gender=Fem|Number=Sing	2	nmod	_	_
+6	in	in	ADP	APPR	_	7	case	_	_
+7	Hannover	Hannover	PROPN	NE	Case=Dat|Gender=Neut|Number=Sing	5	nmod	_	_
+
+# sent_id = test-s346
+# text = Positive Aussagen des japanischen Verwaltungsministers Takami Eto zur Kolonialherrschaft in Südkorea belasten die Beziehungen zwischen beiden Staaten.
+1	Positive	positiv	ADJ	ADJA	Case=Nom|Gender=Fem|Number=Plur	2	dep	_	FixTigerDep=Yes
+2	Aussagen	Aussage	NOUN	NN	Case=Nom|Gender=Fem|Number=Plur	13	nsubj	_	_
+3	des	der	DET	ART	Case=Gen|Definite=Def|Gender=Masc|Number=Sing|PronType=Art	5	det	_	_
+4	japanischen	japanisch	ADJ	ADJA	Case=Gen|Gender=Masc|Number=Sing	5	amod	_	_
+5	Verwaltungsministers	Verwaltungsminister	NOUN	NN	Case=Gen|Gender=Masc|Number=Sing	2	nmod	_	_
+6	Takami	Takami	PROPN	NE	Case=Nom|Gender=Masc|Number=Sing	5	appos	_	_
+7	Eto	Eto	PROPN	NE	Case=Nom|Gender=Masc|Number=Sing	6	flat	_	_
+8-9	zur	_	_	_	_	_	_	_	_
+8	zu	zu	ADP	APPR	_	10	case	_	_
+9	der	der	DET	ART	Case=Dat|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	10	det	_	_
+10	Kolonialherrschaft	Kolonialherrschaft	NOUN	NN	Case=Dat|Gender=Fem|Number=Sing	2	nmod	_	_
+11	in	in	ADP	APPR	_	12	case	_	_
+12	Südkorea	Südkorea	PROPN	NE	Case=Dat|Gender=Neut|Number=Sing	10	nmod	_	_
+13	belasten	belasten	VERB	VVFIN	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	0	root	_	_
+14	die	der	DET	ART	Case=Acc|Definite=Def|Gender=Fem|Number=Plur|PronType=Art	15	det	_	_
+15	Beziehungen	Beziehung	NOUN	NN	Case=Acc|Gender=Fem|Number=Plur	13	obj	_	_
+16	zwischen	zwischen	ADP	APPR	_	18	case	_	_
+17	beiden	beide	PRON	PIAT	Case=Dat|Definite=Ind|Gender=Masc|Number=Plur|PronType=Ind	18	det	_	_
+18	Staaten	Staat	NOUN	NN	Case=Dat|Gender=Masc|Number=Plur	15	nmod	_	SpaceAfter=No
+19	.	.	PUNCT	$.	_	13	punct	_	_
+
+# sent_id = test-s347
+# text = Der Bahn fehlten in den nächsten zehn Jahren bis zu 400 Milliarden Mark, für die Waigel nicht ausreichend Vorsorge getroffen habe.
+1	Der	der	DET	ART	Case=Dat|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	2	dep	_	FixTigerDep=Yes
+2	Bahn	Bahn	NOUN	NN	Case=Dat|Gender=Fem|Number=Sing	3	iobj	_	_
+3	fehlten	fehlen	VERB	VVFIN	Mood=Sub|Number=Plur|Person=3|Tense=Past|VerbForm=Fin	0	root	_	_
+4	in	in	ADP	APPR	_	8	case	_	_
+5	den	der	DET	ART	Case=Dat|Definite=Def|Gender=Neut|Number=Plur|PronType=Art	8	det	_	_
+6	nächsten	nächster	ADJ	ADJA	Case=Dat|Gender=Neut|Number=Plur	8	amod	_	_
+7	zehn	zehn	NUM	CARD	NumType=Card	8	nummod	_	_
+8	Jahren	Jahr	NOUN	NN	Case=Dat|Gender=Neut|Number=Plur	3	obl	_	_
+9	bis	bis	ADP	ADV	_	11	case	_	_
+10	zu	zu	ADP	ADV	_	9	fixed	_	_
+11	400	400	NUM	CARD	NumType=Card	12	nummod	_	_
+12	Milliarden	Milliarde	NOUN	NN	Case=Nom|Gender=Fem|Number=Plur	13	nummod	_	_
+13	Mark	Mark	NOUN	NN	Gender=Fem	3	nsubj	_	SpaceAfter=No
+14	,	,	PUNCT	$,	_	3	punct	_	_
+15	für	für	ADP	APPR	_	16	case	_	_
+16	die	der	DET	PRELS	Case=Acc|Gender=Fem|Number=Plur|PronType=Rel	21	obl	_	_
+17	Waigel	Waigel	PROPN	NE	Case=Nom|Number=Sing	21	nsubj	_	_
+18	nicht	nicht	PART	PTKNEG	Polarity=Neg	21	advmod	_	_
+19	ausreichend	ausreichend	ADV	ADJD	_	18	advmod	_	_
+20	Vorsorge	Vorsorge	NOUN	NN	Case=Acc|Gender=Fem|Number=Sing	21	obj	_	_
+21	getroffen	treffen	VERB	VVPP	VerbForm=Part	13	acl	_	_
+22	habe	haben	AUX	VAFIN	Mood=Sub|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	21	aux	_	SpaceAfter=No
+23	.	.	PUNCT	$.	_	3	punct	_	_
+
+# sent_id = test-s348
+# text = IG BAU propagiert ``Bündnis Arbeit und Natur''
+1	IG	IG	NOUN	NN	Case=Nom|Gender=Fem|Number=Sing	2	dep	_	FixTigerDep=Yes
+2	BAU	BAU	PROPN	NE	Case=Nom|Number=Sing	3	nsubj	_	_
+3	propagiert	propagieren	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	0	root	_	_
+4	``	``	PUNCT	$(	_	5	punct	_	SpaceAfter=No
+5	Bündnis	Bündnis	PROPN	NN	Case=Acc|Gender=Neut|Number=Sing	3	obj	_	_
+6	Arbeit	Arbeit	PROPN	NN	Case=Nom|Gender=Fem|Number=Sing	5	flat	_	_
+7	und	und	CCONJ	KON	_	5	compound	_	_
+8	Natur	Natur	PROPN	NN	Case=Nom|Gender=Fem|Number=Sing	5	flat	_	SpaceAfter=No
+9	''	''	PUNCT	$(	_	5	punct	_	_
+
+# sent_id = test-s349
+# text = Die Bereitschaftspolizei rückte an mehreren zentralen Sperren massiv und mit Panzerfahrzeugen gegen Lkw vor.
+1	Die	der	DET	ART	Case=Nom|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	2	dep	_	FixTigerDep=Yes
+2	Bereitschaftspolizei	Bereitschaftspolizei	NOUN	NN	Case=Nom|Gender=Fem|Number=Sing	3	nsubj	_	_
+3	rückte	rücken	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	0	root	_	_
+4	an	an	ADP	APPR	_	7	case	_	_
+5	mehreren	mehrere	PRON	PIAT	Case=Dat|Definite=Ind|Gender=Fem|Number=Plur|PronType=Ind	7	amod	_	_
+6	zentralen	zentral	ADJ	ADJA	Case=Dat|Gender=Fem|Number=Plur	7	amod	_	_
+7	Sperren	Sperre	NOUN	NN	Case=Dat|Gender=Fem|Number=Plur	3	obl	_	_
+8	massiv	massiv	ADV	ADJD	_	3	advmod	_	_
+9	und	und	CCONJ	KON	_	11	cc	_	_
+10	mit	mit	ADP	APPR	_	11	case	_	_
+11	Panzerfahrzeugen	Panzerfahrzeug	NOUN	NN	Case=Dat|Gender=Neut|Number=Plur	8	conj	_	_
+12	gegen	gegen	ADP	APPR	_	13	case	_	_
+13	Lkw	Lkw	NOUN	NN	Case=Acc|Gender=Masc|Number=Plur	3	obl	_	_
+14	vor	vor	ADP	PTKVZ	_	3	compound:prt	_	SpaceAfter=No
+15	.	.	PUNCT	$.	_	3	punct	_	_
+
+# sent_id = test-s350
+# text = Die Bielefelder veräußern den Nuß- und Knabberartikelhersteller zu einem nicht genannten Preis an Maria May aus der Eigentümerfamilie der May-Werke.
+1	Die	der	DET	ART	Case=Nom|Definite=Def|Gender=Masc|Number=Plur|PronType=Art	2	dep	_	FixTigerDep=Yes
+2	Bielefelder	Bielefelder	PROPN	NN	Case=Nom|Gender=Masc|Number=Plur	3	nsubj	_	_
+3	veräußern	veräußern	VERB	VVFIN	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	0	root	_	_
+4	den	der	DET	ART	Case=Acc|Definite=Def|Gender=Masc|Number=Sing|PronType=Art	5	det	_	_
+5	Nuß	Nuß	NOUN	TRUNC	Case=Acc|Gender=Masc|Number=Sing	3	compound	_	SpaceAfter=No
+6	-	-	PUNCT	$(	_	8	punct	_	_
+7	und	und	CCONJ	KON	_	5	compound	_	_
+8	Knabberartikelhersteller	Knabberartikelhersteller	NOUN	NN	Case=Acc|Gender=Masc|Number=Sing	5	conj	_	_
+9	zu	zu	ADP	APPR	_	13	case	_	_
+10	einem	ein	DET	ART	Case=Dat|Definite=Ind|Gender=Masc|Number=Sing|PronType=Art	13	det	_	_
+11	nicht	nicht	PART	PTKNEG	Polarity=Neg	12	advmod	_	_
+12	genannten	genannt	ADJ	ADJA	Case=Dat|Gender=Masc|Number=Sing	13	amod	_	_
+13	Preis	Preis	NOUN	NN	Case=Dat|Gender=Masc|Number=Sing	3	obl	_	_
+14	an	an	ADP	APPR	_	15	case	_	_
+15	Maria	Maria	PROPN	NE	Case=Nom|Gender=Fem|Number=Sing	3	obl	_	_
+16	May	May	PROPN	NE	Case=Acc|Gender=Fem|Number=Sing	15	flat	_	_
+17	aus	aus	ADP	APPR	_	19	case	_	_
+18	der	der	DET	ART	Case=Dat|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	19	det	_	_
+19	Eigentümerfamilie	Eigentümerfamilie	NOUN	NN	Case=Dat|Gender=Fem|Number=Sing	15	nmod	_	_
+20	der	der	DET	ART	Case=Gen|Definite=Def|Gender=Neut|Number=Plur|PronType=Art	21	det	_	_
+21	May	May	PROPN	NN	Case=Gen|Gender=Neut|Number=Plur	23	compound	_	SpaceAfter=No
+22	-	-	PUNCT	$(	_	21	punct	_	SpaceAfter=No
+23	Werke	Werk	NOUN	NN	Case=Gen|Gender=Neut|Number=Plur	19	nmod	_	SpaceAfter=No
+24	.	.	PUNCT	$.	_	3	punct	_	_
+
 # sent_id = test-s351
-# text = Blick auf die Währungsunion sieht das WSI Vor- und Nachteile.
-1	Blick	Blick	NOUN	NN	Case=Dat|Gender=Masc|Number=Sing	5	dep	_	_
-2	auf	auf	ADP	APPR	_	4	case	_	_
-3	die	der	DET	ART	Case=Acc|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	4	det	_	_
-4	Währungsunion	Währungsunion	NOUN	NN	Case=Acc|Gender=Fem|Number=Sing	1	nmod	_	_
-5	sieht	sehen	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	0	root	_	_
-6	das	der	DET	ART	Case=Nom|Definite=Def|Gender=Neut|Number=Sing|PronType=Art	7	det	_	_
-7	WSI	WSI	PROPN	NE	Case=Nom|Gender=Neut|Number=Sing	5	nsubj	_	_
-8	Vor	vor	NOUN	NE	Case=Acc|Gender=Masc|Number=Plur	5	compound	_	SpaceAfter=No
-9	-	-	PUNCT	$(	_	11	punct	_	_
-10	und	und	CCONJ	KON	_	11	cc	_	_
-11	Nachteile	Nachteil	NOUN	NN	Case=Acc|Gender=Masc|Number=Plur	8	conj	_	SpaceAfter=No
-12	.	.	PUNCT	$.	_	5	punct	_	_
+# text = Mit Blick auf die Währungsunion sieht das WSI Vor- und Nachteile.
+1	Mit	mit	ADP	APPR	_	2	dep	_	FixTigerDep=Yes
+2	Blick	Blick	NOUN	NN	Case=Dat|Gender=Masc|Number=Sing	6	dep	_	_
+3	auf	auf	ADP	APPR	_	5	case	_	_
+4	die	der	DET	ART	Case=Acc|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	5	det	_	_
+5	Währungsunion	Währungsunion	NOUN	NN	Case=Acc|Gender=Fem|Number=Sing	2	nmod	_	_
+6	sieht	sehen	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	0	root	_	_
+7	das	der	DET	ART	Case=Nom|Definite=Def|Gender=Neut|Number=Sing|PronType=Art	8	det	_	_
+8	WSI	WSI	PROPN	NE	Case=Nom|Gender=Neut|Number=Sing	6	nsubj	_	_
+9	Vor	vor	NOUN	NE	Case=Acc|Gender=Masc|Number=Plur	6	compound	_	SpaceAfter=No
+10	-	-	PUNCT	$(	_	12	punct	_	_
+11	und	und	CCONJ	KON	_	12	cc	_	_
+12	Nachteile	Nachteil	NOUN	NN	Case=Acc|Gender=Masc|Number=Plur	9	conj	_	SpaceAfter=No
+13	.	.	PUNCT	$.	_	6	punct	_	_
 
 # sent_id = test-s352
-# text = Blickpunkt: Die Kurilen-Inseln
-1	Blickpunkt	Blickpunkt	NOUN	NN	Case=Dat|Gender=Masc|Number=Sing	0	root	_	SpaceAfter=No
-2	:	:	PUNCT	$.	_	1	punct	_	_
-3	Die	der	DET	ART	Case=Nom|Definite=Def|Gender=Fem|Number=Plur|PronType=Art	4	det	_	_
-4	Kurilen	Kurilen	PROPN	NN	Case=Nom|Gender=Fem|Number=Plur	1	parataxis	_	SpaceAfter=No
-5	-	-	PUNCT	$(	_	4	punct	_	SpaceAfter=No
-6	Inseln	Insel	NOUN	NE	Case=Nom|Gender=Fem|Number=Plur	4	flat	_	_
+# text = Im Blickpunkt: Die Kurilen-Inseln
+1-2	Im	_	_	_	_	_	_	_	_
+1	In	in	ADP	APPR	_	3	case	_	FixTigerDep=Yes
+2	dem	der	DET	ART	Case=Dat|Gender=Masc|Number=Sing	3	det	_	_
+3	Blickpunkt	Blickpunkt	NOUN	NN	Case=Dat|Gender=Masc|Number=Sing	0	root	_	SpaceAfter=No
+4	:	:	PUNCT	$.	_	3	punct	_	_
+5	Die	der	DET	ART	Case=Nom|Definite=Def|Gender=Fem|Number=Plur|PronType=Art	6	det	_	_
+6	Kurilen	Kurilen	PROPN	NN	Case=Nom|Gender=Fem|Number=Plur	3	parataxis	_	SpaceAfter=No
+7	-	-	PUNCT	$(	_	6	punct	_	SpaceAfter=No
+8	Inseln	Insel	NOUN	NE	Case=Nom|Gender=Fem|Number=Plur	6	flat	_	_
 
 # sent_id = test-s353
-# text = Bonns Zukunftsminister Jürgen Rüttgers hält noch am Projekt fest, weil er ITER im ostdeutschen Städtchen Greifswald hochziehen lassen will.
-1	Bonns	Bonn	PROPN	NE	Case=Gen|Gender=Neut|Number=Sing	2	nmod	_	_
-2	Zukunftsminister	Zukunftsminister	NOUN	NN	Case=Nom|Gender=Masc|Number=Sing	5	nsubj	_	_
-3	Jürgen	Jürgen	PROPN	NE	Case=Nom|Gender=Masc|Number=Sing	2	appos	_	_
-4	Rüttgers	Rüttgers	PROPN	NE	Case=Nom|Gender=Masc|Number=Sing	3	flat	_	_
-5	hält	halten	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	0	root	_	_
-6	noch	noch	ADV	ADV	_	5	advmod	_	_
-7-8	am	_	_	_	_	_	_	_	_
-7	an	an	ADP	APPR	_	9	case	_	_
-8	dem	der	DET	ART	Case=Dat|Definite=Def|Gender=Neut|Number=Sing|PronType=Art	9	det	_	_
-9	Projekt	Projekt	NOUN	NN	Case=Dat|Gender=Neut|Number=Sing	5	obl	_	_
-10	fest	fest	ADV	PTKVZ	_	5	compound:prt	_	SpaceAfter=No
-11	,	,	PUNCT	$,	_	5	punct	_	_
-12	weil	weil	SCONJ	KOUS	_	20	mark	_	_
-13	er	er	PRON	PPER	Case=Nom|Gender=Masc|Number=Sing|Person=3|PronType=Prs	20	nsubj	_	_
-14	ITER	ITER	PROPN	NE	Case=Acc|Number=Sing	20	obj	_	_
-15-16	im	_	_	_	_	_	_	_	_
-15	in	in	ADP	APPR	_	18	case	_	_
-16	dem	der	DET	ART	Case=Dat|Definite=Def|Gender=Neut|Number=Sing|PronType=Art	18	det	_	_
-17	ostdeutschen	ostdeutsch	ADJ	ADJA	Case=Dat|Gender=Neut|Number=Sing	18	amod	_	_
-18	Städtchen	Städtchen	NOUN	NN	Case=Dat|Gender=Neut|Number=Sing	20	obl	_	_
-19	Greifswald	Greifswald	PROPN	NE	Case=Nom|Gender=Neut|Number=Sing	18	appos	_	_
-20	hochziehen	hochziehen	VERB	VVINF	VerbForm=Inf	5	advcl	_	_
-21	lassen	lassen	VERB	VVINF	VerbForm=Inf	20	xcomp	_	_
-22	will	wollen	AUX	VMFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	20	aux	_	SpaceAfter=No
-23	.	.	PUNCT	$.	_	5	punct	_	_
+# text = Nur Bonns Zukunftsminister Jürgen Rüttgers hält noch am Projekt fest, weil er ITER im ostdeutschen Städtchen Greifswald hochziehen lassen will.
+1	Nur	nur	ADV	ADV	_	2	dep	_	FixTigerDep=Yes
+2	Bonns	Bonn	PROPN	NE	Case=Gen|Gender=Neut|Number=Sing	3	nmod	_	_
+3	Zukunftsminister	Zukunftsminister	NOUN	NN	Case=Nom|Gender=Masc|Number=Sing	6	nsubj	_	_
+4	Jürgen	Jürgen	PROPN	NE	Case=Nom|Gender=Masc|Number=Sing	3	appos	_	_
+5	Rüttgers	Rüttgers	PROPN	NE	Case=Nom|Gender=Masc|Number=Sing	4	flat	_	_
+6	hält	halten	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	0	root	_	_
+7	noch	noch	ADV	ADV	_	6	advmod	_	_
+8-9	am	_	_	_	_	_	_	_	_
+8	an	an	ADP	APPR	_	10	case	_	_
+9	dem	der	DET	ART	Case=Dat|Definite=Def|Gender=Neut|Number=Sing|PronType=Art	10	det	_	_
+10	Projekt	Projekt	NOUN	NN	Case=Dat|Gender=Neut|Number=Sing	6	obl	_	_
+11	fest	fest	ADV	PTKVZ	_	6	compound:prt	_	SpaceAfter=No
+12	,	,	PUNCT	$,	_	6	punct	_	_
+13	weil	weil	SCONJ	KOUS	_	21	mark	_	_
+14	er	er	PRON	PPER	Case=Nom|Gender=Masc|Number=Sing|Person=3|PronType=Prs	21	nsubj	_	_
+15	ITER	ITER	PROPN	NE	Case=Acc|Number=Sing	21	obj	_	_
+16-17	im	_	_	_	_	_	_	_	_
+16	in	in	ADP	APPR	_	19	case	_	_
+17	dem	der	DET	ART	Case=Dat|Definite=Def|Gender=Neut|Number=Sing|PronType=Art	19	det	_	_
+18	ostdeutschen	ostdeutsch	ADJ	ADJA	Case=Dat|Gender=Neut|Number=Sing	19	amod	_	_
+19	Städtchen	Städtchen	NOUN	NN	Case=Dat|Gender=Neut|Number=Sing	21	obl	_	_
+20	Greifswald	Greifswald	PROPN	NE	Case=Nom|Gender=Neut|Number=Sing	19	appos	_	_
+21	hochziehen	hochziehen	VERB	VVINF	VerbForm=Inf	6	advcl	_	_
+22	lassen	lassen	VERB	VVINF	VerbForm=Inf	21	xcomp	_	_
+23	will	wollen	AUX	VMFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	21	aux	_	SpaceAfter=No
+24	.	.	PUNCT	$.	_	6	punct	_	_
 
 # sent_id = test-s354
-# text = Boykott könne auch auf Kosten von Arbeitsplätzen in den alten Ländern gehen, meinte er weiter in der Berliner ``Sonntagspost''.
-1	Boykott	Boykott	NOUN	NN	Case=Nom|Gender=Masc|Number=Sing	12	nsubj	_	_
-2	könne	können	AUX	VMFIN	Mood=Sub|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	12	aux	_	_
-3	auch	auch	ADV	ADV	_	12	advmod	_	_
-4	auf	auf	ADP	APPR	_	5	case	_	_
-5	Kosten	Kosten	NOUN	NN	Case=Acc|Number=Plur	12	obl	_	_
-6	von	von	ADP	APPR	_	7	case	_	_
-7	Arbeitsplätzen	Arbeitsplatz	NOUN	NN	Case=Dat|Gender=Masc|Number=Plur	5	nmod	_	_
-8	in	in	ADP	APPR	_	11	case	_	_
-9	den	der	DET	ART	Case=Dat|Definite=Def|Gender=Neut|Number=Plur|PronType=Art	11	det	_	_
-10	alten	alt	ADJ	ADJA	Case=Dat|Gender=Neut|Number=Plur	11	amod	_	_
-11	Ländern	Land	NOUN	NN	Case=Dat|Gender=Neut|Number=Plur	12	obl	_	_
-12	gehen	gehen	VERB	VVINF	VerbForm=Inf	14	ccomp	_	SpaceAfter=No
-13	,	,	PUNCT	$,	_	14	punct	_	_
-14	meinte	meinen	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	0	root	_	_
-15	er	er	PRON	PPER	Case=Nom|Gender=Masc|Number=Sing|Person=3|PronType=Prs	14	nsubj	_	_
-16	weiter	weiter	ADV	ADV	_	14	advmod	_	_
-17	in	in	ADP	APPR	_	21	case	_	_
-18	der	der	DET	ART	Case=Dat|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	21	det	_	_
-19	Berliner	Berliner	ADJ	ADJA	_	21	amod	_	_
-20	``	``	PUNCT	$(	_	21	punct	_	SpaceAfter=No
-21	Sonntagspost	Sonntagspost	PROPN	NN	Case=Dat|Gender=Fem|Number=Sing	14	obl	_	SpaceAfter=No
-22	''	''	PUNCT	$(	_	21	punct	_	SpaceAfter=No
-23	.	.	PUNCT	$.	_	14	punct	_	_
+# text = Ein Boykott könne auch auf Kosten von Arbeitsplätzen in den alten Ländern gehen, meinte er weiter in der Berliner ``Sonntagspost''.
+1	Ein	ein	DET	ART	Case=Nom|Definite=Ind|Gender=Masc|Number=Sing|PronType=Art	2	dep	_	FixTigerDep=Yes
+2	Boykott	Boykott	NOUN	NN	Case=Nom|Gender=Masc|Number=Sing	13	nsubj	_	_
+3	könne	können	AUX	VMFIN	Mood=Sub|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	13	aux	_	_
+4	auch	auch	ADV	ADV	_	13	advmod	_	_
+5	auf	auf	ADP	APPR	_	6	case	_	_
+6	Kosten	Kosten	NOUN	NN	Case=Acc|Number=Plur	13	obl	_	_
+7	von	von	ADP	APPR	_	8	case	_	_
+8	Arbeitsplätzen	Arbeitsplatz	NOUN	NN	Case=Dat|Gender=Masc|Number=Plur	6	nmod	_	_
+9	in	in	ADP	APPR	_	12	case	_	_
+10	den	der	DET	ART	Case=Dat|Definite=Def|Gender=Neut|Number=Plur|PronType=Art	12	det	_	_
+11	alten	alt	ADJ	ADJA	Case=Dat|Gender=Neut|Number=Plur	12	amod	_	_
+12	Ländern	Land	NOUN	NN	Case=Dat|Gender=Neut|Number=Plur	13	obl	_	_
+13	gehen	gehen	VERB	VVINF	VerbForm=Inf	15	ccomp	_	SpaceAfter=No
+14	,	,	PUNCT	$,	_	15	punct	_	_
+15	meinte	meinen	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	0	root	_	_
+16	er	er	PRON	PPER	Case=Nom|Gender=Masc|Number=Sing|Person=3|PronType=Prs	15	nsubj	_	_
+17	weiter	weiter	ADV	ADV	_	15	advmod	_	_
+18	in	in	ADP	APPR	_	22	case	_	_
+19	der	der	DET	ART	Case=Dat|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	22	det	_	_
+20	Berliner	Berliner	ADJ	ADJA	_	22	amod	_	_
+21	``	``	PUNCT	$(	_	22	punct	_	SpaceAfter=No
+22	Sonntagspost	Sonntagspost	PROPN	NN	Case=Dat|Gender=Fem|Number=Sing	15	obl	_	SpaceAfter=No
+23	''	''	PUNCT	$(	_	22	punct	_	SpaceAfter=No
+24	.	.	PUNCT	$.	_	15	punct	_	_
 
 # sent_id = test-s355
 # text = Buna allein beschäftigte früher etwa 20 000 Menschen.
@@ -6441,232 +6478,241 @@
 9	.	.	PUNCT	$.	_	3	punct	_	_
 
 # sent_id = test-s356
-# text = Bundesbahn teilte am Sonntag mit, der Schnellzug D 1273 von Köln nach Port Bou an der südfranzösisch-spanischen Grenze falle vorerst aus.
-1	Bundesbahn	Bundesbahn	NOUN	NE	Case=Nom|Gender=Fem|Number=Sing	2	nsubj	_	_
-2	teilte	teilen	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	0	root	_	_
-3-4	am	_	_	_	_	_	_	_	_
-3	an	an	ADP	APPR	_	5	case	_	_
-4	dem	der	DET	ART	Case=Dat|Definite=Def|Gender=Masc|Number=Sing|PronType=Art	5	det	_	_
-5	Sonntag	Sonntag	PROPN	NN	Case=Dat|Gender=Masc|Number=Sing	2	obl	_	_
-6	mit	mit	ADP	PTKVZ	_	2	compound:prt	_	SpaceAfter=No
-7	,	,	PUNCT	$,	_	2	punct	_	_
-8	der	der	DET	ART	Case=Nom|Definite=Def|Gender=Masc|Number=Sing|PronType=Art	9	det	_	_
-9	Schnellzug	Schnellzug	NOUN	NN	Case=Nom|Gender=Masc|Number=Sing	23	nsubj	_	_
-10	D	D	PROPN	NN	_	9	flat	_	_
-11	1273	1273	PROPN	CARD	NumType=Card	10	nummod	_	_
-12	von	von	ADP	APPR	_	13	case	_	_
-13	Köln	Köln	PROPN	NE	Case=Dat|Gender=Neut|Number=Sing	9	nmod	_	_
-14	nach	nach	ADP	APPR	_	15	case	_	_
-15	Port	Port	PROPN	NE	_	9	nmod	_	_
-16	Bou	Bou	PROPN	NE	Case=Dat|Gender=Neut|Number=Sing	15	flat	_	_
-17	an	an	ADP	APPR	_	22	case	_	_
-18	der	der	DET	ART	Case=Dat|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	22	det	_	_
-19	südfranzösisch	südfranzösisch	ADJ	ADJA	Case=Dat|Gender=Fem|Number=Sing	21	compound	_	SpaceAfter=No
-20	-	-	PUNCT	$(	_	19	punct	_	SpaceAfter=No
-21	spanischen	spanisch	ADJ	ADJA	Case=Dat|Gender=Fem|Number=Sing	22	amod	_	_
-22	Grenze	Grenze	NOUN	NN	Case=Dat|Gender=Fem|Number=Sing	15	nmod	_	_
-23	falle	fallen	VERB	VVFIN	Mood=Sub|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	2	ccomp	_	_
-24	vorerst	vorerst	ADV	ADV	_	23	advmod	_	_
-25	aus	aus	ADP	PTKVZ	_	23	compound:prt	_	SpaceAfter=No
-26	.	.	PUNCT	$.	_	2	punct	_	_
+# text = Die Bundesbahn teilte am Sonntag mit, der Schnellzug D 1273 von Köln nach Port Bou an der südfranzösisch-spanischen Grenze falle vorerst aus.
+1	Die	der	DET	ART	Case=Nom|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	2	dep	_	FixTigerDep=Yes
+2	Bundesbahn	Bundesbahn	NOUN	NE	Case=Nom|Gender=Fem|Number=Sing	3	nsubj	_	_
+3	teilte	teilen	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	0	root	_	_
+4-5	am	_	_	_	_	_	_	_	_
+4	an	an	ADP	APPR	_	6	case	_	_
+5	dem	der	DET	ART	Case=Dat|Definite=Def|Gender=Masc|Number=Sing|PronType=Art	6	det	_	_
+6	Sonntag	Sonntag	PROPN	NN	Case=Dat|Gender=Masc|Number=Sing	3	obl	_	_
+7	mit	mit	ADP	PTKVZ	_	3	compound:prt	_	SpaceAfter=No
+8	,	,	PUNCT	$,	_	3	punct	_	_
+9	der	der	DET	ART	Case=Nom|Definite=Def|Gender=Masc|Number=Sing|PronType=Art	10	det	_	_
+10	Schnellzug	Schnellzug	NOUN	NN	Case=Nom|Gender=Masc|Number=Sing	24	nsubj	_	_
+11	D	D	PROPN	NN	_	10	flat	_	_
+12	1273	1273	PROPN	CARD	NumType=Card	11	nummod	_	_
+13	von	von	ADP	APPR	_	14	case	_	_
+14	Köln	Köln	PROPN	NE	Case=Dat|Gender=Neut|Number=Sing	10	nmod	_	_
+15	nach	nach	ADP	APPR	_	16	case	_	_
+16	Port	Port	PROPN	NE	_	10	nmod	_	_
+17	Bou	Bou	PROPN	NE	Case=Dat|Gender=Neut|Number=Sing	16	flat	_	_
+18	an	an	ADP	APPR	_	23	case	_	_
+19	der	der	DET	ART	Case=Dat|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	23	det	_	_
+20	südfranzösisch	südfranzösisch	ADJ	ADJA	Case=Dat|Gender=Fem|Number=Sing	22	compound	_	SpaceAfter=No
+21	-	-	PUNCT	$(	_	20	punct	_	SpaceAfter=No
+22	spanischen	spanisch	ADJ	ADJA	Case=Dat|Gender=Fem|Number=Sing	23	amod	_	_
+23	Grenze	Grenze	NOUN	NN	Case=Dat|Gender=Fem|Number=Sing	16	nmod	_	_
+24	falle	fallen	VERB	VVFIN	Mood=Sub|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	3	ccomp	_	_
+25	vorerst	vorerst	ADV	ADV	_	24	advmod	_	_
+26	aus	aus	ADP	PTKVZ	_	24	compound:prt	_	SpaceAfter=No
+27	.	.	PUNCT	$.	_	3	punct	_	_
 
 # sent_id = test-s357
-# text = Bundesdelegiertentag war auch in diesem Jahr eine einzige Demonstration der Geschlossenheit:
-1	Bundesdelegiertentag	Bundesdelegiertentag	NOUN	NN	Case=Nom|Gender=Masc|Number=Sing	9	nsubj	_	_
-2	war	sein	AUX	VAFIN	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	9	cop	_	_
-3	auch	auch	ADV	ADV	_	6	advmod	_	_
-4	in	in	ADP	APPR	_	6	case	_	_
-5	diesem	dies	PRON	PDAT	Case=Dat|Gender=Neut|Number=Sing|PronType=Dem	6	det	_	_
-6	Jahr	Jahr	NOUN	NN	Case=Dat|Gender=Neut|Number=Sing	9	nmod	_	_
-7	eine	ein	DET	ART	Case=Nom|Definite=Ind|Gender=Fem|Number=Sing|PronType=Art	9	det	_	_
-8	einzige	einzig	ADJ	ADJA	Case=Nom|Gender=Fem|Number=Sing	9	amod	_	_
-9	Demonstration	Demonstration	NOUN	NN	Case=Nom|Gender=Fem|Number=Sing	0	root	_	_
-10	der	der	DET	ART	Case=Gen|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	11	det	_	_
-11	Geschlossenheit	Geschlossenheit	NOUN	NN	Case=Gen|Gender=Fem|Number=Sing	9	nmod	_	SpaceAfter=No
-12	:	:	PUNCT	$.	_	9	punct	_	_
+# text = Der Bundesdelegiertentag war auch in diesem Jahr eine einzige Demonstration der Geschlossenheit:
+1	Der	der	DET	ART	Case=Nom|Definite=Def|Gender=Masc|Number=Sing|PronType=Art	2	dep	_	FixTigerDep=Yes
+2	Bundesdelegiertentag	Bundesdelegiertentag	NOUN	NN	Case=Nom|Gender=Masc|Number=Sing	10	nsubj	_	_
+3	war	sein	AUX	VAFIN	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	10	cop	_	_
+4	auch	auch	ADV	ADV	_	7	advmod	_	_
+5	in	in	ADP	APPR	_	7	case	_	_
+6	diesem	dies	PRON	PDAT	Case=Dat|Gender=Neut|Number=Sing|PronType=Dem	7	det	_	_
+7	Jahr	Jahr	NOUN	NN	Case=Dat|Gender=Neut|Number=Sing	10	nmod	_	_
+8	eine	ein	DET	ART	Case=Nom|Definite=Ind|Gender=Fem|Number=Sing|PronType=Art	10	det	_	_
+9	einzige	einzig	ADJ	ADJA	Case=Nom|Gender=Fem|Number=Sing	10	amod	_	_
+10	Demonstration	Demonstration	NOUN	NN	Case=Nom|Gender=Fem|Number=Sing	0	root	_	_
+11	der	der	DET	ART	Case=Gen|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	12	det	_	_
+12	Geschlossenheit	Geschlossenheit	NOUN	NN	Case=Gen|Gender=Fem|Number=Sing	10	nmod	_	SpaceAfter=No
+13	:	:	PUNCT	$.	_	10	punct	_	_
 
 # sent_id = test-s358
-# text = Bundespolizei erhielt Informationen, denen zufolge das Trio ``dabeigewesen sein könnte, eine Bombe zu bauen''.
-1	Bundespolizei	Bundespolizei	NOUN	NN	Case=Nom|Gender=Masc|Number=Sing	2	nsubj	_	_
-2	erhielt	erhalten	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	0	root	_	_
-3	Informationen	Information	NOUN	NN	Case=Acc|Gender=Fem|Number=Plur	2	obj	_	SpaceAfter=No
-4	,	,	PUNCT	$,	_	2	punct	_	_
-5	denen	der	PRON	PRELS	Case=Dat|Gender=Fem|Number=Plur|PronType=Rel	10	obl	_	_
-6	zufolge	zufolge	ADP	APPO	Case=Dat	5	case	_	_
-7	das	der	DET	ART	Case=Nom|Definite=Def|Gender=Neut|Number=Sing|PronType=Art	8	det	_	_
-8	Trio	Trio	NOUN	NN	Case=Nom|Gender=Neut|Number=Sing	10	nsubj	_	_
-9	``	``	PUNCT	$(	_	10	punct	_	SpaceAfter=No
-10	dabeigewesen	dabeisein	VERB	VVPP	VerbForm=Part	3	acl	_	_
-11	sein	sein	AUX	VAINF	VerbForm=Inf	10	aux	_	_
-12	könnte	können	AUX	VMFIN	Mood=Sub|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	10	aux	_	SpaceAfter=No
-13	,	,	PUNCT	$,	_	2	punct	_	_
-14	eine	ein	DET	ART	Case=Acc|Definite=Ind|Gender=Fem|Number=Sing|PronType=Art	15	det	_	_
-15	Bombe	Bombe	NOUN	NN	Case=Acc|Gender=Fem|Number=Sing	17	obj	_	_
-16	zu	zu	PART	PTKZU	_	17	mark	_	_
-17	bauen	bauen	VERB	VVINF	VerbForm=Inf	10	acl	_	SpaceAfter=No
-18	''	''	PUNCT	$(	_	10	punct	_	SpaceAfter=No
-19	.	.	PUNCT	$.	_	2	punct	_	_
+# text = Die Bundespolizei erhielt Informationen, denen zufolge das Trio ``dabeigewesen sein könnte, eine Bombe zu bauen''.
+1	Die	der	DET	ART	Case=Nom|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	2	dep	_	FixTigerDep=Yes
+2	Bundespolizei	Bundespolizei	NOUN	NN	Case=Nom|Gender=Masc|Number=Sing	3	nsubj	_	_
+3	erhielt	erhalten	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	0	root	_	_
+4	Informationen	Information	NOUN	NN	Case=Acc|Gender=Fem|Number=Plur	3	obj	_	SpaceAfter=No
+5	,	,	PUNCT	$,	_	3	punct	_	_
+6	denen	der	PRON	PRELS	Case=Dat|Gender=Fem|Number=Plur|PronType=Rel	11	obl	_	_
+7	zufolge	zufolge	ADP	APPO	Case=Dat	6	case	_	_
+8	das	der	DET	ART	Case=Nom|Definite=Def|Gender=Neut|Number=Sing|PronType=Art	9	det	_	_
+9	Trio	Trio	NOUN	NN	Case=Nom|Gender=Neut|Number=Sing	11	nsubj	_	_
+10	``	``	PUNCT	$(	_	11	punct	_	SpaceAfter=No
+11	dabeigewesen	dabeisein	VERB	VVPP	VerbForm=Part	4	acl	_	_
+12	sein	sein	AUX	VAINF	VerbForm=Inf	11	aux	_	_
+13	könnte	können	AUX	VMFIN	Mood=Sub|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	11	aux	_	SpaceAfter=No
+14	,	,	PUNCT	$,	_	3	punct	_	_
+15	eine	ein	DET	ART	Case=Acc|Definite=Ind|Gender=Fem|Number=Sing|PronType=Art	16	det	_	_
+16	Bombe	Bombe	NOUN	NN	Case=Acc|Gender=Fem|Number=Sing	18	obj	_	_
+17	zu	zu	PART	PTKZU	_	18	mark	_	_
+18	bauen	bauen	VERB	VVINF	VerbForm=Inf	11	acl	_	SpaceAfter=No
+19	''	''	PUNCT	$(	_	11	punct	_	SpaceAfter=No
+20	.	.	PUNCT	$.	_	3	punct	_	_
 
 # sent_id = test-s359
-# text = Bundesregierung hatte am Montag mitgeteilt, daß sie ``derzeit'' keine Steuererhöhungen plane.
-1	Bundesregierung	Bundesregierung	NOUN	NN	Case=Nom|Gender=Fem|Number=Sing	6	nsubj	_	_
-2	hatte	haben	AUX	VAFIN	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	6	aux	_	_
-3-4	am	_	_	_	_	_	_	_	_
-3	an	an	ADP	APPR	_	6	case	_	_
-4	dem	der	DET	ART	Case=Dat|Definite=Def|Gender=Masc|Number=Sing|PronType=Art	6	det	_	_
-5	Montag	Montag	PROPN	NN	Case=Dat|Gender=Masc|Number=Sing	3	nsubj	_	_
-6	mitgeteilt	mitteilen	VERB	VVPP	VerbForm=Part	0	root	_	SpaceAfter=No
-7	,	,	PUNCT	$,	_	6	punct	_	_
-8	daß	daß	SCONJ	KOUS	_	15	mark	_	_
-9	sie	sie	PRON	PPER	Case=Nom|Gender=Fem|Number=Sing|Person=3|PronType=Prs	15	nsubj	_	_
-10	``	``	PUNCT	$(	_	11	punct	_	SpaceAfter=No
-11	derzeit	derzeit	ADV	ADV	_	15	advmod	_	SpaceAfter=No
-12	''	''	PUNCT	$(	_	11	punct	_	_
-13	keine	kein	PRON	PIAT	Case=Acc|Definite=Ind|Gender=Fem|Number=Plur|Polarity=Neg|PronType=Neg	14	advmod	_	_
-14	Steuererhöhungen	Steuererhöhung	NOUN	NN	Case=Acc|Gender=Fem|Number=Plur	15	obj	_	_
-15	plane	planen	VERB	VVFIN	Mood=Sub|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	6	ccomp	_	SpaceAfter=No
-16	.	.	PUNCT	$.	_	6	punct	_	_
+# text = Die Bundesregierung hatte am Montag mitgeteilt, daß sie ``derzeit'' keine Steuererhöhungen plane.
+1	Die	der	DET	ART	Case=Nom|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	2	dep	_	FixTigerDep=Yes
+2	Bundesregierung	Bundesregierung	NOUN	NN	Case=Nom|Gender=Fem|Number=Sing	7	nsubj	_	_
+3	hatte	haben	AUX	VAFIN	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	7	aux	_	_
+4-5	am	_	_	_	_	_	_	_	_
+4	an	an	ADP	APPR	_	7	case	_	_
+5	dem	der	DET	ART	Case=Dat|Definite=Def|Gender=Masc|Number=Sing|PronType=Art	7	det	_	_
+6	Montag	Montag	PROPN	NN	Case=Dat|Gender=Masc|Number=Sing	4	nsubj	_	_
+7	mitgeteilt	mitteilen	VERB	VVPP	VerbForm=Part	0	root	_	SpaceAfter=No
+8	,	,	PUNCT	$,	_	7	punct	_	_
+9	daß	daß	SCONJ	KOUS	_	16	mark	_	_
+10	sie	sie	PRON	PPER	Case=Nom|Gender=Fem|Number=Sing|Person=3|PronType=Prs	16	nsubj	_	_
+11	``	``	PUNCT	$(	_	12	punct	_	SpaceAfter=No
+12	derzeit	derzeit	ADV	ADV	_	16	advmod	_	SpaceAfter=No
+13	''	''	PUNCT	$(	_	12	punct	_	_
+14	keine	kein	PRON	PIAT	Case=Acc|Definite=Ind|Gender=Fem|Number=Plur|Polarity=Neg|PronType=Neg	15	advmod	_	_
+15	Steuererhöhungen	Steuererhöhung	NOUN	NN	Case=Acc|Gender=Fem|Number=Plur	16	obj	_	_
+16	plane	planen	VERB	VVFIN	Mood=Sub|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	7	ccomp	_	SpaceAfter=No
+17	.	.	PUNCT	$.	_	7	punct	_	_
 
 # sent_id = test-s360
-# text = Bundesregierung will die Förderung der deutschen Wirtschaft noch stärker ``auf kleine und mittlere Unternehmen zuschneiden''.
-1	Bundesregierung	Bundesregierung	NOUN	NN	Case=Nom|Gender=Fem|Number=Sing	16	nsubj	_	_
-2	will	wollen	AUX	VMFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	16	aux	_	_
-3	die	der	DET	ART	Case=Acc|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	4	det	_	_
-4	Förderung	Förderung	NOUN	NN	Case=Acc|Gender=Fem|Number=Sing	16	obj	_	_
-5	der	der	DET	ART	Case=Gen|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	7	det	_	_
-6	deutschen	deutsch	ADJ	ADJA	Case=Gen|Gender=Fem|Number=Sing	7	amod	_	_
-7	Wirtschaft	Wirtschaft	NOUN	NN	Case=Gen|Gender=Fem|Number=Sing	4	nmod	_	_
-8	noch	noch	ADV	ADV	_	9	advmod	_	_
-9	stärker	stark	ADV	ADJD	_	16	advmod	_	_
-10	``	``	PUNCT	$(	_	15	punct	_	SpaceAfter=No
-11	auf	auf	ADP	APPR	_	15	case	_	_
-12	kleine	klein	ADJ	ADJA	Case=Acc|Gender=Neut|Number=Plur	15	amod	_	_
-13	und	und	CCONJ	KON	_	14	cc	_	_
-14	mittlere	mittlerer	ADJ	ADJA	Case=Acc|Gender=Neut|Number=Plur	12	conj	_	_
-15	Unternehmen	Unternehmen	NOUN	NN	Case=Acc|Gender=Neut|Number=Plur	16	obl	_	_
-16	zuschneiden	zuschneiden	VERB	VVINF	VerbForm=Inf	0	root	_	SpaceAfter=No
-17	''	''	PUNCT	$(	_	15	punct	_	SpaceAfter=No
-18	.	.	PUNCT	$.	_	16	punct	_	_
+# text = Die Bundesregierung will die Förderung der deutschen Wirtschaft noch stärker ``auf kleine und mittlere Unternehmen zuschneiden''.
+1	Die	der	DET	ART	Case=Nom|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	2	dep	_	FixTigerDep=Yes
+2	Bundesregierung	Bundesregierung	NOUN	NN	Case=Nom|Gender=Fem|Number=Sing	17	nsubj	_	_
+3	will	wollen	AUX	VMFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	17	aux	_	_
+4	die	der	DET	ART	Case=Acc|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	5	det	_	_
+5	Förderung	Förderung	NOUN	NN	Case=Acc|Gender=Fem|Number=Sing	17	obj	_	_
+6	der	der	DET	ART	Case=Gen|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	8	det	_	_
+7	deutschen	deutsch	ADJ	ADJA	Case=Gen|Gender=Fem|Number=Sing	8	amod	_	_
+8	Wirtschaft	Wirtschaft	NOUN	NN	Case=Gen|Gender=Fem|Number=Sing	5	nmod	_	_
+9	noch	noch	ADV	ADV	_	10	advmod	_	_
+10	stärker	stark	ADV	ADJD	_	17	advmod	_	_
+11	``	``	PUNCT	$(	_	16	punct	_	SpaceAfter=No
+12	auf	auf	ADP	APPR	_	16	case	_	_
+13	kleine	klein	ADJ	ADJA	Case=Acc|Gender=Neut|Number=Plur	16	amod	_	_
+14	und	und	CCONJ	KON	_	15	cc	_	_
+15	mittlere	mittlerer	ADJ	ADJA	Case=Acc|Gender=Neut|Number=Plur	13	conj	_	_
+16	Unternehmen	Unternehmen	NOUN	NN	Case=Acc|Gender=Neut|Number=Plur	17	obl	_	_
+17	zuschneiden	zuschneiden	VERB	VVINF	VerbForm=Inf	0	root	_	SpaceAfter=No
+18	''	''	PUNCT	$(	_	16	punct	_	SpaceAfter=No
+19	.	.	PUNCT	$.	_	17	punct	_	_
 
 # sent_id = test-s361
-# text = CDU-Chef warf dem Ministerpräsidenten Oskar Lafontaine vor, mit seiner Finanzpolitik im Lande ebenso gescheitert zu sein wie mit seiner Stahl- oder Wirtschaftspolitik.
-1	CDU	CDU	PROPN	NN	Case=Nom|Gender=Masc|Number=Sing	3	compound	_	SpaceAfter=No
-2	-	-	PUNCT	$(	_	1	punct	_	SpaceAfter=No
-3	Chef	Chef	NOUN	NN	Case=Nom|Gender=Masc|Number=Sing	4	nsubj	_	_
-4	warf	werfen	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	0	root	_	_
-5	dem	der	DET	ART	Case=Dat|Definite=Def|Gender=Masc|Number=Sing|PronType=Art	6	det	_	_
-6	Ministerpräsidenten	Ministerpräsident	NOUN	NN	Case=Dat|Gender=Masc|Number=Sing	4	iobj	_	_
-7	Oskar	Oskar	PROPN	NE	Case=Nom|Gender=Masc|Number=Sing	6	appos	_	_
-8	Lafontaine	Lafontaine	PROPN	NE	Case=Nom|Gender=Masc|Number=Sing	7	flat	_	_
-9	vor	vor	ADP	PTKVZ	_	4	compound:prt	_	SpaceAfter=No
-10	,	,	PUNCT	$,	_	4	punct	_	_
-11	mit	mit	ADP	APPR	_	13	case	_	_
-12	seiner	sein	PRON	PPOSAT	Case=Dat|Gender=Fem|Number=Sing|Poss=Yes	13	det:poss	_	_
-13	Finanzpolitik	Finanzpolitik	NOUN	NN	Case=Dat|Gender=Fem|Number=Sing	18	obl	_	_
-14-15	im	_	_	_	_	_	_	_	_
-14	in	in	ADP	APPR	_	16	case	_	_
-15	dem	der	DET	ART	Case=Dat|Definite=Def|Gender=Neut|Number=Sing|PronType=Art	16	det	_	_
-16	Lande	Land	NOUN	NN	Case=Dat|Gender=Neut|Number=Sing	18	obl	_	_
-17	ebenso	ebenso	ADV	ADV	_	18	advmod	_	_
-18	gescheitert	scheitern	VERB	VVPP	VerbForm=Part	4	xcomp	_	_
-19	zu	zu	PART	PTKZU	_	20	mark	_	_
-20	sein	sein	AUX	VAINF	VerbForm=Inf	18	aux	_	_
-21	wie	wie	CCONJ	KOKOM	_	18	dep	_	_
-22	mit	mit	ADP	APPR	_	24	case	_	_
-23	seiner	sein	PRON	PPOSAT	Case=Dat|Gender=Fem|Number=Sing|Poss=Yes	24	det:poss	_	_
-24	Stahl	Stahl	NOUN	NN	Case=Dat|Gender=Fem|Number=Sing	21	compound	_	SpaceAfter=No
-25	-	-	PUNCT	$(	_	27	punct	_	_
-26	oder	oder	CCONJ	KON	_	27	cc	_	_
-27	Wirtschaftspolitik	Wirtschaftspolitik	NOUN	NN	Case=Dat|Gender=Fem|Number=Sing	24	conj	_	SpaceAfter=No
-28	.	.	PUNCT	$.	_	4	punct	_	_
+# text = Der CDU-Chef warf dem Ministerpräsidenten Oskar Lafontaine vor, mit seiner Finanzpolitik im Lande ebenso gescheitert zu sein wie mit seiner Stahl- oder Wirtschaftspolitik.
+1	Der	der	DET	ART	Case=Nom|Definite=Def|Gender=Masc|Number=Sing|PronType=Art	2	dep	_	FixTigerDep=Yes
+2	CDU	CDU	PROPN	NN	Case=Nom|Gender=Masc|Number=Sing	4	compound	_	SpaceAfter=No
+3	-	-	PUNCT	$(	_	2	punct	_	SpaceAfter=No
+4	Chef	Chef	NOUN	NN	Case=Nom|Gender=Masc|Number=Sing	5	nsubj	_	_
+5	warf	werfen	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	0	root	_	_
+6	dem	der	DET	ART	Case=Dat|Definite=Def|Gender=Masc|Number=Sing|PronType=Art	7	det	_	_
+7	Ministerpräsidenten	Ministerpräsident	NOUN	NN	Case=Dat|Gender=Masc|Number=Sing	5	iobj	_	_
+8	Oskar	Oskar	PROPN	NE	Case=Nom|Gender=Masc|Number=Sing	7	appos	_	_
+9	Lafontaine	Lafontaine	PROPN	NE	Case=Nom|Gender=Masc|Number=Sing	8	flat	_	_
+10	vor	vor	ADP	PTKVZ	_	5	compound:prt	_	SpaceAfter=No
+11	,	,	PUNCT	$,	_	5	punct	_	_
+12	mit	mit	ADP	APPR	_	14	case	_	_
+13	seiner	sein	PRON	PPOSAT	Case=Dat|Gender=Fem|Number=Sing|Poss=Yes	14	det:poss	_	_
+14	Finanzpolitik	Finanzpolitik	NOUN	NN	Case=Dat|Gender=Fem|Number=Sing	19	obl	_	_
+15-16	im	_	_	_	_	_	_	_	_
+15	in	in	ADP	APPR	_	17	case	_	_
+16	dem	der	DET	ART	Case=Dat|Definite=Def|Gender=Neut|Number=Sing|PronType=Art	17	det	_	_
+17	Lande	Land	NOUN	NN	Case=Dat|Gender=Neut|Number=Sing	19	obl	_	_
+18	ebenso	ebenso	ADV	ADV	_	19	advmod	_	_
+19	gescheitert	scheitern	VERB	VVPP	VerbForm=Part	5	xcomp	_	_
+20	zu	zu	PART	PTKZU	_	21	mark	_	_
+21	sein	sein	AUX	VAINF	VerbForm=Inf	19	aux	_	_
+22	wie	wie	CCONJ	KOKOM	_	19	dep	_	_
+23	mit	mit	ADP	APPR	_	25	case	_	_
+24	seiner	sein	PRON	PPOSAT	Case=Dat|Gender=Fem|Number=Sing|Poss=Yes	25	det:poss	_	_
+25	Stahl	Stahl	NOUN	NN	Case=Dat|Gender=Fem|Number=Sing	22	compound	_	SpaceAfter=No
+26	-	-	PUNCT	$(	_	28	punct	_	_
+27	oder	oder	CCONJ	KON	_	28	cc	_	_
+28	Wirtschaftspolitik	Wirtschaftspolitik	NOUN	NN	Case=Dat|Gender=Fem|Number=Sing	25	conj	_	SpaceAfter=No
+29	.	.	PUNCT	$.	_	5	punct	_	_
 
 # sent_id = test-s362
-# text = chinesische Ministerpräsident Li Peng und der armenische Regierungschef Gagik Arutjunjan haben jetzt in Peking fünf Abkommen unterzeichnet, die eine enge Zusammenarbeit der beiden Länder in Wirtschaft, Technologie und Kultur vereinbaren.
-1	chinesische	chinesisch	ADJ	ADJA	Case=Nom|Gender=Masc|Number=Sing	2	amod	_	_
-2	Ministerpräsident	Ministerpräsident	NOUN	NN	Case=Nom|Gender=Masc|Number=Sing	17	nsubj	_	_
-3	Li	Li	PROPN	NE	Case=Nom|Gender=Masc|Number=Sing	2	appos	_	_
-4	Peng	Peng	PROPN	NE	Case=Nom|Gender=Masc|Number=Sing	3	flat	_	_
-5	und	und	CCONJ	KON	_	8	cc	_	_
-6	der	der	DET	ART	Case=Nom|Definite=Def|Gender=Masc|Number=Sing|PronType=Art	8	det	_	_
-7	armenische	armenisch	ADJ	ADJA	Case=Nom|Gender=Masc|Number=Sing	8	amod	_	_
-8	Regierungschef	Regierungschef	NOUN	NN	Case=Nom|Gender=Masc|Number=Sing	2	conj	_	_
-9	Gagik	Gagik	PROPN	NE	Case=Nom|Gender=Masc|Number=Sing	8	appos	_	_
-10	Arutjunjan	Arutjunjan	PROPN	NE	Case=Nom|Gender=Masc|Number=Sing	9	flat	_	_
-11	haben	haben	AUX	VAFIN	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	17	aux	_	_
-12	jetzt	jetzt	ADV	ADV	_	17	advmod	_	_
-13	in	in	ADP	APPR	_	14	case	_	_
-14	Peking	Peking	PROPN	NE	Case=Dat|Gender=Neut|Number=Sing	17	obl	_	_
-15	fünf	fünf	NUM	CARD	NumType=Card	16	nummod	_	_
-16	Abkommen	Abkommen	NOUN	NN	Case=Acc|Gender=Neut|Number=Plur	17	obj	_	_
-17	unterzeichnet	unterzeichnen	VERB	VVPP	VerbForm=Part	0	root	_	SpaceAfter=No
-18	,	,	PUNCT	$,	_	17	punct	_	_
-19	die	der	PRON	PRELS	Case=Nom|Gender=Neut|Number=Plur|PronType=Rel	32	nsubj	_	_
-20	eine	ein	DET	ART	Case=Acc|Definite=Ind|Gender=Fem|Number=Sing|PronType=Art	22	det	_	_
-21	enge	eng	ADJ	ADJA	Case=Acc|Gender=Fem|Number=Sing	22	amod	_	_
-22	Zusammenarbeit	Zusammenarbeit	NOUN	NN	Case=Acc|Gender=Fem|Number=Sing	32	obj	_	_
-23	der	der	DET	ART	Case=Gen|Definite=Def|Gender=Neut|Number=Plur|PronType=Art	25	det	_	_
-24	beiden	beide	PRON	PIAT	Case=Gen|Definite=Ind|Gender=Neut|Number=Plur|PronType=Ind	25	det	_	_
-25	Länder	Land	NOUN	NN	Case=Gen|Gender=Neut|Number=Plur	22	nmod	_	_
-26	in	in	ADP	APPR	_	27	case	_	_
-27	Wirtschaft	Wirtschaft	NOUN	NN	Case=Dat|Gender=Fem|Number=Sing	22	nmod	_	SpaceAfter=No
-28	,	,	PUNCT	$,	_	29	punct	_	_
-29	Technologie	Technologie	NOUN	NN	Case=Dat|Gender=Fem|Number=Sing	27	conj	_	_
-30	und	und	CCONJ	KON	_	31	cc	_	_
-31	Kultur	Kultur	NOUN	NN	Case=Dat|Gender=Fem|Number=Sing	29	conj	_	_
-32	vereinbaren	vereinbaren	VERB	VVFIN	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	16	acl	_	SpaceAfter=No
-33	.	.	PUNCT	$.	_	17	punct	_	_
+# text = Der chinesische Ministerpräsident Li Peng und der armenische Regierungschef Gagik Arutjunjan haben jetzt in Peking fünf Abkommen unterzeichnet, die eine enge Zusammenarbeit der beiden Länder in Wirtschaft, Technologie und Kultur vereinbaren.
+1	Der	der	DET	ART	Case=Nom|Definite=Def|Gender=Masc|Number=Sing|PronType=Art	2	dep	_	FixTigerDep=Yes
+2	chinesische	chinesisch	ADJ	ADJA	Case=Nom|Gender=Masc|Number=Sing	3	amod	_	_
+3	Ministerpräsident	Ministerpräsident	NOUN	NN	Case=Nom|Gender=Masc|Number=Sing	18	nsubj	_	_
+4	Li	Li	PROPN	NE	Case=Nom|Gender=Masc|Number=Sing	3	appos	_	_
+5	Peng	Peng	PROPN	NE	Case=Nom|Gender=Masc|Number=Sing	4	flat	_	_
+6	und	und	CCONJ	KON	_	9	cc	_	_
+7	der	der	DET	ART	Case=Nom|Definite=Def|Gender=Masc|Number=Sing|PronType=Art	9	det	_	_
+8	armenische	armenisch	ADJ	ADJA	Case=Nom|Gender=Masc|Number=Sing	9	amod	_	_
+9	Regierungschef	Regierungschef	NOUN	NN	Case=Nom|Gender=Masc|Number=Sing	3	conj	_	_
+10	Gagik	Gagik	PROPN	NE	Case=Nom|Gender=Masc|Number=Sing	9	appos	_	_
+11	Arutjunjan	Arutjunjan	PROPN	NE	Case=Nom|Gender=Masc|Number=Sing	10	flat	_	_
+12	haben	haben	AUX	VAFIN	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	18	aux	_	_
+13	jetzt	jetzt	ADV	ADV	_	18	advmod	_	_
+14	in	in	ADP	APPR	_	15	case	_	_
+15	Peking	Peking	PROPN	NE	Case=Dat|Gender=Neut|Number=Sing	18	obl	_	_
+16	fünf	fünf	NUM	CARD	NumType=Card	17	nummod	_	_
+17	Abkommen	Abkommen	NOUN	NN	Case=Acc|Gender=Neut|Number=Plur	18	obj	_	_
+18	unterzeichnet	unterzeichnen	VERB	VVPP	VerbForm=Part	0	root	_	SpaceAfter=No
+19	,	,	PUNCT	$,	_	18	punct	_	_
+20	die	der	PRON	PRELS	Case=Nom|Gender=Neut|Number=Plur|PronType=Rel	33	nsubj	_	_
+21	eine	ein	DET	ART	Case=Acc|Definite=Ind|Gender=Fem|Number=Sing|PronType=Art	23	det	_	_
+22	enge	eng	ADJ	ADJA	Case=Acc|Gender=Fem|Number=Sing	23	amod	_	_
+23	Zusammenarbeit	Zusammenarbeit	NOUN	NN	Case=Acc|Gender=Fem|Number=Sing	33	obj	_	_
+24	der	der	DET	ART	Case=Gen|Definite=Def|Gender=Neut|Number=Plur|PronType=Art	26	det	_	_
+25	beiden	beide	PRON	PIAT	Case=Gen|Definite=Ind|Gender=Neut|Number=Plur|PronType=Ind	26	det	_	_
+26	Länder	Land	NOUN	NN	Case=Gen|Gender=Neut|Number=Plur	23	nmod	_	_
+27	in	in	ADP	APPR	_	28	case	_	_
+28	Wirtschaft	Wirtschaft	NOUN	NN	Case=Dat|Gender=Fem|Number=Sing	23	nmod	_	SpaceAfter=No
+29	,	,	PUNCT	$,	_	30	punct	_	_
+30	Technologie	Technologie	NOUN	NN	Case=Dat|Gender=Fem|Number=Sing	28	conj	_	_
+31	und	und	CCONJ	KON	_	32	cc	_	_
+32	Kultur	Kultur	NOUN	NN	Case=Dat|Gender=Fem|Number=Sing	30	conj	_	_
+33	vereinbaren	vereinbaren	VERB	VVFIN	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	17	acl	_	SpaceAfter=No
+34	.	.	PUNCT	$.	_	18	punct	_	_
 
 # sent_id = test-s363
-# text = Computerbauer SNI hatte schon vor einiger Zeit bekanntgegeben, daß er weitere 3000 Jobs streichen will.
-1	Computerbauer	Computerbauer	NOUN	NN	Case=Nom|Gender=Masc|Number=Sing	2	compound	_	_
-2	SNI	SNI	PROPN	NE	Case=Nom|Number=Sing	8	nsubj	_	_
-3	hatte	haben	AUX	VAFIN	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	8	aux	_	_
-4	schon	schon	ADV	ADV	_	8	advmod	_	_
-5	vor	vor	ADP	APPR	_	7	case	_	_
-6	einiger	einige	PRON	PIAT	Case=Dat|Definite=Ind|Gender=Fem|Number=Sing|PronType=Ind	7	amod	_	_
-7	Zeit	Zeit	NOUN	NN	Case=Dat|Gender=Fem|Number=Sing	8	obl	_	_
-8	bekanntgegeben	bekanntgeben	VERB	VVPP	VerbForm=Part	0	root	_	SpaceAfter=No
-9	,	,	PUNCT	$,	_	8	punct	_	_
-10	daß	daß	SCONJ	KOUS	_	15	mark	_	_
-11	er	er	PRON	PPER	Case=Nom|Gender=Masc|Number=Sing|Person=3|PronType=Prs	15	nsubj	_	_
-12	weitere	weit	ADJ	ADJA	Case=Acc|Gender=Masc|Number=Plur	14	amod	_	_
-13	3000	3000	NUM	CARD	NumType=Card	14	nummod	_	_
-14	Jobs	Job	NOUN	NN	Case=Acc|Gender=Masc|Number=Plur	15	obj	_	_
-15	streichen	streichen	VERB	VVINF	VerbForm=Inf	8	ccomp	_	_
-16	will	wollen	AUX	VMFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	15	aux	_	SpaceAfter=No
-17	.	.	PUNCT	$.	_	8	punct	_	_
+# text = Der Computerbauer SNI hatte schon vor einiger Zeit bekanntgegeben, daß er weitere 3000 Jobs streichen will.
+1	Der	der	DET	ART	Case=Nom|Definite=Def|Gender=Masc|Number=Sing|PronType=Art	2	dep	_	FixTigerDep=Yes
+2	Computerbauer	Computerbauer	NOUN	NN	Case=Nom|Gender=Masc|Number=Sing	3	compound	_	_
+3	SNI	SNI	PROPN	NE	Case=Nom|Number=Sing	9	nsubj	_	_
+4	hatte	haben	AUX	VAFIN	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	9	aux	_	_
+5	schon	schon	ADV	ADV	_	9	advmod	_	_
+6	vor	vor	ADP	APPR	_	8	case	_	_
+7	einiger	einige	PRON	PIAT	Case=Dat|Definite=Ind|Gender=Fem|Number=Sing|PronType=Ind	8	amod	_	_
+8	Zeit	Zeit	NOUN	NN	Case=Dat|Gender=Fem|Number=Sing	9	obl	_	_
+9	bekanntgegeben	bekanntgeben	VERB	VVPP	VerbForm=Part	0	root	_	SpaceAfter=No
+10	,	,	PUNCT	$,	_	9	punct	_	_
+11	daß	daß	SCONJ	KOUS	_	16	mark	_	_
+12	er	er	PRON	PPER	Case=Nom|Gender=Masc|Number=Sing|Person=3|PronType=Prs	16	nsubj	_	_
+13	weitere	weit	ADJ	ADJA	Case=Acc|Gender=Masc|Number=Plur	15	amod	_	_
+14	3000	3000	NUM	CARD	NumType=Card	15	nummod	_	_
+15	Jobs	Job	NOUN	NN	Case=Acc|Gender=Masc|Number=Plur	16	obj	_	_
+16	streichen	streichen	VERB	VVINF	VerbForm=Inf	9	ccomp	_	_
+17	will	wollen	AUX	VMFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	16	aux	_	SpaceAfter=No
+18	.	.	PUNCT	$.	_	9	punct	_	_
 
 # sent_id = test-s364
-# text = Da kommen die anderen Vereine in Deutschland nicht annähernd mit'', verschlug es dem ansonsten nicht auf den Mund gefallenen Bremer Kollegen Willi Lemke fast die Sprache.
-1	Da	da	ADV	ADV	_	2	advmod	_	_
-2	kommen	kommen	VERB	VVFIN	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	13	ccomp	_	_
-3	die	der	DET	ART	Case=Nom|Definite=Def|Gender=Masc|Number=Plur|PronType=Art	5	det	_	_
-4	anderen	anderer	ADJ	ADJA	Case=Nom|Gender=Masc|Number=Plur	5	amod	_	_
-5	Vereine	Verein	NOUN	NN	Case=Nom|Gender=Masc|Number=Plur	2	nsubj	_	_
-6	in	in	ADP	APPR	_	7	case	_	_
-7	Deutschland	Deutschland	PROPN	NE	Case=Dat|Gender=Neut|Number=Sing	5	nmod	_	_
-8	nicht	nicht	PART	PTKNEG	Polarity=Neg	2	advmod	_	_
-9	annähernd	annähernd	ADV	ADJD	_	2	advmod	_	_
-10	mit	mit	ADP	PTKVZ	_	2	compound:prt	_	SpaceAfter=No
-11	''	''	PUNCT	$(	_	13	punct	_	SpaceAfter=No
-12	,	,	PUNCT	$,	_	13	punct	_	_
-13	verschlug	verschlagen	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	0	root	_	_
-14	es	es	PRON	PPER	Case=Nom|Gender=Neut|Number=Sing|Person=3|PronType=Prs	13	nsubj	_	_
-15	dem	der	PRON	ART	Case=Dat|Definite=Def|Gender=Masc|Number=Sing|PronType=Art	23	det	_	_
-16	ansonsten	ansonsten	ADV	ADV	_	23	advmod	_	_
-17	nicht	nicht	PART	PTKNEG	Polarity=Neg	21	advmod	_	_
-18	auf	auf	ADP	APPR	_	20	case	_	_
-19	den	der	DET	ART	Case=Acc|Definite=Def|Gender=Masc|Number=Sing|PronType=Art	20	det	_	_
-20	Mund	Mund	NOUN	NN	Case=Acc|Gender=Masc|Number=Sing	21	nmod	_	_
-21	gefallenen	gefallen	ADJ	ADJA	Case=Dat|Gender=Masc|Number=Sing	23	amod	_	_
-22	Bremer	Bremer	ADJ	ADJA	_	23	amod	_	_
-23	Kollegen	Kollege	NOUN	NN	Case=Dat|Gender=Masc|Number=Sing	13	iobj	_	_
-24	Willi	Willi	PROPN	NE	Case=Nom|Gender=Masc|Number=Sing	23	appos	_	_
-25	Lemke	Lemke	PROPN	NE	Case=Nom|Gender=Masc|Number=Sing	24	flat	_	_
-26	fast	fast	ADV	ADV	_	13	advmod	_	_
-27	die	der	DET	ART	Case=Acc|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	28	det	_	_
-28	Sprache	Sprache	NOUN	NN	Case=Acc|Gender=Fem|Number=Sing	13	obj	_	SpaceAfter=No
-29	.	.	PUNCT	$.	_	13	punct	_	_
+# text = ``Da kommen die anderen Vereine in Deutschland nicht annähernd mit'', verschlug es dem ansonsten nicht auf den Mund gefallenen Bremer Kollegen Willi Lemke fast die Sprache.
+1	``	``	PUNCT	$(	_	2	punct	_	FixTigerDep=Yes|SpaceAfter=No
+2	Da	da	ADV	ADV	_	3	advmod	_	_
+3	kommen	kommen	VERB	VVFIN	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	14	ccomp	_	_
+4	die	der	DET	ART	Case=Nom|Definite=Def|Gender=Masc|Number=Plur|PronType=Art	6	det	_	_
+5	anderen	anderer	ADJ	ADJA	Case=Nom|Gender=Masc|Number=Plur	6	amod	_	_
+6	Vereine	Verein	NOUN	NN	Case=Nom|Gender=Masc|Number=Plur	3	nsubj	_	_
+7	in	in	ADP	APPR	_	8	case	_	_
+8	Deutschland	Deutschland	PROPN	NE	Case=Dat|Gender=Neut|Number=Sing	6	nmod	_	_
+9	nicht	nicht	PART	PTKNEG	Polarity=Neg	3	advmod	_	_
+10	annähernd	annähernd	ADV	ADJD	_	3	advmod	_	_
+11	mit	mit	ADP	PTKVZ	_	3	compound:prt	_	SpaceAfter=No
+12	''	''	PUNCT	$(	_	14	punct	_	SpaceAfter=No
+13	,	,	PUNCT	$,	_	14	punct	_	_
+14	verschlug	verschlagen	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	0	root	_	_
+15	es	es	PRON	PPER	Case=Nom|Gender=Neut|Number=Sing|Person=3|PronType=Prs	14	nsubj	_	_
+16	dem	der	PRON	ART	Case=Dat|Definite=Def|Gender=Masc|Number=Sing|PronType=Art	24	det	_	_
+17	ansonsten	ansonsten	ADV	ADV	_	24	advmod	_	_
+18	nicht	nicht	PART	PTKNEG	Polarity=Neg	22	advmod	_	_
+19	auf	auf	ADP	APPR	_	21	case	_	_
+20	den	der	DET	ART	Case=Acc|Definite=Def|Gender=Masc|Number=Sing|PronType=Art	21	det	_	_
+21	Mund	Mund	NOUN	NN	Case=Acc|Gender=Masc|Number=Sing	22	nmod	_	_
+22	gefallenen	gefallen	ADJ	ADJA	Case=Dat|Gender=Masc|Number=Sing	24	amod	_	_
+23	Bremer	Bremer	ADJ	ADJA	_	24	amod	_	_
+24	Kollegen	Kollege	NOUN	NN	Case=Dat|Gender=Masc|Number=Sing	14	iobj	_	_
+25	Willi	Willi	PROPN	NE	Case=Nom|Gender=Masc|Number=Sing	24	appos	_	_
+26	Lemke	Lemke	PROPN	NE	Case=Nom|Gender=Masc|Number=Sing	25	flat	_	_
+27	fast	fast	ADV	ADV	_	14	advmod	_	_
+28	die	der	DET	ART	Case=Acc|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	29	det	_	_
+29	Sprache	Sprache	NOUN	NN	Case=Acc|Gender=Fem|Number=Sing	14	obj	_	SpaceAfter=No
+30	.	.	PUNCT	$.	_	14	punct	_	_
 
 # sent_id = test-s365
 # text = Dänemark hat von seinem Recht, Renten von Deutschen zu besteuern, lange gar keinen Gebrauch gemacht.
@@ -6690,161 +6736,168 @@
 18	.	.	PUNCT	$.	_	17	punct	_	_
 
 # sent_id = test-s366
-# text = Dann steigen die Kosten, aber mein Umsatz bleibt gleich.''
-1	Dann	dann	ADV	ADV	_	2	advmod	_	_
-2	steigen	steigen	VERB	VVFIN	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	0	root	_	_
-3	die	der	DET	ART	Case=Nom|Definite=Def|Number=Plur|PronType=Art	4	det	_	_
-4	Kosten	Kosten	NOUN	NN	Case=Nom|Number=Plur	2	nsubj	_	SpaceAfter=No
-5	,	,	PUNCT	$,	_	9	punct	_	_
-6	aber	aber	CCONJ	KON	_	9	cc	_	_
-7	mein	mein	PRON	PPOSAT	Case=Nom|Gender=Masc|Number=Sing|Poss=Yes	8	det:poss	_	_
-8	Umsatz	Umsatz	NOUN	NN	Case=Nom|Gender=Masc|Number=Sing	9	nsubj	_	_
-9	bleibt	bleiben	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	2	conj	_	_
-10	gleich	gleich	ADV	ADV	_	9	mark	_	SpaceAfter=No
-11	.	.	PUNCT	$.	_	2	punct	_	SpaceAfter=No
-12	''	''	PUNCT	$(	_	2	punct	_	_
+# text = ``Dann steigen die Kosten, aber mein Umsatz bleibt gleich.''
+1	``	``	PUNCT	$(	_	2	punct	_	FixTigerDep=Yes|SpaceAfter=No
+2	Dann	dann	ADV	ADV	_	3	advmod	_	_
+3	steigen	steigen	VERB	VVFIN	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	0	root	_	_
+4	die	der	DET	ART	Case=Nom|Definite=Def|Number=Plur|PronType=Art	5	det	_	_
+5	Kosten	Kosten	NOUN	NN	Case=Nom|Number=Plur	3	nsubj	_	SpaceAfter=No
+6	,	,	PUNCT	$,	_	10	punct	_	_
+7	aber	aber	CCONJ	KON	_	10	cc	_	_
+8	mein	mein	PRON	PPOSAT	Case=Nom|Gender=Masc|Number=Sing|Poss=Yes	9	det:poss	_	_
+9	Umsatz	Umsatz	NOUN	NN	Case=Nom|Gender=Masc|Number=Sing	10	nsubj	_	_
+10	bleibt	bleiben	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	3	conj	_	_
+11	gleich	gleich	ADV	ADV	_	10	mark	_	SpaceAfter=No
+12	.	.	PUNCT	$.	_	3	punct	_	SpaceAfter=No
+13	''	''	PUNCT	$(	_	3	punct	_	_
 
 # sent_id = test-s367
-# text = Darstellung Dokos rücken bosnische und kroatische Kräfte an mehreren Fronten vor und könnten den Ring um Sarajewo von außen sprengen.
-1	Darstellung	Darstellung	NOUN	NN	Case=Dat|Gender=Fem|Number=Sing	3	dep	_	_
-2	Dokos	Dokos	PROPN	NE	Case=Gen|Number=Sing	1	nmod	_	_
-3	rücken	rücken	VERB	VVFIN	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	0	root	_	_
-4	bosnische	bosnisch	ADJ	ADJA	Case=Nom|Gender=Fem|Number=Plur	7	amod	_	_
-5	und	und	CCONJ	KON	_	6	cc	_	_
-6	kroatische	kroatisch	ADJ	ADJA	Case=Nom|Gender=Fem|Number=Plur	4	conj	_	_
-7	Kräfte	Kraft	NOUN	NN	Case=Nom|Gender=Fem|Number=Plur	3	nsubj	_	_
-8	an	an	ADP	APPR	_	10	case	_	_
-9	mehreren	mehrere	PRON	PIAT	Case=Dat|Definite=Ind|Gender=Fem|Number=Plur|PronType=Ind	10	det	_	_
-10	Fronten	Front	NOUN	NN	Case=Dat|Gender=Fem|Number=Plur	3	obl	_	_
-11	vor	vor	ADP	PTKVZ	_	3	compound:prt	_	_
-12	und	und	CCONJ	KON	_	20	cc	_	_
-13	könnten	können	AUX	VMFIN	Mood=Sub|Number=Plur|Person=3|Tense=Past|VerbForm=Fin	20	aux	_	_
-14	den	der	DET	ART	Case=Acc|Definite=Def|Gender=Masc|Number=Sing|PronType=Art	15	det	_	_
-15	Ring	Ring	NOUN	NN	Case=Acc|Gender=Masc|Number=Sing	20	obj	_	_
-16	um	um	ADP	APPR	_	17	case	_	_
-17	Sarajewo	Sarajewo	PROPN	NE	Case=Acc|Gender=Neut|Number=Sing	15	nmod	_	_
-18	von	von	ADP	APPR	_	19	case	_	_
-19	außen	Außen	NOUN	ADV	_	20	obl	_	_
-20	sprengen	sprengen	VERB	VVINF	VerbForm=Inf	3	conj	_	SpaceAfter=No
-21	.	.	PUNCT	$.	_	3	punct	_	_
+# text = Nach Darstellung Dokos rücken bosnische und kroatische Kräfte an mehreren Fronten vor und könnten den Ring um Sarajewo von außen sprengen.
+1	Nach	nach	ADP	APPR	_	2	dep	_	FixTigerDep=Yes
+2	Darstellung	Darstellung	NOUN	NN	Case=Dat|Gender=Fem|Number=Sing	4	dep	_	_
+3	Dokos	Doko	PROPN	NE	Case=Gen|Number=Sing	2	nmod	_	_
+4	rücken	rücken	VERB	VVFIN	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	0	root	_	_
+5	bosnische	bosnisch	ADJ	ADJA	Case=Nom|Gender=Fem|Number=Plur	8	amod	_	_
+6	und	und	CCONJ	KON	_	7	cc	_	_
+7	kroatische	kroatisch	ADJ	ADJA	Case=Nom|Gender=Fem|Number=Plur	5	conj	_	_
+8	Kräfte	Kraft	NOUN	NN	Case=Nom|Gender=Fem|Number=Plur	4	nsubj	_	_
+9	an	an	ADP	APPR	_	11	case	_	_
+10	mehreren	mehrere	PRON	PIAT	Case=Dat|Definite=Ind|Gender=Fem|Number=Plur|PronType=Ind	11	det	_	_
+11	Fronten	Front	NOUN	NN	Case=Dat|Gender=Fem|Number=Plur	4	obl	_	_
+12	vor	vor	ADP	PTKVZ	_	4	compound:prt	_	_
+13	und	und	CCONJ	KON	_	21	cc	_	_
+14	könnten	können	AUX	VMFIN	Mood=Sub|Number=Plur|Person=3|Tense=Past|VerbForm=Fin	21	aux	_	_
+15	den	der	DET	ART	Case=Acc|Definite=Def|Gender=Masc|Number=Sing|PronType=Art	16	det	_	_
+16	Ring	Ring	NOUN	NN	Case=Acc|Gender=Masc|Number=Sing	21	obj	_	_
+17	um	um	ADP	APPR	_	18	case	_	_
+18	Sarajewo	Sarajewo	PROPN	NE	Case=Acc|Gender=Neut|Number=Sing	16	nmod	_	_
+19	von	von	ADP	APPR	_	20	case	_	_
+20	außen	Außen	NOUN	ADV	_	21	obl	_	_
+21	sprengen	sprengen	VERB	VVINF	VerbForm=Inf	4	conj	_	SpaceAfter=No
+22	.	.	PUNCT	$.	_	4	punct	_	_
 
 # sent_id = test-s368
-# text = Das Damoklesschwert einer militärischen Intervention wird über den Serben hängen'', hieß es in der deutschen Delegation.
-1	Das	der	DET	ART	Case=Nom|Definite=Def|Gender=Neut|Number=Sing|PronType=Art	2	det	_	_
-2	Damoklesschwert	Damoklesschwert	NOUN	NN	Case=Nom|Gender=Neut|Number=Sing	10	nsubj	_	_
-3	einer	ein	DET	ART	Case=Gen|Definite=Ind|Gender=Fem|Number=Sing|PronType=Art	5	det	_	_
-4	militärischen	militärisch	ADJ	ADJA	Case=Gen|Gender=Fem|Number=Sing	5	amod	_	_
-5	Intervention	Intervention	NOUN	NN	Case=Gen|Gender=Fem|Number=Sing	2	nmod	_	_
-6	wird	werden	AUX	VAFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin|Voice=Pass	10	aux	_	_
-7	über	über	ADP	APPR	_	9	case	_	_
-8	den	der	DET	ART	Case=Dat|Definite=Def|Gender=Masc|Number=Plur|PronType=Art	9	det	_	_
-9	Serben	Serbe	PROPN	NN	Case=Dat|Gender=Masc|Number=Plur	10	obl	_	_
-10	hängen	hängen	VERB	VVINF	VerbForm=Inf	13	ccomp	_	SpaceAfter=No
-11	''	''	PUNCT	$(	_	13	punct	_	SpaceAfter=No
-12	,	,	PUNCT	$,	_	13	punct	_	_
-13	hieß	heißen	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	0	root	_	_
-14	es	es	PRON	PPER	Case=Nom|Gender=Neut|Number=Sing|Person=3|PronType=Prs	13	nsubj	_	_
-15	in	in	ADP	APPR	_	18	case	_	_
-16	der	der	DET	ART	Case=Dat|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	18	det	_	_
-17	deutschen	deutsch	ADJ	ADJA	Case=Dat|Gender=Fem|Number=Sing	18	amod	_	_
-18	Delegation	Delegation	NOUN	NN	Case=Dat|Gender=Fem|Number=Sing	13	obl	_	SpaceAfter=No
-19	.	.	PUNCT	$.	_	13	punct	_	_
+# text = ``Das Damoklesschwert einer militärischen Intervention wird über den Serben hängen'', hieß es in der deutschen Delegation.
+1	``	``	PUNCT	$(	_	2	punct	_	FixTigerDep=Yes|SpaceAfter=No
+2	Das	der	DET	ART	Case=Nom|Definite=Def|Gender=Neut|Number=Sing|PronType=Art	3	det	_	_
+3	Damoklesschwert	Damoklesschwert	NOUN	NN	Case=Nom|Gender=Neut|Number=Sing	11	nsubj	_	_
+4	einer	ein	DET	ART	Case=Gen|Definite=Ind|Gender=Fem|Number=Sing|PronType=Art	6	det	_	_
+5	militärischen	militärisch	ADJ	ADJA	Case=Gen|Gender=Fem|Number=Sing	6	amod	_	_
+6	Intervention	Intervention	NOUN	NN	Case=Gen|Gender=Fem|Number=Sing	3	nmod	_	_
+7	wird	werden	AUX	VAFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin|Voice=Pass	11	aux	_	_
+8	über	über	ADP	APPR	_	10	case	_	_
+9	den	der	DET	ART	Case=Dat|Definite=Def|Gender=Masc|Number=Plur|PronType=Art	10	det	_	_
+10	Serben	Serbe	PROPN	NN	Case=Dat|Gender=Masc|Number=Plur	11	obl	_	_
+11	hängen	hängen	VERB	VVINF	VerbForm=Inf	14	ccomp	_	SpaceAfter=No
+12	''	''	PUNCT	$(	_	14	punct	_	SpaceAfter=No
+13	,	,	PUNCT	$,	_	14	punct	_	_
+14	hieß	heißen	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	0	root	_	_
+15	es	es	PRON	PPER	Case=Nom|Gender=Neut|Number=Sing|Person=3|PronType=Prs	14	nsubj	_	_
+16	in	in	ADP	APPR	_	19	case	_	_
+17	der	der	DET	ART	Case=Dat|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	19	det	_	_
+18	deutschen	deutsch	ADJ	ADJA	Case=Dat|Gender=Fem|Number=Sing	19	amod	_	_
+19	Delegation	Delegation	NOUN	NN	Case=Dat|Gender=Fem|Number=Sing	14	obl	_	SpaceAfter=No
+20	.	.	PUNCT	$.	_	14	punct	_	_
 
 # sent_id = test-s369
-# text = Das ist die erste intelligente Äußerung, die ich von der IG Metall seit Jahren höre'', sagte Stihl der FR.
-1	Das	der	PRON	PDS	Case=Nom|Gender=Neut|Number=Sing|PronType=Dem	6	nsubj	_	_
-2	ist	sein	AUX	VAFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	6	cop	_	_
-3	die	der	DET	ART	Case=Nom|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	6	det	_	_
-4	erste	erster	ADJ	ADJA	Case=Nom|Gender=Fem|Number=Sing	6	amod	_	_
-5	intelligente	intelligent	ADJ	ADJA	Case=Nom|Gender=Fem|Number=Sing	6	amod	_	_
-6	Äußerung	Äußerung	NOUN	NN	Case=Nom|Gender=Fem|Number=Sing	19	ccomp	_	SpaceAfter=No
-7	,	,	PUNCT	$,	_	19	punct	_	_
-8	die	der	PRON	PRELS	Case=Acc|Gender=Fem|Number=Sing|PronType=Rel	16	obj	_	_
-9	ich	ich	PRON	PPER	Case=Nom|Number=Sing|Person=1|PronType=Prs	16	nsubj	_	_
-10	von	von	ADP	APPR	_	12	case	_	_
-11	der	der	DET	ART	Case=Dat|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	12	det	_	_
-12	IG	IG	PROPN	NN	Case=Dat|Gender=Fem|Number=Sing	16	obl	_	_
-13	Metall	Metall	PROPN	NN	Case=Nom|Gender=Neut|Number=Sing	12	flat	_	_
-14	seit	seit	ADP	APPR	_	15	case	_	_
-15	Jahren	Jahr	NOUN	NN	Case=Dat|Gender=Neut|Number=Plur	16	obl	_	_
-16	höre	hören	VERB	VVFIN	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	6	acl	_	SpaceAfter=No
-17	''	''	PUNCT	$(	_	19	punct	_	SpaceAfter=No
-18	,	,	PUNCT	$,	_	19	punct	_	_
-19	sagte	sagen	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	0	root	_	_
-20	Stihl	Stihl	PROPN	NE	Case=Nom|Number=Sing	19	nsubj	_	_
-21	der	der	DET	ART	Case=Dat|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	22	det	_	_
-22	FR	FR	PROPN	NE	Case=Dat|Gender=Fem|Number=Sing	19	iobj	_	SpaceAfter=No
-23	.	.	PUNCT	$.	_	19	punct	_	_
+# text = ``Das ist die erste intelligente Äußerung, die ich von der IG Metall seit Jahren höre'', sagte Stihl der FR.
+1	``	``	PUNCT	$(	_	2	punct	_	FixTigerDep=Yes|SpaceAfter=No
+2	Das	der	PRON	PDS	Case=Nom|Gender=Neut|Number=Sing|PronType=Dem	7	nsubj	_	_
+3	ist	sein	AUX	VAFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	7	cop	_	_
+4	die	der	DET	ART	Case=Nom|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	7	det	_	_
+5	erste	erster	ADJ	ADJA	Case=Nom|Gender=Fem|Number=Sing	7	amod	_	_
+6	intelligente	intelligent	ADJ	ADJA	Case=Nom|Gender=Fem|Number=Sing	7	amod	_	_
+7	Äußerung	Äußerung	NOUN	NN	Case=Nom|Gender=Fem|Number=Sing	20	ccomp	_	SpaceAfter=No
+8	,	,	PUNCT	$,	_	20	punct	_	_
+9	die	der	PRON	PRELS	Case=Acc|Gender=Fem|Number=Sing|PronType=Rel	17	obj	_	_
+10	ich	ich	PRON	PPER	Case=Nom|Number=Sing|Person=1|PronType=Prs	17	nsubj	_	_
+11	von	von	ADP	APPR	_	13	case	_	_
+12	der	der	DET	ART	Case=Dat|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	13	det	_	_
+13	IG	IG	PROPN	NN	Case=Dat|Gender=Fem|Number=Sing	17	obl	_	_
+14	Metall	Metall	PROPN	NN	Case=Nom|Gender=Neut|Number=Sing	13	flat	_	_
+15	seit	seit	ADP	APPR	_	16	case	_	_
+16	Jahren	Jahr	NOUN	NN	Case=Dat|Gender=Neut|Number=Plur	17	obl	_	_
+17	höre	hören	VERB	VVFIN	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	7	acl	_	SpaceAfter=No
+18	''	''	PUNCT	$(	_	20	punct	_	SpaceAfter=No
+19	,	,	PUNCT	$,	_	20	punct	_	_
+20	sagte	sagen	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	0	root	_	_
+21	Stihl	Stihl	PROPN	NE	Case=Nom|Number=Sing	20	nsubj	_	_
+22	der	der	DET	ART	Case=Dat|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	23	det	_	_
+23	FR	FR	PROPN	NE	Case=Dat|Gender=Fem|Number=Sing	20	iobj	_	SpaceAfter=No
+24	.	.	PUNCT	$.	_	20	punct	_	_
 
 # sent_id = test-s370
-# text = Delegierten folgten außerdem der Empfehlung des Landesausschusses, über einige Anträge für einen Gang in die Opposition erst auf dem nächsten Parteitag, der für Mitte Dezember vorgesehen ist, abzustimmen.
-1	Delegierten	Delegierter	NOUN	NN	Case=Nom|Number=Plur	2	nsubj	_	_
-2	folgten	folgen	VERB	VVFIN	Mood=Ind|Number=Plur|Person=3|Tense=Past|VerbForm=Fin	0	root	_	_
-3	außerdem	außerdem	ADV	PAV	_	2	advmod	_	_
-4	der	der	DET	ART	Case=Dat|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	5	det	_	_
-5	Empfehlung	Empfehlung	NOUN	NN	Case=Dat|Gender=Fem|Number=Sing	2	iobj	_	_
-6	des	der	DET	ART	Case=Gen|Definite=Def|Gender=Masc|Number=Sing|PronType=Art	7	det	_	_
-7	Landesausschusses	Landesausschuß	NOUN	NN	Case=Gen|Gender=Masc|Number=Sing	5	nmod	_	SpaceAfter=No
-8	,	,	PUNCT	$,	_	2	punct	_	_
-9	über	über	ADP	APPR	_	11	case	_	_
-10	einige	einige	PRON	PIAT	Case=Acc|Definite=Ind|Gender=Masc|Number=Plur|PronType=Ind	11	det	_	_
-11	Anträge	Antrag	NOUN	NN	Case=Acc|Gender=Masc|Number=Plur	31	obl	_	_
-12	für	für	ADP	APPR	_	14	case	_	_
-13	einen	ein	DET	ART	Case=Acc|Definite=Ind|Gender=Masc|Number=Sing|PronType=Art	14	det	_	_
-14	Gang	Gang	NOUN	NN	Case=Acc|Gender=Masc|Number=Sing	11	nmod	_	_
-15	in	in	ADP	APPR	_	17	case	_	_
-16	die	der	DET	ART	Case=Acc|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	17	det	_	_
-17	Opposition	Opposition	NOUN	NN	Case=Acc|Gender=Fem|Number=Sing	14	nmod	_	_
-18	erst	erst	ADV	ADV	_	31	advmod	_	_
-19	auf	auf	ADP	APPR	_	22	case	_	_
-20	dem	der	DET	ART	Case=Dat|Definite=Def|Gender=Masc|Number=Sing|PronType=Art	22	det	_	_
-21	nächsten	nächster	ADJ	ADJA	Case=Dat|Gender=Masc|Number=Sing	22	amod	_	_
-22	Parteitag	Parteitag	NOUN	NN	Case=Dat|Gender=Masc|Number=Sing	31	obl	_	SpaceAfter=No
-23	,	,	PUNCT	$,	_	31	punct	_	_
-24	der	der	PRON	PRELS	Case=Nom|Gender=Masc|Number=Sing|PronType=Rel	29	nsubj	_	_
-25	für	für	ADP	APPR	_	27	case	_	_
-26	Mitte	Mitte	NOUN	NN	Case=Acc|Gender=Fem|Number=Sing	27	compound	_	_
-27	Dezember	Dezember	PROPN	NN	Gender=Masc|Number=Sing	28	nmod	_	_
-28	vorgesehen	vorsehen	ADJ	VVPP	VerbForm=Part	29	amod	_	_
-29	ist	sein	AUX	VAFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	22	acl	_	SpaceAfter=No
-30	,	,	PUNCT	$,	_	2	punct	_	_
-31	abzustimmen	abstimmen	VERB	VVIZU	VerbForm=Inf	5	xcomp	_	SpaceAfter=No
-32	.	.	PUNCT	$.	_	2	punct	_	_
+# text = Die Delegierten folgten außerdem der Empfehlung des Landesausschusses, über einige Anträge für einen Gang in die Opposition erst auf dem nächsten Parteitag, der für Mitte Dezember vorgesehen ist, abzustimmen.
+1	Die	der	DET	ART	Case=Nom|Definite=Def|Number=Plur|PronType=Art	2	dep	_	FixTigerDep=Yes
+2	Delegierten	Delegierter	NOUN	NN	Case=Nom|Number=Plur	3	nsubj	_	_
+3	folgten	folgen	VERB	VVFIN	Mood=Ind|Number=Plur|Person=3|Tense=Past|VerbForm=Fin	0	root	_	_
+4	außerdem	außerdem	ADV	PAV	_	3	advmod	_	_
+5	der	der	DET	ART	Case=Dat|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	6	det	_	_
+6	Empfehlung	Empfehlung	NOUN	NN	Case=Dat|Gender=Fem|Number=Sing	3	iobj	_	_
+7	des	der	DET	ART	Case=Gen|Definite=Def|Gender=Masc|Number=Sing|PronType=Art	8	det	_	_
+8	Landesausschusses	Landesausschuß	NOUN	NN	Case=Gen|Gender=Masc|Number=Sing	6	nmod	_	SpaceAfter=No
+9	,	,	PUNCT	$,	_	3	punct	_	_
+10	über	über	ADP	APPR	_	12	case	_	_
+11	einige	einige	PRON	PIAT	Case=Acc|Definite=Ind|Gender=Masc|Number=Plur|PronType=Ind	12	det	_	_
+12	Anträge	Antrag	NOUN	NN	Case=Acc|Gender=Masc|Number=Plur	32	obl	_	_
+13	für	für	ADP	APPR	_	15	case	_	_
+14	einen	ein	DET	ART	Case=Acc|Definite=Ind|Gender=Masc|Number=Sing|PronType=Art	15	det	_	_
+15	Gang	Gang	NOUN	NN	Case=Acc|Gender=Masc|Number=Sing	12	nmod	_	_
+16	in	in	ADP	APPR	_	18	case	_	_
+17	die	der	DET	ART	Case=Acc|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	18	det	_	_
+18	Opposition	Opposition	NOUN	NN	Case=Acc|Gender=Fem|Number=Sing	15	nmod	_	_
+19	erst	erst	ADV	ADV	_	32	advmod	_	_
+20	auf	auf	ADP	APPR	_	23	case	_	_
+21	dem	der	DET	ART	Case=Dat|Definite=Def|Gender=Masc|Number=Sing|PronType=Art	23	det	_	_
+22	nächsten	nächster	ADJ	ADJA	Case=Dat|Gender=Masc|Number=Sing	23	amod	_	_
+23	Parteitag	Parteitag	NOUN	NN	Case=Dat|Gender=Masc|Number=Sing	32	obl	_	SpaceAfter=No
+24	,	,	PUNCT	$,	_	32	punct	_	_
+25	der	der	PRON	PRELS	Case=Nom|Gender=Masc|Number=Sing|PronType=Rel	30	nsubj	_	_
+26	für	für	ADP	APPR	_	28	case	_	_
+27	Mitte	Mitte	NOUN	NN	Case=Acc|Gender=Fem|Number=Sing	28	compound	_	_
+28	Dezember	Dezember	PROPN	NN	Gender=Masc|Number=Sing	29	nmod	_	_
+29	vorgesehen	vorsehen	ADJ	VVPP	VerbForm=Part	30	amod	_	_
+30	ist	sein	AUX	VAFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	23	acl	_	SpaceAfter=No
+31	,	,	PUNCT	$,	_	3	punct	_	_
+32	abzustimmen	abstimmen	VERB	VVIZU	VerbForm=Inf	6	xcomp	_	SpaceAfter=No
+33	.	.	PUNCT	$.	_	3	punct	_	_
 
 # sent_id = test-s371
-# text = Demokratie müsse direkter werden, sagte sie.
-1	Demokratie	Demokratie	NOUN	NN	Case=Nom|Gender=Fem|Number=Sing	3	nsubj	_	_
-2	müsse	müssen	AUX	VMFIN	Mood=Sub|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	4	aux	_	_
-3	direkter	direkt	ADJ	ADJD	_	6	ccomp	_	_
-4	werden	werden	AUX	VAINF	VerbForm=Inf	3	cop	_	SpaceAfter=No
-5	,	,	PUNCT	$,	_	6	punct	_	_
-6	sagte	sagen	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	0	root	_	_
-7	sie	sie	PRON	PPER	Case=Nom|Gender=Fem|Number=Sing|Person=3|PronType=Prs	6	nsubj	_	SpaceAfter=No
-8	.	.	PUNCT	$.	_	6	punct	_	_
+# text = Die Demokratie müsse direkter werden, sagte sie.
+1	Die	der	DET	ART	Case=Nom|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	2	dep	_	FixTigerDep=Yes
+2	Demokratie	Demokratie	NOUN	NN	Case=Nom|Gender=Fem|Number=Sing	4	nsubj	_	_
+3	müsse	müssen	AUX	VMFIN	Mood=Sub|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	5	aux	_	_
+4	direkter	direkt	ADJ	ADJD	_	7	ccomp	_	_
+5	werden	werden	AUX	VAINF	VerbForm=Inf	4	cop	_	SpaceAfter=No
+6	,	,	PUNCT	$,	_	7	punct	_	_
+7	sagte	sagen	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	0	root	_	_
+8	sie	sie	PRON	PPER	Case=Nom|Gender=Fem|Number=Sing|Person=3|PronType=Prs	7	nsubj	_	SpaceAfter=No
+9	.	.	PUNCT	$.	_	7	punct	_	_
 
 # sent_id = test-s372
-# text = Denkmal und die authentischen Tatorte seien keine Alternative, betonte der Vorsitzende der Jüdischen Gemeinde zu Berlin, Jerzy Kanal.
-1	Denkmal	Denkmal	NOUN	NN	Case=Nom|Gender=Neut|Number=Sing	8	nsubj	_	_
-2	und	und	CCONJ	KON	_	5	cc	_	_
-3	die	der	DET	ART	Case=Nom|Definite=Def|Gender=Masc|Number=Plur|PronType=Art	5	det	_	_
-4	authentischen	authentisch	ADJ	ADJA	Case=Nom|Gender=Masc|Number=Plur	5	amod	_	_
-5	Tatorte	Tatort	NOUN	NN	Case=Nom|Gender=Masc|Number=Plur	1	conj	_	_
-6	seien	sein	AUX	VAFIN	Mood=Sub|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	8	cop	_	_
-7	keine	kein	PRON	PIAT	Case=Nom|Definite=Ind|Gender=Fem|Number=Sing|Polarity=Neg|PronType=Neg	8	advmod	_	_
-8	Alternative	Alternative	NOUN	NN	Case=Nom|Gender=Fem|Number=Sing	10	ccomp	_	SpaceAfter=No
-9	,	,	PUNCT	$,	_	10	punct	_	_
-10	betonte	betonen	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	0	root	_	_
-11	der	der	DET	ART	Case=Nom|Definite=Def|Gender=Masc|Number=Sing|PronType=Art	12	det	_	_
-12	Vorsitzende	Vorsitzend	NOUN	NN	Case=Nom|Gender=Masc|Number=Sing	10	nsubj	_	_
-13	der	der	DET	ART	Case=Gen|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	15	det	_	_
-14	Jüdischen	jüdisch	ADJ	ADJA	Case=Gen|Gender=Fem|Number=Sing	15	amod	_	_
-15	Gemeinde	Gemeinde	NOUN	NN	Case=Gen|Gender=Fem|Number=Sing	12	nmod	_	_
-16	zu	zu	ADP	APPR	_	17	case	_	_
-17	Berlin	Berlin	PROPN	NE	Case=Dat|Gender=Neut|Number=Sing	15	nmod	_	SpaceAfter=No
-18	,	,	PUNCT	$,	_	17	punct	_	_
-19	Jerzy	Jerzy	PROPN	NE	Case=Nom|Gender=Masc|Number=Sing	12	appos	_	_
-20	Kanal	Kanal	PROPN	NE	Case=Nom|Gender=Masc|Number=Sing	19	flat	_	SpaceAfter=No
-21	.	.	PUNCT	$.	_	10	punct	_	_
+# text = Das Denkmal und die authentischen Tatorte seien keine Alternative, betonte der Vorsitzende der Jüdischen Gemeinde zu Berlin, Jerzy Kanal.
+1	Das	der	DET	ART	Case=Nom|Definite=Def|Gender=Neut|Number=Sing|PronType=Art	2	dep	_	FixTigerDep=Yes
+2	Denkmal	Denkmal	NOUN	NN	Case=Nom|Gender=Neut|Number=Sing	9	nsubj	_	_
+3	und	und	CCONJ	KON	_	6	cc	_	_
+4	die	der	DET	ART	Case=Nom|Definite=Def|Gender=Masc|Number=Plur|PronType=Art	6	det	_	_
+5	authentischen	authentisch	ADJ	ADJA	Case=Nom|Gender=Masc|Number=Plur	6	amod	_	_
+6	Tatorte	Tatort	NOUN	NN	Case=Nom|Gender=Masc|Number=Plur	2	conj	_	_
+7	seien	sein	AUX	VAFIN	Mood=Sub|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	9	cop	_	_
+8	keine	kein	PRON	PIAT	Case=Nom|Definite=Ind|Gender=Fem|Number=Sing|Polarity=Neg|PronType=Neg	9	advmod	_	_
+9	Alternative	Alternative	NOUN	NN	Case=Nom|Gender=Fem|Number=Sing	11	ccomp	_	SpaceAfter=No
+10	,	,	PUNCT	$,	_	11	punct	_	_
+11	betonte	betonen	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	0	root	_	_
+12	der	der	DET	ART	Case=Nom|Definite=Def|Gender=Masc|Number=Sing|PronType=Art	13	det	_	_
+13	Vorsitzende	Vorsitzend	NOUN	NN	Case=Nom|Gender=Masc|Number=Sing	11	nsubj	_	_
+14	der	der	DET	ART	Case=Gen|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	16	det	_	_
+15	Jüdischen	jüdisch	ADJ	ADJA	Case=Gen|Gender=Fem|Number=Sing	16	amod	_	_
+16	Gemeinde	Gemeinde	NOUN	NN	Case=Gen|Gender=Fem|Number=Sing	13	nmod	_	_
+17	zu	zu	ADP	APPR	_	18	case	_	_
+18	Berlin	Berlin	PROPN	NE	Case=Dat|Gender=Neut|Number=Sing	16	nmod	_	SpaceAfter=No
+19	,	,	PUNCT	$,	_	18	punct	_	_
+20	Jerzy	Jerzy	PROPN	NE	Case=Nom|Gender=Masc|Number=Sing	13	appos	_	_
+21	Kanal	Kanal	PROPN	NE	Case=Nom|Gender=Masc|Number=Sing	20	flat	_	SpaceAfter=No
+22	.	.	PUNCT	$.	_	11	punct	_	_
 
 # sent_id = test-s373
 # text = Der Staat soll die Pfarrer bezahlen.
@@ -6857,74 +6910,77 @@
 7	.	.	PUNCT	$.	_	6	punct	_	_
 
 # sent_id = test-s374
-# text = deutscher Touristin muß lebenslang in Haft
-1	deutscher	deutsch	ADJ	ADJA	Case=Gen|Gender=Fem|Number=Sing	2	amod	_	_
-2	Touristin	Touristin	NOUN	NN	Case=Gen|Gender=Fem|Number=Sing	3	nsubj	_	_
-3	muß	müssen	VERB	VMFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	0	root	_	_
-4	lebenslang	lebenslang	ADV	ADJD	_	3	advmod	_	_
-5	in	in	ADP	APPR	_	6	case	_	_
-6	Haft	Haft	NOUN	NN	Case=Dat|Gender=Fem|Number=Sing	3	obl	_	_
+# text = Mörder deutscher Touristin muß lebenslang in Haft
+1	Mörder	Mörder	NOUN	NN	Case=Nom|Gender=Masc|Number=Sing	2	dep	_	FixTigerDep=Yes
+2	deutscher	deutsch	ADJ	ADJA	Case=Gen|Gender=Fem|Number=Sing	3	amod	_	_
+3	Touristin	Touristin	NOUN	NN	Case=Gen|Gender=Fem|Number=Sing	4	nsubj	_	_
+4	muß	müssen	VERB	VMFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	0	root	_	_
+5	lebenslang	lebenslang	ADV	ADJD	_	4	advmod	_	_
+6	in	in	ADP	APPR	_	7	case	_	_
+7	Haft	Haft	NOUN	NN	Case=Dat|Gender=Fem|Number=Sing	4	obl	_	_
 
 # sent_id = test-s375
-# text = Dezember soll das Europaparlament über die Verwirklichung einer Zollunion der Türkei mit der EU entscheiden, die zum 1. Januar 1996 geplant ist.
-1	Dezember	Dezember	NOUN	NN	Gender=Masc|Number=Sing	15	obl	_	_
-2	soll	sollen	AUX	VMFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	15	aux	_	_
-3	das	der	DET	ART	Case=Nom|Definite=Def|Gender=Neut|Number=Sing|PronType=Art	4	det	_	_
-4	Europaparlament	Europaparlament	NOUN	NN	Case=Nom|Gender=Neut|Number=Sing	15	nsubj	_	_
-5	über	über	ADP	APPR	_	7	case	_	_
-6	die	der	DET	ART	Case=Acc|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	7	det	_	_
-7	Verwirklichung	Verwirklichung	NOUN	NN	Case=Acc|Gender=Fem|Number=Sing	15	obl	_	_
-8	einer	ein	DET	ART	Case=Gen|Definite=Ind|Gender=Fem|Number=Sing|PronType=Art	9	det	_	_
-9	Zollunion	Zollunion	NOUN	NN	Case=Gen|Gender=Fem|Number=Sing	7	nmod	_	_
-10	der	der	DET	ART	Case=Gen|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	11	det	_	_
-11	Türkei	Türkei	PROPN	NE	Case=Gen|Gender=Fem|Number=Sing	9	nmod	_	_
-12	mit	mit	ADP	APPR	_	14	case	_	_
-13	der	der	DET	ART	Case=Dat|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	14	det	_	_
-14	EU	EU	PROPN	NE	Case=Dat|Gender=Fem|Number=Sing	11	nmod	_	_
-15	entscheiden	entscheiden	VERB	VVINF	VerbForm=Inf	0	root	_	SpaceAfter=No
-16	,	,	PUNCT	$,	_	15	punct	_	_
-17	die	der	PRON	PRELS	Case=Nom|Gender=Fem|Number=Sing|PronType=Rel	23	nsubj:pass	_	_
-18-19	zum	_	_	_	_	_	_	_	_
-18	zu	zu	ADP	APPR	_	21	case	_	_
-19	dem	der	DET	ART	Case=Dat|Definite=Def|Gender=Neut|Number=Sing|PronType=Art	21	det	_	_
-20	1.	1	ADJ	ADJA	Case=Dat|Gender=Masc|Number=Sing	21	amod	_	_
-21	Januar	Januar	NOUN	NN	Case=Dat|Gender=Masc|Number=Sing	23	obl	_	_
-22	1996	1996	NUM	CARD	NumType=Card	21	nmod	_	_
-23	geplant	planen	VERB	VVPP	VerbForm=Part	9	acl	_	_
-24	ist	sein	AUX	VAFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	23	aux:pass	_	SpaceAfter=No
-25	.	.	PUNCT	$.	_	15	punct	_	_
+# text = Mitte Dezember soll das Europaparlament über die Verwirklichung einer Zollunion der Türkei mit der EU entscheiden, die zum 1. Januar 1996 geplant ist.
+1	Mitte	Mitte	NOUN	NN	Gender=Fem|Number=Sing	2	dep	_	FixTigerDep=Yes
+2	Dezember	Dezember	NOUN	NN	Gender=Masc|Number=Sing	16	obl	_	_
+3	soll	sollen	AUX	VMFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	16	aux	_	_
+4	das	der	DET	ART	Case=Nom|Definite=Def|Gender=Neut|Number=Sing|PronType=Art	5	det	_	_
+5	Europaparlament	Europaparlament	NOUN	NN	Case=Nom|Gender=Neut|Number=Sing	16	nsubj	_	_
+6	über	über	ADP	APPR	_	8	case	_	_
+7	die	der	DET	ART	Case=Acc|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	8	det	_	_
+8	Verwirklichung	Verwirklichung	NOUN	NN	Case=Acc|Gender=Fem|Number=Sing	16	obl	_	_
+9	einer	ein	DET	ART	Case=Gen|Definite=Ind|Gender=Fem|Number=Sing|PronType=Art	10	det	_	_
+10	Zollunion	Zollunion	NOUN	NN	Case=Gen|Gender=Fem|Number=Sing	8	nmod	_	_
+11	der	der	DET	ART	Case=Gen|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	12	det	_	_
+12	Türkei	Türkei	PROPN	NE	Case=Gen|Gender=Fem|Number=Sing	10	nmod	_	_
+13	mit	mit	ADP	APPR	_	15	case	_	_
+14	der	der	DET	ART	Case=Dat|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	15	det	_	_
+15	EU	EU	PROPN	NE	Case=Dat|Gender=Fem|Number=Sing	12	nmod	_	_
+16	entscheiden	entscheiden	VERB	VVINF	VerbForm=Inf	0	root	_	SpaceAfter=No
+17	,	,	PUNCT	$,	_	16	punct	_	_
+18	die	der	PRON	PRELS	Case=Nom|Gender=Fem|Number=Sing|PronType=Rel	24	nsubj:pass	_	_
+19-20	zum	_	_	_	_	_	_	_	_
+19	zu	zu	ADP	APPR	_	22	case	_	_
+20	dem	der	DET	ART	Case=Dat|Definite=Def|Gender=Neut|Number=Sing|PronType=Art	22	det	_	_
+21	1.	1	ADJ	ADJA	Case=Dat|Gender=Masc|Number=Sing	22	amod	_	_
+22	Januar	Januar	NOUN	NN	Case=Dat|Gender=Masc|Number=Sing	24	obl	_	_
+23	1996	1996	NUM	CARD	NumType=Card	22	nmod	_	_
+24	geplant	planen	VERB	VVPP	VerbForm=Part	10	acl	_	_
+25	ist	sein	AUX	VAFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	24	aux:pass	_	SpaceAfter=No
+26	.	.	PUNCT	$.	_	16	punct	_	_
 
 # sent_id = test-s376
-# text = Die Einrichtungen der evangelischen Kirche benötigen Wärme und Energie in der Größenordnung einer Stadt wie Hannover'', sagt Uwe Ilgemann vom Öko-Institut Freiburg.
-1	Die	der	DET	ART	Case=Nom|Definite=Def|Gender=Fem|Number=Plur|PronType=Art	2	det	_	_
-2	Einrichtungen	Einrichtung	NOUN	NN	Case=Nom|Gender=Fem|Number=Plur	6	nsubj	_	_
-3	der	der	DET	ART	Case=Gen|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	5	det	_	_
-4	evangelischen	evangelisch	ADJ	ADJA	Case=Gen|Gender=Fem|Number=Sing	5	amod	_	_
-5	Kirche	Kirche	NOUN	NN	Case=Gen|Gender=Fem|Number=Sing	2	nmod	_	_
-6	benötigen	benötigen	VERB	VVFIN	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	19	ccomp	_	_
-7	Wärme	Wärme	NOUN	NN	Case=Acc|Gender=Fem|Number=Sing	6	obj	_	_
-8	und	und	CCONJ	KON	_	9	cc	_	_
-9	Energie	Energie	NOUN	NN	Case=Acc|Gender=Fem|Number=Sing	7	conj	_	_
-10	in	in	ADP	APPR	_	12	case	_	_
-11	der	der	DET	ART	Case=Dat|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	12	det	_	_
-12	Größenordnung	Größenordnung	NOUN	NN	Case=Dat|Gender=Fem|Number=Sing	7	nmod	_	_
-13	einer	ein	DET	ART	Case=Gen|Definite=Ind|Gender=Fem|Number=Sing|PronType=Art	14	det	_	_
-14	Stadt	Stadt	NOUN	NN	Case=Gen|Gender=Fem|Number=Sing	12	nmod	_	_
-15	wie	wie	CCONJ	KOKOM	_	16	case	_	_
-16	Hannover	Hannover	PROPN	NE	Case=Nom|Gender=Neut|Number=Sing	14	nmod	_	SpaceAfter=No
-17	''	''	PUNCT	$(	_	19	punct	_	SpaceAfter=No
-18	,	,	PUNCT	$,	_	19	punct	_	_
-19	sagt	sagen	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	0	root	_	_
-20	Uwe	Uwe	PROPN	NE	Case=Nom|Gender=Masc|Number=Sing	19	nsubj	_	_
-21	Ilgemann	Ilgemann	PROPN	NE	Case=Nom|Gender=Masc|Number=Sing	20	flat	_	_
-22-23	vom	_	_	_	_	_	_	_	_
-22	von	von	ADP	APPR	_	24	case	_	_
-23	dem	der	DET	ART	Case=Dat|Definite=Def|Gender=Neut|Number=Sing|PronType=Art	24	det	_	_
-24	Öko	Öko	PROPN	NN	Case=Dat|Gender=Neut|Number=Sing	26	compound	_	SpaceAfter=No
-25	-	-	PUNCT	$(	_	24	punct	_	SpaceAfter=No
-26	Institut	Institut	PROPN	NN	Case=Dat|Gender=Neut|Number=Sing	20	nmod	_	_
-27	Freiburg	Freiburg	PROPN	NE	Case=Nom|Gender=Neut|Number=Sing	24	flat	_	SpaceAfter=No
-28	.	.	PUNCT	$.	_	19	punct	_	_
+# text = ``Die Einrichtungen der evangelischen Kirche benötigen Wärme und Energie in der Größenordnung einer Stadt wie Hannover'', sagt Uwe Ilgemann vom Öko-Institut Freiburg.
+1	``	``	PUNCT	$(	_	2	punct	_	FixTigerDep=Yes|SpaceAfter=No
+2	Die	der	DET	ART	Case=Nom|Definite=Def|Gender=Fem|Number=Plur|PronType=Art	3	det	_	_
+3	Einrichtungen	Einrichtung	NOUN	NN	Case=Nom|Gender=Fem|Number=Plur	7	nsubj	_	_
+4	der	der	DET	ART	Case=Gen|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	6	det	_	_
+5	evangelischen	evangelisch	ADJ	ADJA	Case=Gen|Gender=Fem|Number=Sing	6	amod	_	_
+6	Kirche	Kirche	NOUN	NN	Case=Gen|Gender=Fem|Number=Sing	3	nmod	_	_
+7	benötigen	benötigen	VERB	VVFIN	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	20	ccomp	_	_
+8	Wärme	Wärme	NOUN	NN	Case=Acc|Gender=Fem|Number=Sing	7	obj	_	_
+9	und	und	CCONJ	KON	_	10	cc	_	_
+10	Energie	Energie	NOUN	NN	Case=Acc|Gender=Fem|Number=Sing	8	conj	_	_
+11	in	in	ADP	APPR	_	13	case	_	_
+12	der	der	DET	ART	Case=Dat|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	13	det	_	_
+13	Größenordnung	Größenordnung	NOUN	NN	Case=Dat|Gender=Fem|Number=Sing	8	nmod	_	_
+14	einer	ein	DET	ART	Case=Gen|Definite=Ind|Gender=Fem|Number=Sing|PronType=Art	15	det	_	_
+15	Stadt	Stadt	NOUN	NN	Case=Gen|Gender=Fem|Number=Sing	13	nmod	_	_
+16	wie	wie	CCONJ	KOKOM	_	17	case	_	_
+17	Hannover	Hannover	PROPN	NE	Case=Nom|Gender=Neut|Number=Sing	15	nmod	_	SpaceAfter=No
+18	''	''	PUNCT	$(	_	20	punct	_	SpaceAfter=No
+19	,	,	PUNCT	$,	_	20	punct	_	_
+20	sagt	sagen	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	0	root	_	_
+21	Uwe	Uwe	PROPN	NE	Case=Nom|Gender=Masc|Number=Sing	20	nsubj	_	_
+22	Ilgemann	Ilgemann	PROPN	NE	Case=Nom|Gender=Masc|Number=Sing	21	flat	_	_
+23-24	vom	_	_	_	_	_	_	_	_
+23	von	von	ADP	APPR	_	25	case	_	_
+24	dem	der	DET	ART	Case=Dat|Definite=Def|Gender=Neut|Number=Sing|PronType=Art	25	det	_	_
+25	Öko	Öko	PROPN	NN	Case=Dat|Gender=Neut|Number=Sing	27	compound	_	SpaceAfter=No
+26	-	-	PUNCT	$(	_	25	punct	_	SpaceAfter=No
+27	Institut	Institut	PROPN	NN	Case=Dat|Gender=Neut|Number=Sing	21	nmod	_	_
+28	Freiburg	Freiburg	PROPN	NE	Case=Nom|Gender=Neut|Number=Sing	25	flat	_	SpaceAfter=No
+29	.	.	PUNCT	$.	_	20	punct	_	_
 
 # sent_id = test-s377
 # text = Die Leute brauchen doch auch privat ein Dach über dem Kopf.
@@ -6942,97 +6998,101 @@
 12	.	.	PUNCT	$.	_	3	punct	_	_
 
 # sent_id = test-s378
-# text = Die lokale Nähe von Universität und Wirtschaft ist sehr wichtig'', betont Stanford-Vizedekan George Parker, ``leider machen sich viele unserer besten Dozenten irgendwann selbständig''.
-1	Die	der	DET	ART	Case=Nom|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	3	det	_	_
-2	lokale	lokal	ADJ	ADJA	Case=Nom|Gender=Fem|Number=Sing	3	amod	_	_
-3	Nähe	Nähe	NOUN	NN	Case=Nom|Gender=Fem|Number=Sing	10	nsubj	_	_
-4	von	von	ADP	APPR	_	5	case	_	_
-5	Universität	Universität	NOUN	NN	Case=Dat|Gender=Fem|Number=Sing	3	nmod	_	_
-6	und	und	CCONJ	KON	_	7	cc	_	_
-7	Wirtschaft	Wirtschaft	NOUN	NN	Case=Dat|Gender=Fem|Number=Sing	5	conj	_	_
-8	ist	sein	AUX	VAFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	10	cop	_	_
-9	sehr	sehr	ADV	ADV	_	10	advmod	_	_
-10	wichtig	wichtig	ADJ	ADJD	_	13	ccomp	_	SpaceAfter=No
-11	''	''	PUNCT	$(	_	13	punct	_	SpaceAfter=No
-12	,	,	PUNCT	$,	_	13	punct	_	_
-13	betont	betonen	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	0	root	_	_
-14	Stanford	Stanford	PROPN	NE	Case=Nom|Gender=Masc|Number=Sing	13	nsubj	_	SpaceAfter=No
-15	-	-	PUNCT	$(	_	14	punct	_	SpaceAfter=No
-16	Vizedekan	Vizedekan	NOUN	NE	Case=Nom|Gender=Masc|Number=Sing	14	flat	_	_
-17	George	George	PROPN	NE	Case=Nom|Gender=Masc|Number=Sing	14	appos	_	_
-18	Parker	Parker	PROPN	NE	Case=Nom|Gender=Masc|Number=Sing	17	flat	_	SpaceAfter=No
-19	,	,	PUNCT	$,	_	13	punct	_	_
-20	``	``	PUNCT	$(	_	13	punct	_	SpaceAfter=No
-21	leider	leider	ADV	ADV	_	22	advmod	_	_
-22	machen	machen	VERB	VVFIN	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	13	parataxis	_	_
-23	sich	er|es|sie	PRON	PRF	Case=Acc|Number=Plur|Person=3|PronType=Prs|Reflex=Yes	22	obj	_	_
-24	viele	viel	PRON	PIS	Case=Nom|Definite=Ind|Gender=Masc|Number=Plur|PronType=Ind	22	nsubj	_	_
-25	unserer	unser	PRON	PPOSAT	Case=Gen|Gender=Masc|Number=Plur|Poss=Yes	27	det:poss	_	_
-26	besten	gut	ADJ	ADJA	Case=Gen|Gender=Masc|Number=Plur	27	amod	_	_
-27	Dozenten	Dozent	NOUN	NN	Case=Gen|Gender=Masc|Number=Plur	24	nmod	_	_
-28	irgendwann	irgendwann	ADV	ADV	_	22	advmod	_	_
-29	selbständig	selbständig	ADJ	ADJD	_	22	xcomp	_	SpaceAfter=No
-30	''	''	PUNCT	$(	_	13	punct	_	SpaceAfter=No
-31	.	.	PUNCT	$.	_	13	punct	_	_
+# text = ``Die lokale Nähe von Universität und Wirtschaft ist sehr wichtig'', betont Stanford-Vizedekan George Parker, ``leider machen sich viele unserer besten Dozenten irgendwann selbständig''.
+1	``	``	PUNCT	$(	_	2	punct	_	FixTigerDep=Yes|SpaceAfter=No
+2	Die	der	DET	ART	Case=Nom|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	4	det	_	_
+3	lokale	lokal	ADJ	ADJA	Case=Nom|Gender=Fem|Number=Sing	4	amod	_	_
+4	Nähe	Nähe	NOUN	NN	Case=Nom|Gender=Fem|Number=Sing	11	nsubj	_	_
+5	von	von	ADP	APPR	_	6	case	_	_
+6	Universität	Universität	NOUN	NN	Case=Dat|Gender=Fem|Number=Sing	4	nmod	_	_
+7	und	und	CCONJ	KON	_	8	cc	_	_
+8	Wirtschaft	Wirtschaft	NOUN	NN	Case=Dat|Gender=Fem|Number=Sing	6	conj	_	_
+9	ist	sein	AUX	VAFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	11	cop	_	_
+10	sehr	sehr	ADV	ADV	_	11	advmod	_	_
+11	wichtig	wichtig	ADJ	ADJD	_	14	ccomp	_	SpaceAfter=No
+12	''	''	PUNCT	$(	_	14	punct	_	SpaceAfter=No
+13	,	,	PUNCT	$,	_	14	punct	_	_
+14	betont	betonen	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	0	root	_	_
+15	Stanford	Stanford	PROPN	NE	Case=Nom|Gender=Masc|Number=Sing	14	nsubj	_	SpaceAfter=No
+16	-	-	PUNCT	$(	_	15	punct	_	SpaceAfter=No
+17	Vizedekan	Vizedekan	NOUN	NE	Case=Nom|Gender=Masc|Number=Sing	15	flat	_	_
+18	George	George	PROPN	NE	Case=Nom|Gender=Masc|Number=Sing	15	appos	_	_
+19	Parker	Parker	PROPN	NE	Case=Nom|Gender=Masc|Number=Sing	18	flat	_	SpaceAfter=No
+20	,	,	PUNCT	$,	_	14	punct	_	_
+21	``	``	PUNCT	$(	_	14	punct	_	SpaceAfter=No
+22	leider	leider	ADV	ADV	_	23	advmod	_	_
+23	machen	machen	VERB	VVFIN	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	14	parataxis	_	_
+24	sich	er|es|sie	PRON	PRF	Case=Acc|Number=Plur|Person=3|PronType=Prs|Reflex=Yes	23	obj	_	_
+25	viele	viel	PRON	PIS	Case=Nom|Definite=Ind|Gender=Masc|Number=Plur|PronType=Ind	23	nsubj	_	_
+26	unserer	unser	PRON	PPOSAT	Case=Gen|Gender=Masc|Number=Plur|Poss=Yes	28	det:poss	_	_
+27	besten	gut	ADJ	ADJA	Case=Gen|Gender=Masc|Number=Plur	28	amod	_	_
+28	Dozenten	Dozent	NOUN	NN	Case=Gen|Gender=Masc|Number=Plur	25	nmod	_	_
+29	irgendwann	irgendwann	ADV	ADV	_	23	advmod	_	_
+30	selbständig	selbständig	ADJ	ADJD	_	23	xcomp	_	SpaceAfter=No
+31	''	''	PUNCT	$(	_	14	punct	_	SpaceAfter=No
+32	.	.	PUNCT	$.	_	14	punct	_	_
 
 # sent_id = test-s379
-# text = Die ursprünglich vorgesehene Quote von 2500 ist 1995 nicht mehr zu erreichen.
-1	Die	der	DET	ART	Case=Nom|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	4	det	_	_
-2	ursprünglich	ursprünglich	ADV	ADJD	_	3	advmod	_	_
-3	vorgesehene	vorgesehen	ADJ	ADJA	Case=Nom|Gender=Fem|Number=Sing	4	amod	_	_
-4	Quote	Quote	NOUN	NN	Case=Nom|Gender=Fem|Number=Sing	12	nsubj:pass	_	_
-5	von	von	ADP	APPR	_	6	case	_	_
-6	2500	2500	NUM	CARD	NumType=Card	4	nmod	_	_
-7	ist	sein	AUX	VAFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	12	aux:pass	_	_
-8	1995	1995	NUM	CARD	NumType=Card	12	obl	_	_
-9	nicht	nicht	PART	PTKNEG	Polarity=Neg	12	advmod	_	_
-10	mehr	mehr	ADV	ADV	_	9	advmod	_	_
-11	zu	zu	PART	PTKZU	_	12	mark	_	_
-12	erreichen	erreichen	VERB	VVINF	VerbForm=Inf	0	root	_	SpaceAfter=No
-13	.	.	PUNCT	$.	_	12	punct	_	_
+# text = ``Die ursprünglich vorgesehene Quote von 2500 ist 1995 nicht mehr zu erreichen.
+1	``	``	PUNCT	$(	_	2	punct	_	FixTigerDep=Yes|SpaceAfter=No
+2	Die	der	DET	ART	Case=Nom|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	5	det	_	_
+3	ursprünglich	ursprünglich	ADV	ADJD	_	4	advmod	_	_
+4	vorgesehene	vorgesehen	ADJ	ADJA	Case=Nom|Gender=Fem|Number=Sing	5	amod	_	_
+5	Quote	Quote	NOUN	NN	Case=Nom|Gender=Fem|Number=Sing	13	nsubj:pass	_	_
+6	von	von	ADP	APPR	_	7	case	_	_
+7	2500	2500	NUM	CARD	NumType=Card	5	nmod	_	_
+8	ist	sein	AUX	VAFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	13	aux:pass	_	_
+9	1995	1995	NUM	CARD	NumType=Card	13	obl	_	_
+10	nicht	nicht	PART	PTKNEG	Polarity=Neg	13	advmod	_	_
+11	mehr	mehr	ADV	ADV	_	10	advmod	_	_
+12	zu	zu	PART	PTKZU	_	13	mark	_	_
+13	erreichen	erreichen	VERB	VVINF	VerbForm=Inf	0	root	_	SpaceAfter=No
+14	.	.	PUNCT	$.	_	13	punct	_	_
 
 # sent_id = test-s380
-# text = Die Wissenschaft ist das beste, was wir haben.
-1	Die	der	DET	ART	Case=Nom|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	2	det	_	_
-2	Wissenschaft	Wissenschaft	NOUN	NN	Case=Nom|Gender=Fem|Number=Sing	5	nsubj	_	_
-3	ist	sein	AUX	VAFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	5	cop	_	_
-4	das	der	DET	ART	Case=Nom|Definite=Def|Gender=Neut|Number=Sing|PronType=Art	5	det	_	_
-5	beste	gut	ADJ	ADJA	Case=Nom|Gender=Neut|Number=Sing	0	root	_	SpaceAfter=No
-6	,	,	PUNCT	$,	_	5	punct	_	_
-7	was	was	PRON	PRELS	Case=Acc|Gender=Neut|Number=Sing|PronType=Rel	9	obj	_	_
-8	wir	wir	PRON	PPER	Case=Nom|Number=Plur|Person=1|PronType=Prs	9	nsubj	_	_
-9	haben	haben	VERB	VAFIN	Mood=Ind|Number=Plur|Person=1|Tense=Pres|VerbForm=Fin	5	acl	_	SpaceAfter=No
-10	.	.	PUNCT	$.	_	5	punct	_	_
+# text = ``Die Wissenschaft ist das beste, was wir haben.
+1	``	``	PUNCT	$(	_	2	punct	_	FixTigerDep=Yes|SpaceAfter=No
+2	Die	der	DET	ART	Case=Nom|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	3	det	_	_
+3	Wissenschaft	Wissenschaft	NOUN	NN	Case=Nom|Gender=Fem|Number=Sing	6	nsubj	_	_
+4	ist	sein	AUX	VAFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	6	cop	_	_
+5	das	der	DET	ART	Case=Nom|Definite=Def|Gender=Neut|Number=Sing|PronType=Art	6	det	_	_
+6	beste	gut	ADJ	ADJA	Case=Nom|Gender=Neut|Number=Sing	0	root	_	SpaceAfter=No
+7	,	,	PUNCT	$,	_	6	punct	_	_
+8	was	was	PRON	PRELS	Case=Acc|Gender=Neut|Number=Sing|PronType=Rel	10	obj	_	_
+9	wir	wir	PRON	PPER	Case=Nom|Number=Plur|Person=1|PronType=Prs	10	nsubj	_	_
+10	haben	haben	VERB	VAFIN	Mood=Ind|Number=Plur|Person=1|Tense=Pres|VerbForm=Fin	6	acl	_	SpaceAfter=No
+11	.	.	PUNCT	$.	_	6	punct	_	_
 
 # sent_id = test-s381
-# text = Die wollen, daß ich im Westjordanland oder im Gaza-Streifen eine Fabrik baue'', erzählt der Fleischfabrikant Heinz Annuss.
-1	Die	der	PRON	PDS	Case=Nom|Number=Plur|PronType=Dem	2	nsubj	_	_
-2	wollen	wollen	VERB	VMFIN	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	20	ccomp	_	SpaceAfter=No
-3	,	,	PUNCT	$,	_	2	punct	_	_
-4	daß	daß	SCONJ	KOUS	_	17	mark	_	_
-5	ich	ich	PRON	PPER	Case=Nom|Gender=Masc|Number=Sing|Person=1|PronType=Prs	17	nsubj	_	_
-6-7	im	_	_	_	_	_	_	_	_
-6	in	in	ADP	APPR	_	8	case	_	_
-7	dem	der	DET	ART	Case=Dat|Definite=Def|Gender=Neut|Number=Sing|PronType=Art	8	det	_	_
-8	Westjordanland	Westjordanland	PROPN	NE	Case=Dat|Gender=Neut|Number=Sing	17	obl	_	_
-9	oder	oder	CCONJ	KON	_	12	cc	_	_
-10-11	im	_	_	_	_	_	_	_	_
-10	in	in	ADP	APPR	_	12	case	_	_
-11	dem	der	DET	ART	Case=Dat|Definite=Def|Gender=Masc|Number=Sing|PronType=Art	12	det	_	_
-12	Gaza	Gaza	PROPN	NE	Case=Dat|Gender=Masc|Number=Sing	8	conj	_	SpaceAfter=No
-13	-	-	PUNCT	$(	_	12	punct	_	SpaceAfter=No
-14	Streifen	Streifen	PROPN	NE	Case=Dat|Gender=Masc|Number=Sing	12	flat	_	_
-15	eine	ein	DET	ART	Case=Acc|Definite=Ind|Gender=Fem|Number=Sing|PronType=Art	16	det	_	_
-16	Fabrik	Fabrik	NOUN	NN	Case=Acc|Gender=Fem|Number=Sing	17	obj	_	_
-17	baue	bauen	VERB	VVFIN	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	2	ccomp	_	SpaceAfter=No
-18	''	''	PUNCT	$(	_	20	punct	_	SpaceAfter=No
-19	,	,	PUNCT	$,	_	20	punct	_	_
-20	erzählt	erzählen	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	0	root	_	_
-21	der	der	DET	ART	Case=Nom|Definite=Def|Gender=Masc|Number=Sing|PronType=Art	22	det	_	_
-22	Fleischfabrikant	Fleischfabrikant	NOUN	NN	Case=Nom|Gender=Masc|Number=Sing	20	nsubj	_	_
-23	Heinz	Heinz	PROPN	NE	Case=Nom|Gender=Masc|Number=Sing	22	appos	_	_
-24	Annuss	Annuss	PROPN	NE	Case=Nom|Gender=Masc|Number=Sing	23	flat	_	SpaceAfter=No
-25	.	.	PUNCT	$.	_	20	punct	_	_
+# text = ``Die wollen, daß ich im Westjordanland oder im Gaza-Streifen eine Fabrik baue'', erzählt der Fleischfabrikant Heinz Annuss.
+1	``	``	PUNCT	$(	_	2	punct	_	FixTigerDep=Yes|SpaceAfter=No
+2	Die	der	PRON	PDS	Case=Nom|Number=Plur|PronType=Dem	3	nsubj	_	_
+3	wollen	wollen	VERB	VMFIN	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	21	ccomp	_	SpaceAfter=No
+4	,	,	PUNCT	$,	_	3	punct	_	_
+5	daß	daß	SCONJ	KOUS	_	18	mark	_	_
+6	ich	ich	PRON	PPER	Case=Nom|Gender=Masc|Number=Sing|Person=1|PronType=Prs	18	nsubj	_	_
+7-8	im	_	_	_	_	_	_	_	_
+7	in	in	ADP	APPR	_	9	case	_	_
+8	dem	der	DET	ART	Case=Dat|Definite=Def|Gender=Neut|Number=Sing|PronType=Art	9	det	_	_
+9	Westjordanland	Westjordanland	PROPN	NE	Case=Dat|Gender=Neut|Number=Sing	18	obl	_	_
+10	oder	oder	CCONJ	KON	_	13	cc	_	_
+11-12	im	_	_	_	_	_	_	_	_
+11	in	in	ADP	APPR	_	13	case	_	_
+12	dem	der	DET	ART	Case=Dat|Definite=Def|Gender=Masc|Number=Sing|PronType=Art	13	det	_	_
+13	Gaza	Gaza	PROPN	NE	Case=Dat|Gender=Masc|Number=Sing	9	conj	_	SpaceAfter=No
+14	-	-	PUNCT	$(	_	13	punct	_	SpaceAfter=No
+15	Streifen	Streifen	PROPN	NE	Case=Dat|Gender=Masc|Number=Sing	13	flat	_	_
+16	eine	ein	DET	ART	Case=Acc|Definite=Ind|Gender=Fem|Number=Sing|PronType=Art	17	det	_	_
+17	Fabrik	Fabrik	NOUN	NN	Case=Acc|Gender=Fem|Number=Sing	18	obj	_	_
+18	baue	bauen	VERB	VVFIN	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	3	ccomp	_	SpaceAfter=No
+19	''	''	PUNCT	$(	_	21	punct	_	SpaceAfter=No
+20	,	,	PUNCT	$,	_	21	punct	_	_
+21	erzählt	erzählen	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	0	root	_	_
+22	der	der	DET	ART	Case=Nom|Definite=Def|Gender=Masc|Number=Sing|PronType=Art	23	det	_	_
+23	Fleischfabrikant	Fleischfabrikant	NOUN	NN	Case=Nom|Gender=Masc|Number=Sing	21	nsubj	_	_
+24	Heinz	Heinz	PROPN	NE	Case=Nom|Gender=Masc|Number=Sing	23	appos	_	_
+25	Annuss	Annuss	PROPN	NE	Case=Nom|Gender=Masc|Number=Sing	24	flat	_	SpaceAfter=No
+26	.	.	PUNCT	$.	_	21	punct	_	_
 
 # sent_id = test-s382
 # text = Diese und andere Argumente kamen zur Freude der Kompromiß-Gegner offenbar ziemlich gut an.
@@ -7056,277 +7116,290 @@
 17	.	.	PUNCT	$.	_	5	punct	_	_
 
 # sent_id = test-s383
-# text = Dietrich Grabbes ``Herzog von Gothland'' am Geburtsort des Dichters
-1	Dietrich	Dietrich	PROPN	NE	Case=Nom|Gender=Masc|Number=Sing	0	root	_	_
-2	Grabbes	Grabbes	PROPN	NE	Case=Gen|Gender=Masc|Number=Sing	1	flat	_	_
-3	``	``	PUNCT	$(	_	4	punct	_	SpaceAfter=No
-4	Herzog	Herzog	NOUN	NN	Case=Nom|Gender=Masc|Number=Sing	1	appos	_	_
-5	von	von	ADP	APPR	_	6	case	_	_
-6	Gothland	Gothland	PROPN	NE	Case=Dat|Gender=Neut|Number=Sing	4	nmod	_	SpaceAfter=No
-7	''	''	PUNCT	$(	_	4	punct	_	_
-8-9	am	_	_	_	_	_	_	_	_
-8	an	an	ADP	APPR	_	10	case	_	_
-9	dem	der	DET	ART	Case=Dat|Definite=Def|Gender=Masc|Number=Sing|PronType=Art	10	det	_	_
-10	Geburtsort	Geburtsort	NOUN	NN	Case=Dat|Gender=Masc|Number=Sing	1	nmod	_	_
-11	des	der	DET	ART	Case=Gen|Definite=Def|Gender=Masc|Number=Sing|PronType=Art	12	det	_	_
-12	Dichters	Dichter	NOUN	NN	Case=Gen|Gender=Masc|Number=Sing	10	nmod	_	_
+# text = Christian Dietrich Grabbes ``Herzog von Gothland'' am Geburtsort des Dichters
+1	Christian	Christian	PROPN	NE	Case=Nom|Gender=Masc|Number=Sing	2	dep	_	FixTigerDep=Yes
+2	Dietrich	Dietrich	PROPN	NE	Case=Nom|Gender=Masc|Number=Sing	0	root	_	_
+3	Grabbes	Grabbe	PROPN	NE	Case=Gen|Gender=Masc|Number=Sing	2	flat	_	_
+4	``	``	PUNCT	$(	_	5	punct	_	SpaceAfter=No
+5	Herzog	Herzog	NOUN	NN	Case=Nom|Gender=Masc|Number=Sing	2	appos	_	_
+6	von	von	ADP	APPR	_	7	case	_	_
+7	Gothland	Gothland	PROPN	NE	Case=Dat|Gender=Neut|Number=Sing	5	nmod	_	SpaceAfter=No
+8	''	''	PUNCT	$(	_	5	punct	_	_
+9-10	am	_	_	_	_	_	_	_	_
+9	an	an	ADP	APPR	_	11	case	_	_
+10	dem	der	DET	ART	Case=Dat|Definite=Def|Gender=Masc|Number=Sing|PronType=Art	11	det	_	_
+11	Geburtsort	Geburtsort	NOUN	NN	Case=Dat|Gender=Masc|Number=Sing	2	nmod	_	_
+12	des	der	DET	ART	Case=Gen|Definite=Def|Gender=Masc|Number=Sing|PronType=Art	13	det	_	_
+13	Dichters	Dichter	NOUN	NN	Case=Gen|Gender=Masc|Number=Sing	11	nmod	_	_
 
 # sent_id = test-s384
-# text = dort war Kraftstoff in das Erdreich gesickert.
-1	dort	dort	ADV	ADV	_	7	advmod	_	_
-2	war	sein	AUX	VAFIN	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	7	aux	_	_
-3	Kraftstoff	Kraftstoff	NOUN	NN	Case=Nom|Gender=Masc|Number=Sing	7	nsubj	_	_
-4	in	in	ADP	APPR	_	6	case	_	_
-5	das	der	DET	ART	Case=Acc|Definite=Def|Gender=Neut|Number=Sing|PronType=Art	6	det	_	_
-6	Erdreich	Erdreich	NOUN	NN	Case=Acc|Gender=Neut|Number=Sing	7	obl	_	_
-7	gesickert	sickern	VERB	VVPP	VerbForm=Part	0	root	_	SpaceAfter=No
-8	.	.	PUNCT	$.	_	7	punct	_	_
+# text = Von dort war Kraftstoff in das Erdreich gesickert.
+1	Von	von	ADP	APPR	_	2	dep	_	FixTigerDep=Yes
+2	dort	dort	ADV	ADV	_	8	advmod	_	_
+3	war	sein	AUX	VAFIN	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	8	aux	_	_
+4	Kraftstoff	Kraftstoff	NOUN	NN	Case=Nom|Gender=Masc|Number=Sing	8	nsubj	_	_
+5	in	in	ADP	APPR	_	7	case	_	_
+6	das	der	DET	ART	Case=Acc|Definite=Def|Gender=Neut|Number=Sing|PronType=Art	7	det	_	_
+7	Erdreich	Erdreich	NOUN	NN	Case=Acc|Gender=Neut|Number=Sing	8	obl	_	_
+8	gesickert	sickern	VERB	VVPP	VerbForm=Part	0	root	_	SpaceAfter=No
+9	.	.	PUNCT	$.	_	8	punct	_	_
 
 # sent_id = test-s385
-# text = drei von zehn Frauen leben in den Städten wie Bombay, Neu-Delhi oder Kalkutta.
-1	drei	drei	NUM	CARD	NumType=Card	5	nsubj	_	_
-2	von	von	ADP	APPR	_	4	case	_	_
-3	zehn	zehn	NUM	CARD	NumType=Card	4	nummod	_	_
-4	Frauen	Frau	NOUN	NN	Case=Nom|Gender=Fem|Number=Plur	1	nmod	_	_
-5	leben	leben	VERB	VVFIN	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	0	root	_	_
-6	in	in	ADP	APPR	_	8	case	_	_
-7	den	der	DET	ART	Case=Dat|Definite=Def|Gender=Fem|Number=Plur|PronType=Art	8	det	_	_
-8	Städten	Stadt	NOUN	NN	Case=Dat|Gender=Fem|Number=Plur	5	obl	_	_
-9	wie	wie	CCONJ	KOKOM	_	8	dep	_	_
-10	Bombay	Bombay	PROPN	NE	Case=Nom|Gender=Neut|Number=Sing	9	conj	_	SpaceAfter=No
-11	,	,	PUNCT	$,	_	12	punct	_	_
-12	Neu	Neu	PROPN	NE	Case=Nom|Gender=Neut|Number=Sing	10	conj	_	SpaceAfter=No
-13	-	-	PUNCT	$(	_	12	punct	_	SpaceAfter=No
-14	Delhi	Delhi	PROPN	NE	Case=Nom|Gender=Neut|Number=Sing	12	flat	_	_
-15	oder	oder	CCONJ	KON	_	16	cc	_	_
-16	Kalkutta	Kalkutta	PROPN	NE	Case=Nom|Gender=Neut|Number=Sing	10	conj	_	SpaceAfter=No
-17	.	.	PUNCT	$.	_	5	punct	_	_
+# text = Nur drei von zehn Frauen leben in den Städten wie Bombay, Neu-Delhi oder Kalkutta.
+1	Nur	nur	ADV	ADV	_	2	dep	_	FixTigerDep=Yes
+2	drei	drei	NUM	CARD	NumType=Card	6	nsubj	_	_
+3	von	von	ADP	APPR	_	5	case	_	_
+4	zehn	zehn	NUM	CARD	NumType=Card	5	nummod	_	_
+5	Frauen	Frau	NOUN	NN	Case=Nom|Gender=Fem|Number=Plur	2	nmod	_	_
+6	leben	leben	VERB	VVFIN	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	0	root	_	_
+7	in	in	ADP	APPR	_	9	case	_	_
+8	den	der	DET	ART	Case=Dat|Definite=Def|Gender=Fem|Number=Plur|PronType=Art	9	det	_	_
+9	Städten	Stadt	NOUN	NN	Case=Dat|Gender=Fem|Number=Plur	6	obl	_	_
+10	wie	wie	CCONJ	KOKOM	_	9	dep	_	_
+11	Bombay	Bombay	PROPN	NE	Case=Nom|Gender=Neut|Number=Sing	10	conj	_	SpaceAfter=No
+12	,	,	PUNCT	$,	_	13	punct	_	_
+13	Neu	Neu	PROPN	NE	Case=Nom|Gender=Neut|Number=Sing	11	conj	_	SpaceAfter=No
+14	-	-	PUNCT	$(	_	13	punct	_	SpaceAfter=No
+15	Delhi	Delhi	PROPN	NE	Case=Nom|Gender=Neut|Number=Sing	13	flat	_	_
+16	oder	oder	CCONJ	KON	_	17	cc	_	_
+17	Kalkutta	Kalkutta	PROPN	NE	Case=Nom|Gender=Neut|Number=Sing	11	conj	_	SpaceAfter=No
+18	.	.	PUNCT	$.	_	6	punct	_	_
 
 # sent_id = test-s386
-# text = Druck auf die Zimmerpreise bleibt unverändert groß:
-1	Druck	Druck	NOUN	NN	Case=Nom|Gender=Masc|Number=Sing	5	nsubj	_	_
-2	auf	auf	ADP	APPR	_	4	case	_	_
-3	die	der	DET	ART	Case=Acc|Definite=Def|Gender=Masc|Number=Plur|PronType=Art	4	det	_	_
-4	Zimmerpreise	Zimmerpreis	NOUN	NN	Case=Acc|Gender=Masc|Number=Plur	1	nmod	_	_
-5	bleibt	bleiben	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	0	root	_	_
-6	unverändert	unverändert	ADV	ADJD	_	7	advmod	_	_
-7	groß	groß	ADJ	ADJD	_	5	xcomp	_	SpaceAfter=No
-8	:	:	PUNCT	$.	_	5	punct	_	_
+# text = Der Druck auf die Zimmerpreise bleibt unverändert groß:
+1	Der	der	DET	ART	Case=Nom|Definite=Def|Gender=Masc|Number=Sing|PronType=Art	2	dep	_	FixTigerDep=Yes
+2	Druck	Druck	NOUN	NN	Case=Nom|Gender=Masc|Number=Sing	6	nsubj	_	_
+3	auf	auf	ADP	APPR	_	5	case	_	_
+4	die	der	DET	ART	Case=Acc|Definite=Def|Gender=Masc|Number=Plur|PronType=Art	5	det	_	_
+5	Zimmerpreise	Zimmerpreis	NOUN	NN	Case=Acc|Gender=Masc|Number=Plur	2	nmod	_	_
+6	bleibt	bleiben	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	0	root	_	_
+7	unverändert	unverändert	ADV	ADJD	_	8	advmod	_	_
+8	groß	groß	ADJ	ADJD	_	6	xcomp	_	SpaceAfter=No
+9	:	:	PUNCT	$.	_	6	punct	_	_
 
 # sent_id = test-s387
-# text = EGB hebt besonders hervor, daß es sich um ein individuelles, nicht an die Firmengröße gebundenes Recht für Männer und Frauen handle, das den Anspruch auf Mutterschaftsurlaub unberührt lasse und so bislang erst in drei EU-Ländern existiere.
-1	EGB	EGB	PROPN	NE	Case=Nom|Gender=Masc|Number=Sing	2	nsubj	_	_
-2	hebt	heben	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	0	root	_	_
-3	besonders	besonders	ADV	ADV	_	2	advmod	_	_
-4	hervor	hervor	ADV	PTKVZ	_	2	compound:prt	_	SpaceAfter=No
-5	,	,	PUNCT	$,	_	2	punct	_	_
-6	daß	daß	CCONJ	KOUS	_	23	cc	_	_
-7	es	es	PRON	PPER	Case=Nom|Gender=Neut|Number=Sing|Person=3|PronType=Prs	23	nsubj	_	_
-8	sich	er|es|sie	PRON	PRF	Case=Acc|Number=Sing|Person=3|PronType=Prs|Reflex=Yes	23	obj	_	_
-9	um	um	ADP	APPR	_	18	case	_	_
-10	ein	ein	DET	ART	Case=Acc|Definite=Ind|Gender=Neut|Number=Sing|PronType=Art	18	det	_	_
-11	individuelles	individuell	ADJ	ADJA	Case=Acc|Gender=Neut|Number=Sing	18	amod	_	SpaceAfter=No
-12	,	,	PUNCT	$,	_	17	punct	_	_
-13	nicht	nicht	PART	PTKNEG	Polarity=Neg	16	advmod	_	_
-14	an	an	ADP	APPR	_	16	case	_	_
-15	die	der	DET	ART	Case=Acc|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	16	det	_	_
-16	Firmengröße	Firmengröße	NOUN	NN	Case=Acc|Gender=Fem|Number=Sing	17	nmod	_	_
-17	gebundenes	gebunden	ADJ	ADJA	Case=Acc|Gender=Neut|Number=Sing	11	conj	_	_
-18	Recht	Recht	NOUN	NN	Case=Acc|Gender=Neut|Number=Sing	23	obl	_	_
-19	für	für	ADP	APPR	_	20	case	_	_
-20	Männer	Mann	NOUN	NN	Case=Acc|Gender=Masc|Number=Plur	18	nmod	_	_
-21	und	und	CCONJ	KON	_	22	cc	_	_
-22	Frauen	Frau	NOUN	NN	Case=Acc|Gender=Fem|Number=Plur	20	conj	_	_
-23	handle	handeln	VERB	VVFIN	Mood=Sub|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	2	ccomp	_	SpaceAfter=No
-24	,	,	PUNCT	$,	_	2	punct	_	_
-25	das	der	PRON	PRELS	Case=Nom|Gender=Neut|Number=Sing|PronType=Rel	31	nsubj	_	_
-26	den	der	DET	ART	Case=Acc|Definite=Def|Gender=Masc|Number=Sing|PronType=Art	27	det	_	_
-27	Anspruch	Anspruch	NOUN	NN	Case=Acc|Gender=Masc|Number=Sing	31	obj	_	_
-28	auf	auf	ADP	APPR	_	29	case	_	_
-29	Mutterschaftsurlaub	Mutterschaftsurlaub	NOUN	NN	Case=Acc|Gender=Masc|Number=Sing	27	nmod	_	_
-30	unberührt	unberührt	ADJ	ADJD	_	31	xcomp	_	_
-31	lasse	lassen	VERB	VVFIN	Mood=Sub|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	18	acl	_	_
-32	und	und	CCONJ	KON	_	41	cc	_	_
-33	so	so	ADV	ADV	_	41	advmod	_	_
-34	bislang	bislang	ADV	ADV	_	41	advmod	_	_
-35	erst	erst	ADV	ADV	_	41	advmod	_	_
-36	in	in	ADP	APPR	_	38	case	_	_
-37	drei	drei	NUM	CARD	NumType=Card	38	nummod	_	_
-38	EU	EU	PROPN	NN	Case=Dat|Gender=Neut|Number=Plur	40	compound	_	SpaceAfter=No
-39	-	-	PUNCT	$(	_	38	punct	_	SpaceAfter=No
-40	Ländern	Land	NOUN	NN	Case=Dat|Gender=Neut|Number=Plur	41	obl	_	_
-41	existiere	existieren	VERB	VVFIN	Mood=Sub|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	31	conj	_	SpaceAfter=No
-42	.	.	PUNCT	$.	_	2	punct	_	_
+# text = Der EGB hebt besonders hervor, daß es sich um ein individuelles, nicht an die Firmengröße gebundenes Recht für Männer und Frauen handle, das den Anspruch auf Mutterschaftsurlaub unberührt lasse und so bislang erst in drei EU-Ländern existiere.
+1	Der	der	DET	ART	Case=Nom|Definite=Def|Gender=Masc|Number=Sing|PronType=Art	2	dep	_	FixTigerDep=Yes
+2	EGB	EGB	PROPN	NE	Case=Nom|Gender=Masc|Number=Sing	3	nsubj	_	_
+3	hebt	heben	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	0	root	_	_
+4	besonders	besonders	ADV	ADV	_	3	advmod	_	_
+5	hervor	hervor	ADV	PTKVZ	_	3	compound:prt	_	SpaceAfter=No
+6	,	,	PUNCT	$,	_	3	punct	_	_
+7	daß	daß	CCONJ	KOUS	_	24	cc	_	_
+8	es	es	PRON	PPER	Case=Nom|Gender=Neut|Number=Sing|Person=3|PronType=Prs	24	nsubj	_	_
+9	sich	er|es|sie	PRON	PRF	Case=Acc|Number=Sing|Person=3|PronType=Prs|Reflex=Yes	24	obj	_	_
+10	um	um	ADP	APPR	_	19	case	_	_
+11	ein	ein	DET	ART	Case=Acc|Definite=Ind|Gender=Neut|Number=Sing|PronType=Art	19	det	_	_
+12	individuelles	individuell	ADJ	ADJA	Case=Acc|Gender=Neut|Number=Sing	19	amod	_	SpaceAfter=No
+13	,	,	PUNCT	$,	_	18	punct	_	_
+14	nicht	nicht	PART	PTKNEG	Polarity=Neg	17	advmod	_	_
+15	an	an	ADP	APPR	_	17	case	_	_
+16	die	der	DET	ART	Case=Acc|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	17	det	_	_
+17	Firmengröße	Firmengröße	NOUN	NN	Case=Acc|Gender=Fem|Number=Sing	18	nmod	_	_
+18	gebundenes	gebunden	ADJ	ADJA	Case=Acc|Gender=Neut|Number=Sing	12	conj	_	_
+19	Recht	Recht	NOUN	NN	Case=Acc|Gender=Neut|Number=Sing	24	obl	_	_
+20	für	für	ADP	APPR	_	21	case	_	_
+21	Männer	Mann	NOUN	NN	Case=Acc|Gender=Masc|Number=Plur	19	nmod	_	_
+22	und	und	CCONJ	KON	_	23	cc	_	_
+23	Frauen	Frau	NOUN	NN	Case=Acc|Gender=Fem|Number=Plur	21	conj	_	_
+24	handle	handeln	VERB	VVFIN	Mood=Sub|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	3	ccomp	_	SpaceAfter=No
+25	,	,	PUNCT	$,	_	3	punct	_	_
+26	das	der	PRON	PRELS	Case=Nom|Gender=Neut|Number=Sing|PronType=Rel	32	nsubj	_	_
+27	den	der	DET	ART	Case=Acc|Definite=Def|Gender=Masc|Number=Sing|PronType=Art	28	det	_	_
+28	Anspruch	Anspruch	NOUN	NN	Case=Acc|Gender=Masc|Number=Sing	32	obj	_	_
+29	auf	auf	ADP	APPR	_	30	case	_	_
+30	Mutterschaftsurlaub	Mutterschaftsurlaub	NOUN	NN	Case=Acc|Gender=Masc|Number=Sing	28	nmod	_	_
+31	unberührt	unberührt	ADJ	ADJD	_	32	xcomp	_	_
+32	lasse	lassen	VERB	VVFIN	Mood=Sub|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	19	acl	_	_
+33	und	und	CCONJ	KON	_	42	cc	_	_
+34	so	so	ADV	ADV	_	42	advmod	_	_
+35	bislang	bislang	ADV	ADV	_	42	advmod	_	_
+36	erst	erst	ADV	ADV	_	42	advmod	_	_
+37	in	in	ADP	APPR	_	39	case	_	_
+38	drei	drei	NUM	CARD	NumType=Card	39	nummod	_	_
+39	EU	EU	PROPN	NN	Case=Dat|Gender=Neut|Number=Plur	41	compound	_	SpaceAfter=No
+40	-	-	PUNCT	$(	_	39	punct	_	SpaceAfter=No
+41	Ländern	Land	NOUN	NN	Case=Dat|Gender=Neut|Number=Plur	42	obl	_	_
+42	existiere	existieren	VERB	VVFIN	Mood=Sub|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	32	conj	_	SpaceAfter=No
+43	.	.	PUNCT	$.	_	3	punct	_	_
 
 # sent_id = test-s388
-# text = Ein Großteil'' der Entscheidungen, die Einwanderer und Minderheiten betreffen, werde bislang auf Bundes- und Landesebene getroffen, ohne diese anzuhören.
-1	Ein	ein	DET	ART	Case=Nom|Definite=Ind|Gender=Masc|Number=Sing|PronType=Art	2	det	_	_
-2	Großteil	Großteil	NOUN	NN	Case=Nom|Gender=Masc|Number=Sing	20	nsubj:pass	_	SpaceAfter=No
-3	''	''	PUNCT	$(	_	20	punct	_	_
-4	der	der	DET	ART	Case=Gen|Definite=Def|Gender=Fem|Number=Plur|PronType=Art	5	det	_	_
-5	Entscheidungen	Entscheidung	NOUN	NN	Case=Gen|Gender=Fem|Number=Plur	2	nmod	_	SpaceAfter=No
-6	,	,	PUNCT	$,	_	20	punct	_	_
-7	die	der	DET	PRELS	Case=Nom|Gender=Fem|Number=Plur|PronType=Rel	11	nsubj	_	_
-8	Einwanderer	Einwanderer	NOUN	NN	Case=Acc|Gender=Masc|Number=Plur	11	obj	_	_
-9	und	und	CCONJ	KON	_	10	cc	_	_
-10	Minderheiten	Minderheit	NOUN	NN	Case=Acc|Gender=Fem|Number=Plur	8	conj	_	_
-11	betreffen	betreffen	VERB	VVFIN	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	5	acl	_	SpaceAfter=No
-12	,	,	PUNCT	$,	_	20	punct	_	_
-13	werde	werden	AUX	VAFIN	Mood=Sub|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin|Voice=Pass	20	aux:pass	_	_
-14	bislang	bislang	ADV	ADV	_	20	advmod	_	_
-15	auf	auf	ADP	APPR	_	16	case	_	_
-16	Bundes	Bund	NOUN	TRUNC	Case=Dat|Gender=Fem|Number=Sing	20	compound	_	SpaceAfter=No
-17	-	-	PUNCT	$(	_	19	punct	_	_
-18	und	und	CCONJ	KON	_	19	cc	_	_
-19	Landesebene	Landesebene	NOUN	NN	Case=Dat|Gender=Fem|Number=Sing	16	conj	_	_
-20	getroffen	treffen	VERB	VVPP	VerbForm=Part	0	root	_	SpaceAfter=No
-21	,	,	PUNCT	$,	_	20	punct	_	_
-22	ohne	ohne	ADP	KOUI	_	24	case	_	_
-23	diese	dies	PRON	PDS	Case=Acc|Gender=Fem|Number=Plur|PronType=Dem	24	obj	_	_
-24	anzuhören	anhören	VERB	VVIZU	VerbForm=Inf	20	xcomp	_	SpaceAfter=No
-25	.	.	PUNCT	$.	_	20	punct	_	_
+# text = ``Ein Großteil'' der Entscheidungen, die Einwanderer und Minderheiten betreffen, werde bislang auf Bundes- und Landesebene getroffen, ohne diese anzuhören.
+1	``	``	PUNCT	$(	_	2	punct	_	FixTigerDep=Yes|SpaceAfter=No
+2	Ein	ein	DET	ART	Case=Nom|Definite=Ind|Gender=Masc|Number=Sing|PronType=Art	3	det	_	_
+3	Großteil	Großteil	NOUN	NN	Case=Nom|Gender=Masc|Number=Sing	21	nsubj:pass	_	SpaceAfter=No
+4	''	''	PUNCT	$(	_	21	punct	_	_
+5	der	der	DET	ART	Case=Gen|Definite=Def|Gender=Fem|Number=Plur|PronType=Art	6	det	_	_
+6	Entscheidungen	Entscheidung	NOUN	NN	Case=Gen|Gender=Fem|Number=Plur	3	nmod	_	SpaceAfter=No
+7	,	,	PUNCT	$,	_	21	punct	_	_
+8	die	der	DET	PRELS	Case=Nom|Gender=Fem|Number=Plur|PronType=Rel	12	nsubj	_	_
+9	Einwanderer	Einwanderer	NOUN	NN	Case=Acc|Gender=Masc|Number=Plur	12	obj	_	_
+10	und	und	CCONJ	KON	_	11	cc	_	_
+11	Minderheiten	Minderheit	NOUN	NN	Case=Acc|Gender=Fem|Number=Plur	9	conj	_	_
+12	betreffen	betreffen	VERB	VVFIN	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	6	acl	_	SpaceAfter=No
+13	,	,	PUNCT	$,	_	21	punct	_	_
+14	werde	werden	AUX	VAFIN	Mood=Sub|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin|Voice=Pass	21	aux:pass	_	_
+15	bislang	bislang	ADV	ADV	_	21	advmod	_	_
+16	auf	auf	ADP	APPR	_	17	case	_	_
+17	Bundes	Bund	NOUN	TRUNC	Case=Dat|Gender=Fem|Number=Sing	21	compound	_	SpaceAfter=No
+18	-	-	PUNCT	$(	_	20	punct	_	_
+19	und	und	CCONJ	KON	_	20	cc	_	_
+20	Landesebene	Landesebene	NOUN	NN	Case=Dat|Gender=Fem|Number=Sing	17	conj	_	_
+21	getroffen	treffen	VERB	VVPP	VerbForm=Part	0	root	_	SpaceAfter=No
+22	,	,	PUNCT	$,	_	21	punct	_	_
+23	ohne	ohne	ADP	KOUI	_	25	case	_	_
+24	diese	dies	PRON	PDS	Case=Acc|Gender=Fem|Number=Plur|PronType=Dem	25	obj	_	_
+25	anzuhören	anhören	VERB	VVIZU	VerbForm=Inf	21	xcomp	_	SpaceAfter=No
+26	.	.	PUNCT	$.	_	21	punct	_	_
 
 # sent_id = test-s389
-# text = Ende des Jahres soll aber alles unter Dach und Fach sein.
-1	Ende	Ende	NOUN	NN	Gender=Neut|Number=Sing	11	obl	_	_
-2	des	der	DET	ART	Case=Gen|Definite=Def|Gender=Neut|Number=Sing|PronType=Art	3	det	_	_
-3	Jahres	Jahr	NOUN	NN	Case=Gen|Gender=Neut|Number=Sing	1	nmod	_	_
-4	soll	sollen	AUX	VMFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	11	aux	_	_
-5	aber	aber	ADV	ADV	_	11	advmod	_	_
-6	alles	alle	PRON	PIS	Case=Nom|Definite=Ind|Gender=Neut|Number=Sing|PronType=Ind	11	nsubj	_	_
-7	unter	unter	ADP	APPR	_	8	case	_	_
-8	Dach	Dach	NOUN	NN	Case=Dat|Gender=Neut|Number=Sing	11	obl	_	_
-9	und	und	CCONJ	KON	_	10	cc	_	_
-10	Fach	Fach	NOUN	NN	Case=Dat|Gender=Neut|Number=Sing	8	conj	_	_
-11	sein	sein	VERB	VAINF	VerbForm=Inf	0	root	_	SpaceAfter=No
-12	.	.	PUNCT	$.	_	11	punct	_	_
+# text = Bis Ende des Jahres soll aber alles unter Dach und Fach sein.
+1	Bis	bis	ADP	APPR	_	2	dep	_	FixTigerDep=Yes
+2	Ende	Ende	NOUN	NN	Gender=Neut|Number=Sing	12	obl	_	_
+3	des	der	DET	ART	Case=Gen|Definite=Def|Gender=Neut|Number=Sing|PronType=Art	4	det	_	_
+4	Jahres	Jahr	NOUN	NN	Case=Gen|Gender=Neut|Number=Sing	2	nmod	_	_
+5	soll	sollen	AUX	VMFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	12	aux	_	_
+6	aber	aber	ADV	ADV	_	12	advmod	_	_
+7	alles	alle	PRON	PIS	Case=Nom|Definite=Ind|Gender=Neut|Number=Sing|PronType=Ind	12	nsubj	_	_
+8	unter	unter	ADP	APPR	_	9	case	_	_
+9	Dach	Dach	NOUN	NN	Case=Dat|Gender=Neut|Number=Sing	12	obl	_	_
+10	und	und	CCONJ	KON	_	11	cc	_	_
+11	Fach	Fach	NOUN	NN	Case=Dat|Gender=Neut|Number=Sing	9	conj	_	_
+12	sein	sein	VERB	VAINF	VerbForm=Inf	0	root	_	SpaceAfter=No
+13	.	.	PUNCT	$.	_	12	punct	_	_
 
 # sent_id = test-s390
-# text = Entscheidung der nigerianischen Militärregierung, die Todesurteile gegen neun Menschenrechtler zu bestätigen, ist international und bei Nigerias Opposition auf scharfe Kritik gestoßen.
-1	Entscheidung	Entscheidung	NOUN	NN	Case=Nom|Gender=Fem|Number=Sing	23	nsubj	_	_
-2	der	der	DET	ART	Case=Gen|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	4	det	_	_
-3	nigerianischen	nigerianisch	ADJ	ADJA	Case=Gen|Gender=Fem|Number=Sing	4	amod	_	_
-4	Militärregierung	Militärregierung	NOUN	NN	Case=Gen|Gender=Fem|Number=Sing	1	nmod	_	SpaceAfter=No
-5	,	,	PUNCT	$,	_	4	punct	_	_
-6	die	der	DET	ART	Case=Acc|Definite=Def|Gender=Neut|Number=Plur|PronType=Art	7	det	_	_
-7	Todesurteile	Todesurteil	NOUN	NN	Case=Acc|Gender=Neut|Number=Plur	12	obj	_	_
-8	gegen	gegen	ADP	APPR	_	10	case	_	_
-9	neun	neun	NUM	CARD	NumType=Card	10	nummod	_	_
-10	Menschenrechtler	Menschenrechtler	NOUN	NN	Case=Acc|Gender=Masc|Number=Plur	7	nmod	_	_
-11	zu	zu	PART	PTKZU	_	12	mark	_	_
-12	bestätigen	bestätigen	VERB	VVINF	VerbForm=Inf	1	xcomp	_	SpaceAfter=No
-13	,	,	PUNCT	$,	_	23	punct	_	_
-14	ist	sein	AUX	VAFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	23	aux	_	_
-15	international	international	ADV	ADJD	_	23	advmod	_	_
-16	und	und	CCONJ	KON	_	15	cc	_	_
-17	bei	bei	ADP	APPR	_	19	case	_	_
-18	Nigerias	Nigeria	PROPN	NE	Case=Gen|Gender=Neut|Number=Sing	19	nmod	_	_
-19	Opposition	Opposition	NOUN	NN	Case=Dat|Gender=Fem|Number=Sing	15	nmod	_	_
-20	auf	auf	ADP	APPR	_	22	case	_	_
-21	scharfe	scharf	ADJ	ADJA	Case=Acc|Gender=Fem|Number=Sing	22	amod	_	_
-22	Kritik	Kritik	NOUN	NN	Case=Acc|Gender=Fem|Number=Sing	23	obl	_	_
-23	gestoßen	stoßen	VERB	VVPP	VerbForm=Part	0	root	_	SpaceAfter=No
-24	.	.	PUNCT	$.	_	23	punct	_	_
+# text = Die Entscheidung der nigerianischen Militärregierung, die Todesurteile gegen neun Menschenrechtler zu bestätigen, ist international und bei Nigerias Opposition auf scharfe Kritik gestoßen.
+1	Die	der	DET	ART	Case=Nom|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	2	dep	_	FixTigerDep=Yes
+2	Entscheidung	Entscheidung	NOUN	NN	Case=Nom|Gender=Fem|Number=Sing	24	nsubj	_	_
+3	der	der	DET	ART	Case=Gen|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	5	det	_	_
+4	nigerianischen	nigerianisch	ADJ	ADJA	Case=Gen|Gender=Fem|Number=Sing	5	amod	_	_
+5	Militärregierung	Militärregierung	NOUN	NN	Case=Gen|Gender=Fem|Number=Sing	2	nmod	_	SpaceAfter=No
+6	,	,	PUNCT	$,	_	5	punct	_	_
+7	die	der	DET	ART	Case=Acc|Definite=Def|Gender=Neut|Number=Plur|PronType=Art	8	det	_	_
+8	Todesurteile	Todesurteil	NOUN	NN	Case=Acc|Gender=Neut|Number=Plur	13	obj	_	_
+9	gegen	gegen	ADP	APPR	_	11	case	_	_
+10	neun	neun	NUM	CARD	NumType=Card	11	nummod	_	_
+11	Menschenrechtler	Menschenrechtler	NOUN	NN	Case=Acc|Gender=Masc|Number=Plur	8	nmod	_	_
+12	zu	zu	PART	PTKZU	_	13	mark	_	_
+13	bestätigen	bestätigen	VERB	VVINF	VerbForm=Inf	2	xcomp	_	SpaceAfter=No
+14	,	,	PUNCT	$,	_	24	punct	_	_
+15	ist	sein	AUX	VAFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	24	aux	_	_
+16	international	international	ADV	ADJD	_	24	advmod	_	_
+17	und	und	CCONJ	KON	_	16	cc	_	_
+18	bei	bei	ADP	APPR	_	20	case	_	_
+19	Nigerias	Nigeria	PROPN	NE	Case=Gen|Gender=Neut|Number=Sing	20	nmod	_	_
+20	Opposition	Opposition	NOUN	NN	Case=Dat|Gender=Fem|Number=Sing	16	nmod	_	_
+21	auf	auf	ADP	APPR	_	23	case	_	_
+22	scharfe	scharf	ADJ	ADJA	Case=Acc|Gender=Fem|Number=Sing	23	amod	_	_
+23	Kritik	Kritik	NOUN	NN	Case=Acc|Gender=Fem|Number=Sing	24	obl	_	_
+24	gestoßen	stoßen	VERB	VVPP	VerbForm=Part	0	root	_	SpaceAfter=No
+25	.	.	PUNCT	$.	_	24	punct	_	_
 
 # sent_id = test-s391
-# text = Entwurf einer neuen Datenschutzrichtlinie verbot es, daß Kirchen, Arbeitgeber und Staat Daten miteinander austauschen.
-1	Entwurf	Entwurf	NOUN	NN	Case=Nom|Gender=Masc|Number=Sing	5	nsubj	_	_
-2	einer	ein	DET	ART	Case=Gen|Definite=Ind|Gender=Fem|Number=Sing|PronType=Art	4	det	_	_
-3	neuen	neu	ADJ	ADJA	Case=Gen|Gender=Fem|Number=Sing	4	amod	_	_
-4	Datenschutzrichtlinie	Datenschutzrichtlinie	NOUN	NN	Case=Gen|Gender=Fem|Number=Sing	1	nmod	_	_
-5	verbot	verbieten	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	0	root	_	_
-6	es	es	PRON	PPER	Case=Acc|Gender=Neut|Number=Sing|Person=3|PronType=Prs	5	obj	_	SpaceAfter=No
-7	,	,	PUNCT	$,	_	5	punct	_	_
-8	daß	daß	SCONJ	KOUS	_	16	mark	_	_
-9	Kirchen	Kirche	NOUN	NN	Case=Nom|Gender=Fem|Number=Plur	16	nsubj	_	SpaceAfter=No
-10	,	,	PUNCT	$,	_	11	punct	_	_
-11	Arbeitgeber	Arbeitgeber	NOUN	NN	Case=Nom|Gender=Masc|Number=Plur	9	conj	_	_
-12	und	und	CCONJ	KON	_	13	cc	_	_
-13	Staat	Staat	NOUN	NN	Case=Nom|Gender=Masc|Number=Sing	9	conj	_	_
-14	Daten	Datum	NOUN	NN	Case=Acc|Gender=Neut|Number=Plur	16	obj	_	_
-15	miteinander	miteinander	ADV	PAV	_	16	advmod	_	_
-16	austauschen	austauschen	VERB	VVFIN	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	5	ccomp	_	SpaceAfter=No
-17	.	.	PUNCT	$.	_	5	punct	_	_
+# text = Der Entwurf einer neuen Datenschutzrichtlinie verbot es, daß Kirchen, Arbeitgeber und Staat Daten miteinander austauschen.
+1	Der	der	DET	ART	Case=Nom|Definite=Def|Gender=Masc|Number=Sing|PronType=Art	2	dep	_	FixTigerDep=Yes
+2	Entwurf	Entwurf	NOUN	NN	Case=Nom|Gender=Masc|Number=Sing	6	nsubj	_	_
+3	einer	ein	DET	ART	Case=Gen|Definite=Ind|Gender=Fem|Number=Sing|PronType=Art	5	det	_	_
+4	neuen	neu	ADJ	ADJA	Case=Gen|Gender=Fem|Number=Sing	5	amod	_	_
+5	Datenschutzrichtlinie	Datenschutzrichtlinie	NOUN	NN	Case=Gen|Gender=Fem|Number=Sing	2	nmod	_	_
+6	verbot	verbieten	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	0	root	_	_
+7	es	es	PRON	PPER	Case=Acc|Gender=Neut|Number=Sing|Person=3|PronType=Prs	6	obj	_	SpaceAfter=No
+8	,	,	PUNCT	$,	_	6	punct	_	_
+9	daß	daß	SCONJ	KOUS	_	17	mark	_	_
+10	Kirchen	Kirche	NOUN	NN	Case=Nom|Gender=Fem|Number=Plur	17	nsubj	_	SpaceAfter=No
+11	,	,	PUNCT	$,	_	12	punct	_	_
+12	Arbeitgeber	Arbeitgeber	NOUN	NN	Case=Nom|Gender=Masc|Number=Plur	10	conj	_	_
+13	und	und	CCONJ	KON	_	14	cc	_	_
+14	Staat	Staat	NOUN	NN	Case=Nom|Gender=Masc|Number=Sing	10	conj	_	_
+15	Daten	Datum	NOUN	NN	Case=Acc|Gender=Neut|Number=Plur	17	obj	_	_
+16	miteinander	miteinander	ADV	PAV	_	17	advmod	_	_
+17	austauschen	austauschen	VERB	VVFIN	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	6	ccomp	_	SpaceAfter=No
+18	.	.	PUNCT	$.	_	6	punct	_	_
 
 # sent_id = test-s392
-# text = Er kann seine Hände nicht in Unschuld waschen und vorgeben, nichts damit zu tun zu haben.
-1	Er	er	PRON	PPER	Case=Nom|Gender=Masc|Number=Sing|Person=3|PronType=Prs	8	nsubj	_	_
-2	kann	können	AUX	VMFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	8	aux	_	_
-3	seine	sein	PRON	PPOSAT	Case=Acc|Gender=Fem|Number=Plur|Poss=Yes	4	det:poss	_	_
-4	Hände	Hand	NOUN	NN	Case=Acc|Gender=Fem|Number=Plur	8	obj	_	_
-5	nicht	nicht	PART	PTKNEG	Polarity=Neg	8	advmod	_	_
-6	in	in	ADP	APPR	_	7	case	_	_
-7	Unschuld	Unschuld	NOUN	NN	Case=Dat|Gender=Fem|Number=Sing	8	obl	_	_
-8	waschen	waschen	VERB	VVINF	VerbForm=Inf	0	root	_	_
-9	und	und	CCONJ	KON	_	10	cc	_	_
-10	vorgeben	vorgeben	VERB	VVINF	VerbForm=Inf	8	conj	_	SpaceAfter=No
-11	,	,	PUNCT	$,	_	8	punct	_	_
-12	nichts	nichts	PRON	PIS	Definite=Ind|Gender=Neut|PronType=Ind	17	obj	_	_
-13	damit	damit	ADV	PAV	_	15	advmod	_	_
-14	zu	zu	PART	PTKZU	_	15	mark	_	_
-15	tun	tun	VERB	VVINF	VerbForm=Inf	17	acl	_	_
-16	zu	zu	PART	PTKZU	_	17	mark	_	_
-17	haben	haben	VERB	VAINF	VerbForm=Inf	10	xcomp	_	SpaceAfter=No
-18	.	.	PUNCT	$.	_	8	punct	_	_
+# text = ``Er kann seine Hände nicht in Unschuld waschen und vorgeben, nichts damit zu tun zu haben.
+1	``	``	PUNCT	$(	_	2	punct	_	FixTigerDep=Yes|SpaceAfter=No
+2	Er	er	PRON	PPER	Case=Nom|Gender=Masc|Number=Sing|Person=3|PronType=Prs	9	nsubj	_	_
+3	kann	können	AUX	VMFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	9	aux	_	_
+4	seine	sein	PRON	PPOSAT	Case=Acc|Gender=Fem|Number=Plur|Poss=Yes	5	det:poss	_	_
+5	Hände	Hand	NOUN	NN	Case=Acc|Gender=Fem|Number=Plur	9	obj	_	_
+6	nicht	nicht	PART	PTKNEG	Polarity=Neg	9	advmod	_	_
+7	in	in	ADP	APPR	_	8	case	_	_
+8	Unschuld	Unschuld	NOUN	NN	Case=Dat|Gender=Fem|Number=Sing	9	obl	_	_
+9	waschen	waschen	VERB	VVINF	VerbForm=Inf	0	root	_	_
+10	und	und	CCONJ	KON	_	11	cc	_	_
+11	vorgeben	vorgeben	VERB	VVINF	VerbForm=Inf	9	conj	_	SpaceAfter=No
+12	,	,	PUNCT	$,	_	9	punct	_	_
+13	nichts	nichts	PRON	PIS	Definite=Ind|Gender=Neut|PronType=Ind	18	obj	_	_
+14	damit	damit	ADV	PAV	_	16	advmod	_	_
+15	zu	zu	PART	PTKZU	_	16	mark	_	_
+16	tun	tun	VERB	VVINF	VerbForm=Inf	18	acl	_	_
+17	zu	zu	PART	PTKZU	_	18	mark	_	_
+18	haben	haben	VERB	VAINF	VerbForm=Inf	11	xcomp	_	SpaceAfter=No
+19	.	.	PUNCT	$.	_	9	punct	_	_
 
 # sent_id = test-s393
-# text = Erinnerung und der Glaube an Befreiung seien Bedingung für Vernunft und Freiheit.
-1	Erinnerung	Erinnerung	NOUN	NN	Case=Nom|Gender=Fem|Number=Sing	8	nsubj	_	_
-2	und	und	CCONJ	KON	_	4	cc	_	_
-3	der	der	DET	ART	Case=Nom|Definite=Def|Gender=Masc|Number=Sing|PronType=Art	4	det	_	_
-4	Glaube	Glaube	NOUN	NN	Case=Nom|Gender=Masc|Number=Sing	1	conj	_	_
-5	an	an	ADP	APPR	_	6	case	_	_
-6	Befreiung	Befreiung	NOUN	NN	Case=Acc|Gender=Fem|Number=Sing	1	nmod	_	_
-7	seien	sein	AUX	VAFIN	Mood=Sub|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	8	cop	_	_
-8	Bedingung	Bedingung	NOUN	NN	Case=Nom|Gender=Fem|Number=Sing	0	root	_	_
-9	für	für	ADP	APPR	_	10	case	_	_
-10	Vernunft	Vernunft	NOUN	NN	Case=Acc|Gender=Fem|Number=Sing	8	nmod	_	_
-11	und	und	CCONJ	KON	_	12	cc	_	_
-12	Freiheit	Freiheit	NOUN	NN	Case=Acc|Gender=Fem|Number=Sing	10	conj	_	SpaceAfter=No
-13	.	.	PUNCT	$.	_	8	punct	_	_
+# text = Diese Erinnerung und der Glaube an Befreiung seien Bedingung für Vernunft und Freiheit.
+1	Diese	dies	DET	PDAT	Case=Nom|Gender=Fem|Number=Sing|PronType=Dem	2	dep	_	FixTigerDep=Yes
+2	Erinnerung	Erinnerung	NOUN	NN	Case=Nom|Gender=Fem|Number=Sing	9	nsubj	_	_
+3	und	und	CCONJ	KON	_	5	cc	_	_
+4	der	der	DET	ART	Case=Nom|Definite=Def|Gender=Masc|Number=Sing|PronType=Art	5	det	_	_
+5	Glaube	Glaube	NOUN	NN	Case=Nom|Gender=Masc|Number=Sing	2	conj	_	_
+6	an	an	ADP	APPR	_	7	case	_	_
+7	Befreiung	Befreiung	NOUN	NN	Case=Acc|Gender=Fem|Number=Sing	2	nmod	_	_
+8	seien	sein	AUX	VAFIN	Mood=Sub|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	9	cop	_	_
+9	Bedingung	Bedingung	NOUN	NN	Case=Nom|Gender=Fem|Number=Sing	0	root	_	_
+10	für	für	ADP	APPR	_	11	case	_	_
+11	Vernunft	Vernunft	NOUN	NN	Case=Acc|Gender=Fem|Number=Sing	9	nmod	_	_
+12	und	und	CCONJ	KON	_	13	cc	_	_
+13	Freiheit	Freiheit	NOUN	NN	Case=Acc|Gender=Fem|Number=Sing	11	conj	_	SpaceAfter=No
+14	.	.	PUNCT	$.	_	9	punct	_	_
 
 # sent_id = test-s394
-# text = Ermittlungen konzentrieren sich unter anderem auf den Sprecher der Siedler aus Kyriat Arba, Abraham Ben David.
-1	Ermittlungen	Ermittlung	NOUN	NN	Case=Nom|Gender=Fem|Number=Plur	2	nsubj	_	_
-2	konzentrieren	konzentrieren	VERB	VVFIN	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	0	root	_	_
-3	sich	er|es|sie	PRON	PRF	Case=Acc|Number=Plur|Person=3|PronType=Prs|Reflex=Yes	2	obj	_	_
-4	unter	unter	ADP	APPR	_	5	case	_	_
-5	anderem	ander	PRON	PIS	Case=Dat|Definite=Ind|Gender=Neut|Number=Sing|PronType=Ind	2	obl	_	_
-6	auf	auf	ADP	APPR	_	8	case	_	_
-7	den	der	DET	ART	Case=Acc|Definite=Def|Gender=Masc|Number=Sing|PronType=Art	8	det	_	_
-8	Sprecher	Sprecher	NOUN	NN	Case=Acc|Gender=Masc|Number=Sing	2	obl	_	_
-9	der	der	DET	ART	Case=Gen|Definite=Def|Gender=Masc|Number=Plur|PronType=Art	10	det	_	_
-10	Siedler	Siedler	NOUN	NN	Case=Gen|Gender=Masc|Number=Plur	8	nmod	_	_
-11	aus	aus	ADP	APPR	_	12	case	_	_
-12	Kyriat	Kyriat	PROPN	NE	_	10	nmod	_	_
-13	Arba	Arba	PROPN	NE	Case=Dat|Gender=Neut|Number=Sing	12	flat	_	SpaceAfter=No
-14	,	,	PUNCT	$,	_	2	punct	_	_
-15	Abraham	Abraham	PROPN	NE	Case=Nom|Gender=Masc|Number=Sing	8	appos	_	_
-16	Ben	Ben	PROPN	NE	Case=Nom|Gender=Masc|Number=Sing	15	flat	_	_
-17	David	David	PROPN	NE	Case=Acc|Gender=Masc|Number=Sing	15	flat	_	SpaceAfter=No
-18	.	.	PUNCT	$.	_	2	punct	_	_
+# text = Die Ermittlungen konzentrieren sich unter anderem auf den Sprecher der Siedler aus Kyriat Arba, Abraham Ben David.
+1	Die	der	DET	ART	Case=Nom|Definite=Def|Gender=Fem|Number=Plur|PronType=Art	2	dep	_	FixTigerDep=Yes
+2	Ermittlungen	Ermittlung	NOUN	NN	Case=Nom|Gender=Fem|Number=Plur	3	nsubj	_	_
+3	konzentrieren	konzentrieren	VERB	VVFIN	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	0	root	_	_
+4	sich	er|es|sie	PRON	PRF	Case=Acc|Number=Plur|Person=3|PronType=Prs|Reflex=Yes	3	obj	_	_
+5	unter	unter	ADP	APPR	_	6	case	_	_
+6	anderem	ander	PRON	PIS	Case=Dat|Definite=Ind|Gender=Neut|Number=Sing|PronType=Ind	3	obl	_	_
+7	auf	auf	ADP	APPR	_	9	case	_	_
+8	den	der	DET	ART	Case=Acc|Definite=Def|Gender=Masc|Number=Sing|PronType=Art	9	det	_	_
+9	Sprecher	Sprecher	NOUN	NN	Case=Acc|Gender=Masc|Number=Sing	3	obl	_	_
+10	der	der	DET	ART	Case=Gen|Definite=Def|Gender=Masc|Number=Plur|PronType=Art	11	det	_	_
+11	Siedler	Siedler	NOUN	NN	Case=Gen|Gender=Masc|Number=Plur	9	nmod	_	_
+12	aus	aus	ADP	APPR	_	13	case	_	_
+13	Kyriat	Kyriat	PROPN	NE	_	11	nmod	_	_
+14	Arba	Arba	PROPN	NE	Case=Dat|Gender=Neut|Number=Sing	13	flat	_	SpaceAfter=No
+15	,	,	PUNCT	$,	_	3	punct	_	_
+16	Abraham	Abraham	PROPN	NE	Case=Nom|Gender=Masc|Number=Sing	9	appos	_	_
+17	Ben	Ben	PROPN	NE	Case=Nom|Gender=Masc|Number=Sing	16	flat	_	_
+18	David	David	PROPN	NE	Case=Acc|Gender=Masc|Number=Sing	16	flat	_	SpaceAfter=No
+19	.	.	PUNCT	$.	_	3	punct	_	_
 
 # sent_id = test-s395
-# text = Es handelt sich wieder einmal um die falsche Fragestellung'', moniert Katrin Grüber.
-1	Es	es	PRON	PPER	Case=Nom|Gender=Neut|Number=Sing|Person=3|PronType=Prs	2	nsubj	_	_
-2	handelt	handeln	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	12	ccomp	_	_
-3	sich	er|es|sie	PRON	PRF	Case=Acc|Number=Sing|Person=3|PronType=Prs|Reflex=Yes	2	obj	_	_
-4	wieder	wieder	ADV	ADV	_	2	advmod	_	_
-5	einmal	einmal	ADV	ADV	_	4	advmod	_	_
-6	um	um	ADP	APPR	_	9	case	_	_
-7	die	der	DET	ART	Case=Acc|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	9	det	_	_
-8	falsche	falsch	ADJ	ADJA	Case=Acc|Gender=Fem|Number=Sing	9	amod	_	_
-9	Fragestellung	Fragestellung	NOUN	NN	Case=Acc|Gender=Fem|Number=Sing	2	obl	_	SpaceAfter=No
-10	''	''	PUNCT	$(	_	12	punct	_	SpaceAfter=No
-11	,	,	PUNCT	$,	_	12	punct	_	_
-12	moniert	monieren	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	0	root	_	_
-13	Katrin	Katrin	PROPN	NE	Case=Nom|Gender=Fem|Number=Sing	12	nsubj	_	_
-14	Grüber	Grüber	PROPN	NE	Case=Nom|Gender=Fem|Number=Sing	13	flat	_	SpaceAfter=No
-15	.	.	PUNCT	$.	_	12	punct	_	_
+# text = ``Es handelt sich wieder einmal um die falsche Fragestellung'', moniert Katrin Grüber.
+1	``	``	PUNCT	$(	_	2	punct	_	FixTigerDep=Yes|SpaceAfter=No
+2	Es	es	PRON	PPER	Case=Nom|Gender=Neut|Number=Sing|Person=3|PronType=Prs	3	nsubj	_	_
+3	handelt	handeln	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	13	ccomp	_	_
+4	sich	er|es|sie	PRON	PRF	Case=Acc|Number=Sing|Person=3|PronType=Prs|Reflex=Yes	3	obj	_	_
+5	wieder	wieder	ADV	ADV	_	3	advmod	_	_
+6	einmal	einmal	ADV	ADV	_	5	advmod	_	_
+7	um	um	ADP	APPR	_	10	case	_	_
+8	die	der	DET	ART	Case=Acc|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	10	det	_	_
+9	falsche	falsch	ADJ	ADJA	Case=Acc|Gender=Fem|Number=Sing	10	amod	_	_
+10	Fragestellung	Fragestellung	NOUN	NN	Case=Acc|Gender=Fem|Number=Sing	3	obl	_	SpaceAfter=No
+11	''	''	PUNCT	$(	_	13	punct	_	SpaceAfter=No
+12	,	,	PUNCT	$,	_	13	punct	_	_
+13	moniert	monieren	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	0	root	_	_
+14	Katrin	Katrin	PROPN	NE	Case=Nom|Gender=Fem|Number=Sing	13	nsubj	_	_
+15	Grüber	Grüber	PROPN	NE	Case=Nom|Gender=Fem|Number=Sing	14	flat	_	SpaceAfter=No
+16	.	.	PUNCT	$.	_	13	punct	_	_
 
 # sent_id = test-s396
-# text = "Es ist ein Bohren von dicken Brettern'', sagte Professor Manfred Bauer, einer der Väter der Sozialpsychiatrie in Deutschland.
-1	"	"	PUNCT	$(	_	5	punct	_	SpaceAfter=No
+# text = ``Es ist ein Bohren von dicken Brettern'', sagte Professor Manfred Bauer, einer der Väter der Sozialpsychiatrie in Deutschland.
+1	``	"	PUNCT	$(	_	2	punct	_	FixTigerDep=Yes|SpaceAfter=No
 2	Es	es	PRON	PPER	Case=Nom|Gender=Neut|Number=Sing|Person=3|PronType=Prs	5	nsubj	_	_
 3	ist	sein	AUX	VAFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	5	cop	_	_
 4	ein	ein	DET	ART	Case=Nom|Definite=Ind|Gender=Neut|Number=Sing|PronType=Art	5	det	_	_
@@ -7351,8 +7424,8 @@
 23	.	.	PUNCT	$.	_	11	punct	_	_
 
 # sent_id = test-s397
-# text = "Es ist ja nicht so, daß die Europäer plötzlich die DM regieren.
-1	"	"	PUNCT	$(	_	3	punct	_	SpaceAfter=No
+# text = ``Es ist ja nicht so, daß die Europäer plötzlich die DM regieren.
+1	``	"	PUNCT	$(	_	2	punct	_	FixTigerDep=Yes|SpaceAfter=No
 2	Es	es	PRON	PPER	Case=Acc|Gender=Neut|Number=Sing|Person=3|PronType=Prs	3	nsubj	_	_
 3	ist	sein	VERB	VAFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	0	root	_	_
 4	ja	ja	ADV	ADV	_	3	advmod	_	_
@@ -7364,7 +7437,7 @@
 10	Europäer	Europäer	NOUN	NN	Case=Nom|Gender=Masc|Number=Plur	14	nsubj	_	_
 11	plötzlich	plötzlich	ADV	ADJD	_	14	advmod	_	_
 12	die	der	DET	ART	Case=Acc|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	13	det	_	_
-13	DM	DM	PROPN	NN	Case=Acc|Gender=Fem|Number=Sing	14	obj	_	_
+13	DM	Deutsche_Mark	PROPN	NN	Case=Acc|Gender=Fem|Number=Sing	14	obj	_	_
 14	regieren	regieren	VERB	VVFIN	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	3	ccomp	_	SpaceAfter=No
 15	.	.	PUNCT	$.	_	3	punct	_	_
 
@@ -7399,100 +7472,103 @@
 27	.	.	PUNCT	$.	_	2	punct	_	_
 
 # sent_id = test-s399
-# text = Es zog sie den ganzen Sommer schon so unwiderstehlich in die Schweiz, sie wollte noch die lieben Berge, Wärme und Sonnenschein genießen und hat sie genossen mit dem Gefühl gebesserter Gesundheit'', berichtet Valerie, die Tochter von Sisi.
-1	Es	es	PRON	PPER	Case=Nom|Gender=Neut|Number=Sing|Person=3|PronType=Prs	2	nsubj	_	_
-2	zog	ziehen	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	36	ccomp	_	_
-3	sie	sie	PRON	PPER	Case=Acc|Gender=Fem|Number=Sing|Person=3|PronType=Prs	2	obj	_	_
-4	den	der	DET	ART	Case=Acc|Definite=Def|Gender=Masc|Number=Sing|PronType=Art	6	det	_	_
-5	ganzen	ganz	ADJ	ADJA	Case=Acc|Gender=Masc|Number=Sing	6	amod	_	_
-6	Sommer	Sommer	NOUN	NN	Case=Acc|Gender=Masc|Number=Sing	2	obl	_	_
-7	schon	schon	ADV	ADV	_	2	advmod	_	_
-8	so	so	ADV	ADV	_	9	advmod	_	_
-9	unwiderstehlich	unwiderstehlich	ADV	ADJD	_	2	advmod	_	_
-10	in	in	ADP	APPR	_	12	case	_	_
-11	die	der	DET	ART	Case=Acc|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	12	det	_	_
-12	Schweiz	Schweiz	PROPN	NE	Case=Acc|Gender=Fem|Number=Sing	2	obl	_	SpaceAfter=No
-13	,	,	PUNCT	$,	_	36	punct	_	_
-14	sie	sie	PRON	PPER	Case=Nom|Gender=Fem|Number=Sing|Person=3|PronType=Prs	24	nsubj	_	_
-15	wollte	wollen	AUX	VMFIN	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	24	aux	_	_
-16	noch	noch	ADV	ADV	_	24	advmod	_	_
-17	die	der	DET	ART	Case=Acc|Definite=Def|Gender=Masc|Number=Plur|PronType=Art	19	det	_	_
-18	lieben	lieb	ADJ	ADJA	Case=Acc|Gender=Masc|Number=Plur	19	amod	_	_
-19	Berge	Berg	NOUN	NN	Case=Acc|Gender=Masc|Number=Plur	24	obj	_	SpaceAfter=No
-20	,	,	PUNCT	$,	_	21	punct	_	_
-21	Wärme	Wärme	NOUN	NN	Case=Acc|Gender=Fem|Number=Sing	19	conj	_	_
-22	und	und	CCONJ	KON	_	23	cc	_	_
-23	Sonnenschein	Sonnenschein	NOUN	NN	Case=Acc|Gender=Masc|Number=Sing	21	conj	_	_
-24	genießen	genießen	VERB	VVINF	VerbForm=Inf	2	conj	_	_
-25	und	und	CCONJ	KON	_	28	cc	_	_
-26	hat	haben	AUX	VAFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	28	aux	_	_
-27	sie	sie	PRON	PPER	Case=Acc|Gender=Fem|Number=Sing|Person=3|PronType=Prs	28	obj	_	_
-28	genossen	genießen	VERB	VVPP	VerbForm=Part	24	conj	_	_
-29	mit	mit	ADP	APPR	_	31	case	_	_
-30	dem	der	DET	ART	Case=Dat|Definite=Def|Gender=Neut|Number=Sing|PronType=Art	31	det	_	_
-31	Gefühl	Gefühl	NOUN	NN	Case=Dat|Gender=Neut|Number=Sing	28	obl	_	_
-32	gebesserter	gebessert	ADJ	ADJA	Case=Gen|Gender=Fem|Number=Sing	33	amod	_	_
-33	Gesundheit	Gesundheit	NOUN	NN	Case=Gen|Gender=Fem|Number=Sing	31	nmod	_	SpaceAfter=No
-34	''	''	PUNCT	$(	_	36	punct	_	SpaceAfter=No
-35	,	,	PUNCT	$,	_	36	punct	_	_
-36	berichtet	berichten	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	0	root	_	_
-37	Valerie	Valerie	PROPN	NE	Case=Nom|Gender=Fem|Number=Sing	36	nsubj	_	SpaceAfter=No
-38	,	,	PUNCT	$,	_	36	punct	_	_
-39	die	der	DET	ART	Case=Nom|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	40	det	_	_
-40	Tochter	Tochter	NOUN	NN	Case=Nom|Gender=Fem|Number=Sing	37	appos	_	_
-41	von	von	ADP	APPR	_	42	case	_	_
-42	Sisi	Sisi	PROPN	NE	Case=Dat|Gender=Fem|Number=Sing	40	nmod	_	SpaceAfter=No
-43	.	.	PUNCT	$.	_	36	punct	_	_
+# text = ``Es zog sie den ganzen Sommer schon so unwiderstehlich in die Schweiz, sie wollte noch die lieben Berge, Wärme und Sonnenschein genießen und hat sie genossen mit dem Gefühl gebesserter Gesundheit'', berichtet Valerie, die Tochter von Sisi.
+1	``	``	PUNCT	$(	_	2	punct	_	FixTigerDep=Yes|SpaceAfter=No
+2	Es	es	PRON	PPER	Case=Nom|Gender=Neut|Number=Sing|Person=3|PronType=Prs	3	nsubj	_	_
+3	zog	ziehen	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	37	ccomp	_	_
+4	sie	sie	PRON	PPER	Case=Acc|Gender=Fem|Number=Sing|Person=3|PronType=Prs	3	obj	_	_
+5	den	der	DET	ART	Case=Acc|Definite=Def|Gender=Masc|Number=Sing|PronType=Art	7	det	_	_
+6	ganzen	ganz	ADJ	ADJA	Case=Acc|Gender=Masc|Number=Sing	7	amod	_	_
+7	Sommer	Sommer	NOUN	NN	Case=Acc|Gender=Masc|Number=Sing	3	obl	_	_
+8	schon	schon	ADV	ADV	_	3	advmod	_	_
+9	so	so	ADV	ADV	_	10	advmod	_	_
+10	unwiderstehlich	unwiderstehlich	ADV	ADJD	_	3	advmod	_	_
+11	in	in	ADP	APPR	_	13	case	_	_
+12	die	der	DET	ART	Case=Acc|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	13	det	_	_
+13	Schweiz	Schweiz	PROPN	NE	Case=Acc|Gender=Fem|Number=Sing	3	obl	_	SpaceAfter=No
+14	,	,	PUNCT	$,	_	37	punct	_	_
+15	sie	sie	PRON	PPER	Case=Nom|Gender=Fem|Number=Sing|Person=3|PronType=Prs	25	nsubj	_	_
+16	wollte	wollen	AUX	VMFIN	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	25	aux	_	_
+17	noch	noch	ADV	ADV	_	25	advmod	_	_
+18	die	der	DET	ART	Case=Acc|Definite=Def|Gender=Masc|Number=Plur|PronType=Art	20	det	_	_
+19	lieben	lieb	ADJ	ADJA	Case=Acc|Gender=Masc|Number=Plur	20	amod	_	_
+20	Berge	Berg	NOUN	NN	Case=Acc|Gender=Masc|Number=Plur	25	obj	_	SpaceAfter=No
+21	,	,	PUNCT	$,	_	22	punct	_	_
+22	Wärme	Wärme	NOUN	NN	Case=Acc|Gender=Fem|Number=Sing	20	conj	_	_
+23	und	und	CCONJ	KON	_	24	cc	_	_
+24	Sonnenschein	Sonnenschein	NOUN	NN	Case=Acc|Gender=Masc|Number=Sing	22	conj	_	_
+25	genießen	genießen	VERB	VVINF	VerbForm=Inf	3	conj	_	_
+26	und	und	CCONJ	KON	_	29	cc	_	_
+27	hat	haben	AUX	VAFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	29	aux	_	_
+28	sie	sie	PRON	PPER	Case=Acc|Gender=Fem|Number=Sing|Person=3|PronType=Prs	29	obj	_	_
+29	genossen	genießen	VERB	VVPP	VerbForm=Part	25	conj	_	_
+30	mit	mit	ADP	APPR	_	32	case	_	_
+31	dem	der	DET	ART	Case=Dat|Definite=Def|Gender=Neut|Number=Sing|PronType=Art	32	det	_	_
+32	Gefühl	Gefühl	NOUN	NN	Case=Dat|Gender=Neut|Number=Sing	29	obl	_	_
+33	gebesserter	gebessert	ADJ	ADJA	Case=Gen|Gender=Fem|Number=Sing	34	amod	_	_
+34	Gesundheit	Gesundheit	NOUN	NN	Case=Gen|Gender=Fem|Number=Sing	32	nmod	_	SpaceAfter=No
+35	''	''	PUNCT	$(	_	37	punct	_	SpaceAfter=No
+36	,	,	PUNCT	$,	_	37	punct	_	_
+37	berichtet	berichten	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	0	root	_	_
+38	Valerie	Valerie	PROPN	NE	Case=Nom|Gender=Fem|Number=Sing	37	nsubj	_	SpaceAfter=No
+39	,	,	PUNCT	$,	_	37	punct	_	_
+40	die	der	DET	ART	Case=Nom|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	41	det	_	_
+41	Tochter	Tochter	NOUN	NN	Case=Nom|Gender=Fem|Number=Sing	38	appos	_	_
+42	von	von	ADP	APPR	_	43	case	_	_
+43	Sisi	Sisi	PROPN	NE	Case=Dat|Gender=Fem|Number=Sing	41	nmod	_	SpaceAfter=No
+44	.	.	PUNCT	$.	_	37	punct	_	_
 
 # sent_id = test-s400
-# text = Ex-Generalstabschef Colin Powell hat am Mittwoch angekündigt, er werde bei den Präsidentenwahlen in den USA nicht kandidieren.
-1	Ex	ex	NOUN	NN	Case=Nom|Gender=Masc|Number=Sing	3	compound	_	SpaceAfter=No
-2	-	-	PUNCT	$(	_	1	punct	_	SpaceAfter=No
-3	Generalstabschef	Generalstabschef	NOUN	NN	Case=Nom|Gender=Masc|Number=Sing	10	nsubj	_	_
-4	Colin	Colin	PROPN	NE	Case=Nom|Gender=Masc|Number=Sing	3	appos	_	_
-5	Powell	Powell	PROPN	NE	Case=Nom|Gender=Masc|Number=Sing	4	flat	_	_
-6	hat	haben	AUX	VAFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	10	aux	_	_
-7-8	am	_	_	_	_	_	_	_	_
-7	an	an	ADP	APPR	_	9	case	_	_
-8	dem	der	DET	ART	Case=Dat|Definite=Def|Gender=Masc|Number=Sing|PronType=Art	9	det	_	_
-9	Mittwoch	Mittwoch	PROPN	NN	Case=Dat|Gender=Masc|Number=Sing	10	obl	_	_
-10	angekündigt	ankündigen	VERB	VVPP	VerbForm=Part	0	root	_	SpaceAfter=No
-11	,	,	PUNCT	$,	_	10	punct	_	_
-12	er	er	PRON	PPER	Case=Nom|Gender=Masc|Number=Sing|Person=3|PronType=Prs	21	nsubj	_	_
-13	werde	werden	AUX	VAFIN	Mood=Sub|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	21	aux	_	_
-14	bei	bei	ADP	APPR	_	16	case	_	_
-15	den	der	DET	ART	Case=Dat|Definite=Def|Gender=Fem|Number=Plur|PronType=Art	16	det	_	_
-16	Präsidentenwahlen	Präsidentenwahl	NOUN	NN	Case=Dat|Gender=Fem|Number=Plur	21	obl	_	_
-17	in	in	ADP	APPR	_	19	case	_	_
-18	den	der	DET	ART	Case=Dat|Definite=Def|Number=Plur|PronType=Art	19	det	_	_
-19	USA	USA	PROPN	NE	Case=Dat|Number=Plur	16	nmod	_	_
-20	nicht	nicht	PART	PTKNEG	Polarity=Neg	21	advmod	_	_
-21	kandidieren	kandidieren	VERB	VVINF	VerbForm=Inf	10	ccomp	_	SpaceAfter=No
-22	.	.	PUNCT	$.	_	10	punct	_	_
+# text = Der Ex-Generalstabschef Colin Powell hat am Mittwoch angekündigt, er werde bei den Präsidentenwahlen in den USA nicht kandidieren.
+1	Der	der	DET	ART	Case=Nom|Definite=Def|Gender=Masc|Number=Sing|PronType=Art	2	dep	_	FixTigerDep=Yes
+2	Ex	ex	NOUN	NN	Case=Nom|Gender=Masc|Number=Sing	4	compound	_	SpaceAfter=No
+3	-	-	PUNCT	$(	_	2	punct	_	SpaceAfter=No
+4	Generalstabschef	Generalstabschef	NOUN	NN	Case=Nom|Gender=Masc|Number=Sing	11	nsubj	_	_
+5	Colin	Colin	PROPN	NE	Case=Nom|Gender=Masc|Number=Sing	4	appos	_	_
+6	Powell	Powell	PROPN	NE	Case=Nom|Gender=Masc|Number=Sing	5	flat	_	_
+7	hat	haben	AUX	VAFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	11	aux	_	_
+8-9	am	_	_	_	_	_	_	_	_
+8	an	an	ADP	APPR	_	10	case	_	_
+9	dem	der	DET	ART	Case=Dat|Definite=Def|Gender=Masc|Number=Sing|PronType=Art	10	det	_	_
+10	Mittwoch	Mittwoch	PROPN	NN	Case=Dat|Gender=Masc|Number=Sing	11	obl	_	_
+11	angekündigt	ankündigen	VERB	VVPP	VerbForm=Part	0	root	_	SpaceAfter=No
+12	,	,	PUNCT	$,	_	11	punct	_	_
+13	er	er	PRON	PPER	Case=Nom|Gender=Masc|Number=Sing|Person=3|PronType=Prs	22	nsubj	_	_
+14	werde	werden	AUX	VAFIN	Mood=Sub|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	22	aux	_	_
+15	bei	bei	ADP	APPR	_	17	case	_	_
+16	den	der	DET	ART	Case=Dat|Definite=Def|Gender=Fem|Number=Plur|PronType=Art	17	det	_	_
+17	Präsidentenwahlen	Präsidentenwahl	NOUN	NN	Case=Dat|Gender=Fem|Number=Plur	22	obl	_	_
+18	in	in	ADP	APPR	_	20	case	_	_
+19	den	der	DET	ART	Case=Dat|Definite=Def|Number=Plur|PronType=Art	20	det	_	_
+20	USA	USA	PROPN	NE	Case=Dat|Number=Plur	17	nmod	_	_
+21	nicht	nicht	PART	PTKNEG	Polarity=Neg	22	advmod	_	_
+22	kandidieren	kandidieren	VERB	VVINF	VerbForm=Inf	11	ccomp	_	SpaceAfter=No
+23	.	.	PUNCT	$.	_	11	punct	_	_
 
 # sent_id = test-s401
-# text = externe Liberalisierung auf Weltmarktebene mußte aber zwangsläufig den Druck zur internen Liberalisierung beziehungsweise Deregulierung innerhalb der Nationalstaaten verstärken.
-1	externe	extern	ADJ	ADJA	Case=Nom|Gender=Fem|Number=Sing	2	amod	_	_
-2	Liberalisierung	Liberalisierung	NOUN	NN	Case=Nom|Gender=Fem|Number=Sing	19	nsubj	_	_
-3	auf	auf	ADP	APPR	_	4	case	_	_
-4	Weltmarktebene	Weltmarktebene	NOUN	NN	Case=Dat|Gender=Fem|Number=Sing	2	nmod	_	_
-5	mußte	müssen	AUX	VMFIN	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	19	aux	_	_
-6	aber	aber	ADV	ADV	_	19	advmod	_	_
-7	zwangsläufig	zwangsläufig	ADV	ADJD	_	19	advmod	_	_
-8	den	der	DET	ART	Case=Acc|Definite=Def|Gender=Masc|Number=Sing|PronType=Art	9	det	_	_
-9	Druck	Druck	NOUN	NN	Case=Acc|Gender=Masc|Number=Sing	19	obj	_	_
-10-11	zur	_	_	_	_	_	_	_	_
-10	zu	zu	ADP	APPR	_	13	case	_	_
-11	der	der	DET	ART	Case=Dat|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	13	det	_	_
-12	internen	intern	ADJ	ADJA	Case=Dat|Gender=Fem|Number=Sing	13	amod	_	_
-13	Liberalisierung	Liberalisierung	NOUN	NN	Case=Dat|Gender=Fem|Number=Sing	9	nmod	_	_
-14	beziehungsweise	beziehungsweise	CCONJ	KON	_	15	cc	_	_
-15	Deregulierung	Deregulierung	NOUN	NN	Case=Dat|Gender=Fem|Number=Sing	13	conj	_	_
-16	innerhalb	innerhalb	ADP	APPR	_	18	case	_	_
-17	der	der	DET	ART	Case=Gen|Definite=Def|Gender=Masc|Number=Plur|PronType=Art	18	det	_	_
-18	Nationalstaaten	Nationalstaat	NOUN	NN	Case=Gen|Gender=Masc|Number=Plur	19	obl	_	_
-19	verstärken	verstärken	VERB	VVINF	VerbForm=Inf	0	root	_	SpaceAfter=No
-20	.	.	PUNCT	$.	_	19	punct	_	_
+# text = Die externe Liberalisierung auf Weltmarktebene mußte aber zwangsläufig den Druck zur internen Liberalisierung beziehungsweise Deregulierung innerhalb der Nationalstaaten verstärken.
+1	Die	der	DET	ART	Case=Nom|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	2	dep	_	FixTigerDep=Yes
+2	externe	extern	ADJ	ADJA	Case=Nom|Gender=Fem|Number=Sing	3	amod	_	_
+3	Liberalisierung	Liberalisierung	NOUN	NN	Case=Nom|Gender=Fem|Number=Sing	20	nsubj	_	_
+4	auf	auf	ADP	APPR	_	5	case	_	_
+5	Weltmarktebene	Weltmarktebene	NOUN	NN	Case=Dat|Gender=Fem|Number=Sing	3	nmod	_	_
+6	mußte	müssen	AUX	VMFIN	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	20	aux	_	_
+7	aber	aber	ADV	ADV	_	20	advmod	_	_
+8	zwangsläufig	zwangsläufig	ADV	ADJD	_	20	advmod	_	_
+9	den	der	DET	ART	Case=Acc|Definite=Def|Gender=Masc|Number=Sing|PronType=Art	10	det	_	_
+10	Druck	Druck	NOUN	NN	Case=Acc|Gender=Masc|Number=Sing	20	obj	_	_
+11-12	zur	_	_	_	_	_	_	_	_
+11	zu	zu	ADP	APPR	_	14	case	_	_
+12	der	der	DET	ART	Case=Dat|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	14	det	_	_
+13	internen	intern	ADJ	ADJA	Case=Dat|Gender=Fem|Number=Sing	14	amod	_	_
+14	Liberalisierung	Liberalisierung	NOUN	NN	Case=Dat|Gender=Fem|Number=Sing	10	nmod	_	_
+15	beziehungsweise	beziehungsweise	CCONJ	KON	_	16	cc	_	_
+16	Deregulierung	Deregulierung	NOUN	NN	Case=Dat|Gender=Fem|Number=Sing	14	conj	_	_
+17	innerhalb	innerhalb	ADP	APPR	_	19	case	_	_
+18	der	der	DET	ART	Case=Gen|Definite=Def|Gender=Masc|Number=Plur|PronType=Art	19	det	_	_
+19	Nationalstaaten	Nationalstaat	NOUN	NN	Case=Gen|Gender=Masc|Number=Plur	20	obl	_	_
+20	verstärken	verstärken	VERB	VVINF	VerbForm=Inf	0	root	_	SpaceAfter=No
+21	.	.	PUNCT	$.	_	20	punct	_	_
 
 # sent_id = test-s402
 # text = Falls die Anwälte weiter so taktieren wie bisher, könnte das länger dauern.
@@ -7512,360 +7588,376 @@
 14	.	.	PUNCT	$.	_	13	punct	_	_
 
 # sent_id = test-s403
-# text = FDP hat erst zugestimmt und will jetzt nichts mehr damit zu tun haben.
-1	FDP	FDP	PROPN	NE	Case=Nom|Gender=Fem|Number=Sing	4	nsubj	_	_
-2	hat	haben	AUX	VAFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	4	aux	_	_
-3	erst	erst	ADV	ADV	_	4	advmod	_	_
-4	zugestimmt	zustimmen	VERB	VVPP	VerbForm=Part	0	root	_	_
-5	und	und	CCONJ	KON	_	13	cc	_	_
-6	will	wollen	AUX	VMFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	13	aux	_	_
-7	jetzt	jetzt	ADV	ADV	_	13	advmod	_	_
-8	nichts	nichts	PRON	PIS	Definite=Ind|Gender=Neut|PronType=Ind	13	obj	_	_
-9	mehr	mehr	ADV	ADV	_	8	advmod	_	_
-10	damit	damit	ADV	PAV	_	12	advmod	_	_
-11	zu	zu	PART	PTKZU	_	12	mark	_	_
-12	tun	tun	VERB	VVINF	VerbForm=Inf	13	acl	_	_
-13	haben	haben	AUX	VAINF	VerbForm=Inf	4	conj	_	SpaceAfter=No
-14	.	.	PUNCT	$.	_	4	punct	_	_
+# text = Die FDP hat erst zugestimmt und will jetzt nichts mehr damit zu tun haben.
+1	Die	der	DET	ART	Case=Nom|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	2	dep	_	FixTigerDep=Yes
+2	FDP	FDP	PROPN	NE	Case=Nom|Gender=Fem|Number=Sing	5	nsubj	_	_
+3	hat	haben	AUX	VAFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	5	aux	_	_
+4	erst	erst	ADV	ADV	_	5	advmod	_	_
+5	zugestimmt	zustimmen	VERB	VVPP	VerbForm=Part	0	root	_	_
+6	und	und	CCONJ	KON	_	14	cc	_	_
+7	will	wollen	AUX	VMFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	14	aux	_	_
+8	jetzt	jetzt	ADV	ADV	_	14	advmod	_	_
+9	nichts	nichts	PRON	PIS	Definite=Ind|Gender=Neut|PronType=Ind	14	obj	_	_
+10	mehr	mehr	ADV	ADV	_	9	advmod	_	_
+11	damit	damit	ADV	PAV	_	13	advmod	_	_
+12	zu	zu	PART	PTKZU	_	13	mark	_	_
+13	tun	tun	VERB	VVINF	VerbForm=Inf	14	acl	_	_
+14	haben	haben	AUX	VAINF	VerbForm=Inf	5	conj	_	SpaceAfter=No
+15	.	.	PUNCT	$.	_	5	punct	_	_
 
 # sent_id = test-s404
-# text = FDP werde sich an weiteren Verhandlungen über die Kostendeckung nicht beteiligen.
-1	FDP	FDP	PROPN	NE	Case=Nom|Gender=Fem|Number=Sing	11	nsubj	_	_
-2	werde	werden	AUX	VAFIN	Mood=Sub|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	11	aux	_	_
-3	sich	er|es|sie	PRON	PRF	Case=Acc|Number=Sing|Person=3|PronType=Prs|Reflex=Yes	11	obj	_	_
-4	an	an	ADP	APPR	_	11	det	_	_
-5	weiteren	weit	ADJ	ADJA	Case=Dat|Gender=Fem|Number=Plur	6	amod	_	_
-6	Verhandlungen	Verhandlung	NOUN	NN	Case=Dat|Gender=Fem|Number=Plur	4	obj	_	_
-7	über	über	ADP	APPR	_	9	case	_	_
-8	die	der	DET	ART	Case=Acc|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	9	det	_	_
-9	Kostendeckung	Kostendeckung	NOUN	NN	Case=Acc|Gender=Fem|Number=Sing	6	nmod	_	_
-10	nicht	nicht	PART	PTKNEG	Polarity=Neg	11	advmod	_	_
-11	beteiligen	beteiligen	VERB	VVINF	VerbForm=Inf	0	root	_	SpaceAfter=No
-12	.	.	PUNCT	$.	_	11	punct	_	_
+# text = Die FDP werde sich an weiteren Verhandlungen über die Kostendeckung nicht beteiligen.
+1	Die	der	DET	ART	Case=Nom|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	2	dep	_	FixTigerDep=Yes
+2	FDP	FDP	PROPN	NE	Case=Nom|Gender=Fem|Number=Sing	12	nsubj	_	_
+3	werde	werden	AUX	VAFIN	Mood=Sub|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	12	aux	_	_
+4	sich	er|es|sie	PRON	PRF	Case=Acc|Number=Sing|Person=3|PronType=Prs|Reflex=Yes	12	obj	_	_
+5	an	an	ADP	APPR	_	12	det	_	_
+6	weiteren	weit	ADJ	ADJA	Case=Dat|Gender=Fem|Number=Plur	7	amod	_	_
+7	Verhandlungen	Verhandlung	NOUN	NN	Case=Dat|Gender=Fem|Number=Plur	5	obj	_	_
+8	über	über	ADP	APPR	_	10	case	_	_
+9	die	der	DET	ART	Case=Acc|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	10	det	_	_
+10	Kostendeckung	Kostendeckung	NOUN	NN	Case=Acc|Gender=Fem|Number=Sing	7	nmod	_	_
+11	nicht	nicht	PART	PTKNEG	Polarity=Neg	12	advmod	_	_
+12	beteiligen	beteiligen	VERB	VVINF	VerbForm=Inf	0	root	_	SpaceAfter=No
+13	.	.	PUNCT	$.	_	12	punct	_	_
 
 # sent_id = test-s405
-# text = Fernfahrer diskutierten über den Kompromiß, und ihr Verband hielt den Streikaufruf aufrecht, weil er grundsätzlich jedes Strafpunktesystem mit Führerscheinentzug ablehnt.
-1	Fernfahrer	Fernfahrer	NOUN	NN	Case=Nom|Gender=Masc|Number=Plur	2	nsubj	_	_
-2	diskutierten	diskutieren	VERB	VVFIN	Mood=Ind|Number=Plur|Person=3|Tense=Past|VerbForm=Fin	0	root	_	_
-3	über	über	ADP	APPR	_	5	case	_	_
-4	den	der	DET	ART	Case=Acc|Definite=Def|Gender=Masc|Number=Sing|PronType=Art	5	det	_	_
-5	Kompromiß	Kompromiß	NOUN	NN	Case=Acc|Gender=Masc|Number=Sing	2	obl	_	SpaceAfter=No
-6	,	,	PUNCT	$,	_	10	punct	_	_
-7	und	und	CCONJ	KON	_	10	cc	_	_
-8	ihr	ihr	PRON	PPOSAT	Case=Nom|Gender=Masc|Number=Sing|Poss=Yes	9	det:poss	_	_
-9	Verband	Verband	NOUN	NN	Case=Nom|Gender=Masc|Number=Sing	10	nsubj	_	_
-10	hielt	halten	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	2	conj	_	_
-11	den	der	DET	ART	Case=Acc|Definite=Def|Gender=Masc|Number=Sing|PronType=Art	12	det	_	_
-12	Streikaufruf	Streikaufruf	NOUN	NN	Case=Acc|Gender=Masc|Number=Sing	10	obj	_	_
-13	aufrecht	aufrecht	ADV	PTKVZ	_	10	compound:prt	_	SpaceAfter=No
-14	,	,	PUNCT	$,	_	2	punct	_	_
-15	weil	weil	SCONJ	KOUS	_	22	mark	_	_
-16	er	er	PRON	PPER	Case=Nom|Gender=Masc|Number=Sing|Person=3|PronType=Prs	22	nsubj	_	_
-17	grundsätzlich	grundsätzlich	ADV	ADJD	_	22	advmod	_	_
-18	jedes	jed	PRON	PIAT	Case=Acc|Definite=Ind|Gender=Neut|Number=Sing|PronType=Ind	19	det	_	_
-19	Strafpunktesystem	Strafpunktesystem	NOUN	NN	Case=Acc|Gender=Neut|Number=Sing	22	obj	_	_
-20	mit	mit	ADP	APPR	_	21	case	_	_
-21	Führerscheinentzug	Führerscheinentzug	NOUN	NN	Case=Dat|Gender=Masc|Number=Sing	19	nmod	_	_
-22	ablehnt	ablehnen	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	10	advcl	_	SpaceAfter=No
-23	.	.	PUNCT	$.	_	2	punct	_	_
+# text = Die Fernfahrer diskutierten über den Kompromiß, und ihr Verband hielt den Streikaufruf aufrecht, weil er grundsätzlich jedes Strafpunktesystem mit Führerscheinentzug ablehnt.
+1	Die	der	DET	ART	Case=Nom|Definite=Def|Gender=Masc|Number=Plur|PronType=Art	2	dep	_	FixTigerDep=Yes
+2	Fernfahrer	Fernfahrer	NOUN	NN	Case=Nom|Gender=Masc|Number=Plur	3	nsubj	_	_
+3	diskutierten	diskutieren	VERB	VVFIN	Mood=Ind|Number=Plur|Person=3|Tense=Past|VerbForm=Fin	0	root	_	_
+4	über	über	ADP	APPR	_	6	case	_	_
+5	den	der	DET	ART	Case=Acc|Definite=Def|Gender=Masc|Number=Sing|PronType=Art	6	det	_	_
+6	Kompromiß	Kompromiß	NOUN	NN	Case=Acc|Gender=Masc|Number=Sing	3	obl	_	SpaceAfter=No
+7	,	,	PUNCT	$,	_	11	punct	_	_
+8	und	und	CCONJ	KON	_	11	cc	_	_
+9	ihr	ihr	PRON	PPOSAT	Case=Nom|Gender=Masc|Number=Sing|Poss=Yes	10	det:poss	_	_
+10	Verband	Verband	NOUN	NN	Case=Nom|Gender=Masc|Number=Sing	11	nsubj	_	_
+11	hielt	halten	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	3	conj	_	_
+12	den	der	DET	ART	Case=Acc|Definite=Def|Gender=Masc|Number=Sing|PronType=Art	13	det	_	_
+13	Streikaufruf	Streikaufruf	NOUN	NN	Case=Acc|Gender=Masc|Number=Sing	11	obj	_	_
+14	aufrecht	aufrecht	ADV	PTKVZ	_	11	compound:prt	_	SpaceAfter=No
+15	,	,	PUNCT	$,	_	3	punct	_	_
+16	weil	weil	SCONJ	KOUS	_	23	mark	_	_
+17	er	er	PRON	PPER	Case=Nom|Gender=Masc|Number=Sing|Person=3|PronType=Prs	23	nsubj	_	_
+18	grundsätzlich	grundsätzlich	ADV	ADJD	_	23	advmod	_	_
+19	jedes	jed	PRON	PIAT	Case=Acc|Definite=Ind|Gender=Neut|Number=Sing|PronType=Ind	20	det	_	_
+20	Strafpunktesystem	Strafpunktesystem	NOUN	NN	Case=Acc|Gender=Neut|Number=Sing	23	obj	_	_
+21	mit	mit	ADP	APPR	_	22	case	_	_
+22	Führerscheinentzug	Führerscheinentzug	NOUN	NN	Case=Dat|Gender=Masc|Number=Sing	20	nmod	_	_
+23	ablehnt	ablehnen	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	11	advcl	_	SpaceAfter=No
+24	.	.	PUNCT	$.	_	3	punct	_	_
 
 # sent_id = test-s406
-# text = Finanzierung des Geschäfts soll bereits gesichert sein.
-1	Finanzierung	Finanzierung	NOUN	NN	Case=Nom|Gender=Fem|Number=Sing	6	nsubj:pass	_	_
-2	des	der	DET	ART	Case=Gen|Definite=Def|Gender=Neut|Number=Sing|PronType=Art	3	det	_	_
-3	Geschäfts	Geschäft	NOUN	NN	Case=Gen|Gender=Neut|Number=Sing	1	nmod	_	_
-4	soll	sollen	AUX	VMFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	6	aux	_	_
-5	bereits	bereits	ADV	ADV	_	6	advmod	_	_
-6	gesichert	sichern	VERB	VVPP	VerbForm=Part	0	root	_	_
-7	sein	sein	AUX	VAINF	VerbForm=Inf	6	aux:pass	_	SpaceAfter=No
-8	.	.	PUNCT	$.	_	6	punct	_	_
+# text = Die Finanzierung des Geschäfts soll bereits gesichert sein.
+1	Die	der	DET	ART	Case=Nom|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	2	dep	_	FixTigerDep=Yes
+2	Finanzierung	Finanzierung	NOUN	NN	Case=Nom|Gender=Fem|Number=Sing	7	nsubj:pass	_	_
+3	des	der	DET	ART	Case=Gen|Definite=Def|Gender=Neut|Number=Sing|PronType=Art	4	det	_	_
+4	Geschäfts	Geschäft	NOUN	NN	Case=Gen|Gender=Neut|Number=Sing	2	nmod	_	_
+5	soll	sollen	AUX	VMFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	7	aux	_	_
+6	bereits	bereits	ADV	ADV	_	7	advmod	_	_
+7	gesichert	sichern	VERB	VVPP	VerbForm=Part	0	root	_	_
+8	sein	sein	AUX	VAINF	VerbForm=Inf	7	aux:pass	_	SpaceAfter=No
+9	.	.	PUNCT	$.	_	7	punct	_	_
 
 # sent_id = test-s407
-# text = Finanzriese Christiania scheitert nur knapp
-1	Finanzriese	Finanzriese	NOUN	NN	Case=Nom|Gender=Masc|Number=Sing	3	nsubj	_	_
-2	Christiania	Christiania	PROPN	NE	Case=Nom|Number=Sing	1	appos	_	_
-3	scheitert	scheitern	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	0	root	_	_
-4	nur	nur	ADV	ADV	_	5	advmod	_	_
-5	knapp	knapp	ADV	ADJD	_	3	advmod	_	_
+# text = Norwegens Finanzriese Christiania scheitert nur knapp
+1	Norwegens	Norwegen	PROPN	NE	Case=Gen|Gender=Neut|Number=Sing	2	dep	_	FixTigerDep=Yes
+2	Finanzriese	Finanzriese	NOUN	NN	Case=Nom|Gender=Masc|Number=Sing	4	nsubj	_	_
+3	Christiania	Christiania	PROPN	NE	Case=Nom|Number=Sing	2	appos	_	_
+4	scheitert	scheitern	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	0	root	_	_
+5	nur	nur	ADV	ADV	_	6	advmod	_	_
+6	knapp	knapp	ADV	ADJD	_	4	advmod	_	_
 
 # sent_id = test-s408
-# text = Flugzeug mit sechs Offizieren und 13 Soldaten der Luftwaffe an Bord transportierte Treibstoff, Waffen und Munition von der Hauptstadt Colombo zum Stützpunkt Palay auf der Halbinsel Jaffna, der Hochburg der aufständischen Tamilen.
-1	Flugzeug	Flugzeug	NOUN	NN	Case=Nom|Gender=Neut|Number=Sing	12	nsubj	_	_
-2	mit	mit	ADP	APPR	_	4	case	_	_
-3	sechs	sechs	NUM	CARD	NumType=Card	4	nummod	_	_
-4	Offizieren	Offizier	NOUN	NN	Case=Dat|Gender=Masc|Number=Plur	1	nmod	_	_
-5	und	und	CCONJ	KON	_	7	cc	_	_
-6	13	13	NUM	CARD	NumType=Card	7	nummod	_	_
-7	Soldaten	Soldat	NOUN	NN	Case=Dat|Gender=Masc|Number=Plur	4	conj	_	_
-8	der	der	DET	ART	Case=Gen|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	9	det	_	_
-9	Luftwaffe	Luftwaffe	NOUN	NN	Case=Gen|Gender=Fem|Number=Sing	7	nmod	_	_
-10	an	an	ADP	APPR	_	11	case	_	_
-11	Bord	Bord	NOUN	NN	Case=Dat|Gender=Neut|Number=Sing	4	nmod	_	_
-12	transportierte	transportieren	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	0	root	_	_
-13	Treibstoff	Treibstoff	NOUN	NN	Case=Acc|Gender=Masc|Number=Sing	12	obj	_	SpaceAfter=No
-14	,	,	PUNCT	$,	_	15	punct	_	_
-15	Waffen	Waffe	NOUN	NN	Case=Acc|Gender=Fem|Number=Plur	13	conj	_	_
-16	und	und	CCONJ	KON	_	17	cc	_	_
-17	Munition	Munition	NOUN	NN	Case=Acc|Gender=Fem|Number=Sing	13	conj	_	_
-18	von	von	ADP	APPR	_	20	case	_	_
-19	der	der	DET	ART	Case=Dat|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	20	det	_	_
-20	Hauptstadt	Hauptstadt	NOUN	NN	Case=Dat|Gender=Fem|Number=Sing	12	obl	_	_
-21	Colombo	Colombo	PROPN	NE	Case=Nom|Gender=Neut|Number=Sing	20	appos	_	_
-22-23	zum	_	_	_	_	_	_	_	_
-22	zu	zu	ADP	APPR	_	24	case	_	_
-23	dem	der	DET	ART	Case=Dat|Definite=Def|Gender=Masc|Number=Sing|PronType=Art	24	det	_	_
-24	Stützpunkt	Stützpunkt	NOUN	NN	Case=Dat|Gender=Masc|Number=Sing	12	obl	_	_
-25	Palay	Palay	PROPN	NE	Case=Nom|Number=Sing	24	appos	_	_
-26	auf	auf	ADP	APPR	_	28	case	_	_
-27	der	der	DET	ART	Case=Dat|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	28	det	_	_
-28	Halbinsel	Halbinsel	NOUN	NN	Case=Dat|Gender=Fem|Number=Sing	24	nmod	_	_
-29	Jaffna	Jaffna	PROPN	NE	Case=Nom|Gender=Neut|Number=Sing	28	appos	_	SpaceAfter=No
-30	,	,	PUNCT	$,	_	12	punct	_	_
-31	der	der	DET	ART	Case=Dat|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	32	det	_	_
-32	Hochburg	Hochburg	NOUN	NN	Case=Dat|Gender=Fem|Number=Sing	28	appos	_	_
-33	der	der	DET	ART	Case=Gen|Definite=Def|Gender=Masc|Number=Plur|PronType=Art	35	det	_	_
-34	aufständischen	aufständisch	ADJ	ADJA	Case=Gen|Gender=Masc|Number=Plur	35	amod	_	_
-35	Tamilen	Tamile	PROPN	NN	Case=Gen|Gender=Masc|Number=Plur	32	nmod	_	SpaceAfter=No
-36	.	.	PUNCT	$.	_	12	punct	_	_
+# text = Das Flugzeug mit sechs Offizieren und 13 Soldaten der Luftwaffe an Bord transportierte Treibstoff, Waffen und Munition von der Hauptstadt Colombo zum Stützpunkt Palay auf der Halbinsel Jaffna, der Hochburg der aufständischen Tamilen.
+1	Das	der	DET	ART	Case=Nom|Definite=Def|Gender=Neut|Number=Sing|PronType=Art	2	dep	_	FixTigerDep=Yes
+2	Flugzeug	Flugzeug	NOUN	NN	Case=Nom|Gender=Neut|Number=Sing	13	nsubj	_	_
+3	mit	mit	ADP	APPR	_	5	case	_	_
+4	sechs	sechs	NUM	CARD	NumType=Card	5	nummod	_	_
+5	Offizieren	Offizier	NOUN	NN	Case=Dat|Gender=Masc|Number=Plur	2	nmod	_	_
+6	und	und	CCONJ	KON	_	8	cc	_	_
+7	13	13	NUM	CARD	NumType=Card	8	nummod	_	_
+8	Soldaten	Soldat	NOUN	NN	Case=Dat|Gender=Masc|Number=Plur	5	conj	_	_
+9	der	der	DET	ART	Case=Gen|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	10	det	_	_
+10	Luftwaffe	Luftwaffe	NOUN	NN	Case=Gen|Gender=Fem|Number=Sing	8	nmod	_	_
+11	an	an	ADP	APPR	_	12	case	_	_
+12	Bord	Bord	NOUN	NN	Case=Dat|Gender=Neut|Number=Sing	5	nmod	_	_
+13	transportierte	transportieren	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	0	root	_	_
+14	Treibstoff	Treibstoff	NOUN	NN	Case=Acc|Gender=Masc|Number=Sing	13	obj	_	SpaceAfter=No
+15	,	,	PUNCT	$,	_	16	punct	_	_
+16	Waffen	Waffe	NOUN	NN	Case=Acc|Gender=Fem|Number=Plur	14	conj	_	_
+17	und	und	CCONJ	KON	_	18	cc	_	_
+18	Munition	Munition	NOUN	NN	Case=Acc|Gender=Fem|Number=Sing	14	conj	_	_
+19	von	von	ADP	APPR	_	21	case	_	_
+20	der	der	DET	ART	Case=Dat|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	21	det	_	_
+21	Hauptstadt	Hauptstadt	NOUN	NN	Case=Dat|Gender=Fem|Number=Sing	13	obl	_	_
+22	Colombo	Colombo	PROPN	NE	Case=Nom|Gender=Neut|Number=Sing	21	appos	_	_
+23-24	zum	_	_	_	_	_	_	_	_
+23	zu	zu	ADP	APPR	_	25	case	_	_
+24	dem	der	DET	ART	Case=Dat|Definite=Def|Gender=Masc|Number=Sing|PronType=Art	25	det	_	_
+25	Stützpunkt	Stützpunkt	NOUN	NN	Case=Dat|Gender=Masc|Number=Sing	13	obl	_	_
+26	Palay	Palay	PROPN	NE	Case=Nom|Number=Sing	25	appos	_	_
+27	auf	auf	ADP	APPR	_	29	case	_	_
+28	der	der	DET	ART	Case=Dat|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	29	det	_	_
+29	Halbinsel	Halbinsel	NOUN	NN	Case=Dat|Gender=Fem|Number=Sing	25	nmod	_	_
+30	Jaffna	Jaffna	PROPN	NE	Case=Nom|Gender=Neut|Number=Sing	29	appos	_	SpaceAfter=No
+31	,	,	PUNCT	$,	_	13	punct	_	_
+32	der	der	DET	ART	Case=Dat|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	33	det	_	_
+33	Hochburg	Hochburg	NOUN	NN	Case=Dat|Gender=Fem|Number=Sing	29	appos	_	_
+34	der	der	DET	ART	Case=Gen|Definite=Def|Gender=Masc|Number=Plur|PronType=Art	36	det	_	_
+35	aufständischen	aufständisch	ADJ	ADJA	Case=Gen|Gender=Masc|Number=Plur	36	amod	_	_
+36	Tamilen	Tamile	PROPN	NN	Case=Gen|Gender=Masc|Number=Plur	33	nmod	_	SpaceAfter=No
+37	.	.	PUNCT	$.	_	13	punct	_	_
 
 # sent_id = test-s409
-# text = Formulierung stößt auf Widerspruch bei Heidemarie Wieczorek-Zeul und Oskar Lafontaine.
-1	Formulierung	Formulierung	NOUN	NN	Case=Nom|Gender=Fem|Number=Sing	2	nsubj	_	_
-2	stößt	stoßen	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	0	root	_	_
-3	auf	auf	ADP	APPR	_	4	case	_	_
-4	Widerspruch	Widerspruch	NOUN	NN	Case=Acc|Gender=Masc|Number=Sing	2	obl	_	_
-5	bei	bei	ADP	APPR	_	6	case	_	_
-6	Heidemarie	Heidemarie	PROPN	NE	Case=Nom|Gender=Fem|Number=Sing	4	nmod	_	_
-7	Wieczorek	Wieczorek	PROPN	NE	Case=Dat|Gender=Fem|Number=Sing	6	flat	_	SpaceAfter=No
-8	-	-	PUNCT	$(	_	7	punct	_	SpaceAfter=No
-9	Zeul	Zeul	PROPN	NE	Case=Dat|Gender=Fem|Number=Sing	6	flat	_	_
-10	und	und	CCONJ	KON	_	11	cc	_	_
-11	Oskar	Oskar	PROPN	NE	Case=Nom|Gender=Masc|Number=Sing	6	conj	_	_
-12	Lafontaine	Lafontaine	PROPN	NE	Case=Dat|Gender=Masc|Number=Sing	11	flat	_	SpaceAfter=No
-13	.	.	PUNCT	$.	_	2	punct	_	_
+# text = Diese Formulierung stößt auf Widerspruch bei Heidemarie Wieczorek-Zeul und Oskar Lafontaine.
+1	Diese	dies	DET	PDAT	Case=Nom|Gender=Fem|Number=Sing|PronType=Dem	2	dep	_	FixTigerDep=Yes
+2	Formulierung	Formulierung	NOUN	NN	Case=Nom|Gender=Fem|Number=Sing	3	nsubj	_	_
+3	stößt	stoßen	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	0	root	_	_
+4	auf	auf	ADP	APPR	_	5	case	_	_
+5	Widerspruch	Widerspruch	NOUN	NN	Case=Acc|Gender=Masc|Number=Sing	3	obl	_	_
+6	bei	bei	ADP	APPR	_	7	case	_	_
+7	Heidemarie	Heidemarie	PROPN	NE	Case=Nom|Gender=Fem|Number=Sing	5	nmod	_	_
+8	Wieczorek	Wieczorek	PROPN	NE	Case=Dat|Gender=Fem|Number=Sing	7	flat	_	SpaceAfter=No
+9	-	-	PUNCT	$(	_	8	punct	_	SpaceAfter=No
+10	Zeul	Zeul	PROPN	NE	Case=Dat|Gender=Fem|Number=Sing	7	flat	_	_
+11	und	und	CCONJ	KON	_	12	cc	_	_
+12	Oskar	Oskar	PROPN	NE	Case=Nom|Gender=Masc|Number=Sing	7	conj	_	_
+13	Lafontaine	Lafontaine	PROPN	NE	Case=Dat|Gender=Masc|Number=Sing	12	flat	_	SpaceAfter=No
+14	.	.	PUNCT	$.	_	3	punct	_	_
 
 # sent_id = test-s410
-# text = Franzose, der über seine Firma Bernard Tapie Finance Mehrheitsgesellschafter des nordbayerischen Unternehmens ist, ging auf die angeblich mit einer Milliarde Mark dotierte Offerte nicht ein.
-1	Franzose	Franzose	NOUN	NN	Case=Nom|Gender=Masc|Number=Sing	16	nsubj	_	SpaceAfter=No
-2	,	,	PUNCT	$,	_	16	punct	_	_
-3	der	der	DET	PRELS	Case=Nom|Gender=Masc|Number=Sing|PronType=Rel	10	nsubj	_	_
-4	über	über	ADP	APPR	_	6	case	_	_
-5	seine	sein	PRON	PPOSAT	Case=Acc|Gender=Fem|Number=Sing|Poss=Yes	6	det:poss	_	_
-6	Firma	Firma	NOUN	NN	Case=Acc|Gender=Fem|Number=Sing	10	nmod	_	_
-7	Bernard	Bernard	PROPN	NE	Gender=Masc	6	appos	_	_
-8	Tapie	Tapie	PROPN	NE	Gender=Masc	7	flat	_	_
-9	Finance	Finance	PROPN	NE	Case=Nom|Number=Sing	7	flat	_	_
-10	Mehrheitsgesellschafter	Mehrheitsgesellschafter	NOUN	NN	Case=Nom|Gender=Masc|Number=Sing	1	acl	_	_
-11	des	der	DET	ART	Case=Gen|Definite=Def|Gender=Neut|Number=Sing|PronType=Art	13	det	_	_
-12	nordbayerischen	nordbayerisch	ADJ	ADJA	Case=Gen|Gender=Neut|Number=Sing	13	amod	_	_
-13	Unternehmens	Unternehmen	NOUN	NN	Case=Gen|Gender=Neut|Number=Sing	10	nmod	_	_
-14	ist	sein	AUX	VAFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	10	cop	_	SpaceAfter=No
-15	,	,	PUNCT	$,	_	16	punct	_	_
-16	ging	gehen	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	0	root	_	_
-17	auf	auf	ADP	APPR	_	25	case	_	_
-18	die	der	DET	ART	Case=Acc|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	25	det	_	_
-19	angeblich	angeblich	ADV	ADJD	_	23	advmod	_	_
-20	mit	mit	ADP	APPR	_	23	case	_	_
-21	einer	ein	NUM	ART	Case=Dat|Definite=Ind|Gender=Fem|Number=Sing|PronType=Art	22	nummod	_	_
-22	Milliarde	Milliarde	NUM	NN	Case=Dat|Gender=Fem|Number=Sing	23	nummod	_	_
-23	Mark	Mark	NOUN	NN	Case=Dat|Gender=Fem|Number=Sing	24	nmod	_	_
-24	dotierte	dotiert	ADJ	ADJA	Case=Acc|Gender=Fem|Number=Sing	25	amod	_	_
-25	Offerte	Offerte	NOUN	NN	Case=Acc|Gender=Fem|Number=Sing	16	obl	_	_
-26	nicht	nicht	PART	PTKNEG	Polarity=Neg	16	advmod	_	_
-27	ein	ein	ADV	PTKVZ	_	16	compound:prt	_	SpaceAfter=No
-28	.	.	PUNCT	$.	_	16	punct	_	_
+# text = Der Franzose, der über seine Firma Bernard Tapie Finance Mehrheitsgesellschafter des nordbayerischen Unternehmens ist, ging auf die angeblich mit einer Milliarde Mark dotierte Offerte nicht ein.
+1	Der	der	DET	ART	Case=Nom|Definite=Def|Gender=Masc|Number=Sing|PronType=Art	2	dep	_	FixTigerDep=Yes
+2	Franzose	Franzose	NOUN	NN	Case=Nom|Gender=Masc|Number=Sing	17	nsubj	_	SpaceAfter=No
+3	,	,	PUNCT	$,	_	17	punct	_	_
+4	der	der	DET	PRELS	Case=Nom|Gender=Masc|Number=Sing|PronType=Rel	11	nsubj	_	_
+5	über	über	ADP	APPR	_	7	case	_	_
+6	seine	sein	PRON	PPOSAT	Case=Acc|Gender=Fem|Number=Sing|Poss=Yes	7	det:poss	_	_
+7	Firma	Firma	NOUN	NN	Case=Acc|Gender=Fem|Number=Sing	11	nmod	_	_
+8	Bernard	Bernard	PROPN	NE	Gender=Masc	7	appos	_	_
+9	Tapie	Tapie	PROPN	NE	Gender=Masc	8	flat	_	_
+10	Finance	Finance	PROPN	NE	Case=Nom|Number=Sing	8	flat	_	_
+11	Mehrheitsgesellschafter	Mehrheitsgesellschafter	NOUN	NN	Case=Nom|Gender=Masc|Number=Sing	2	acl	_	_
+12	des	der	DET	ART	Case=Gen|Definite=Def|Gender=Neut|Number=Sing|PronType=Art	14	det	_	_
+13	nordbayerischen	nordbayerisch	ADJ	ADJA	Case=Gen|Gender=Neut|Number=Sing	14	amod	_	_
+14	Unternehmens	Unternehmen	NOUN	NN	Case=Gen|Gender=Neut|Number=Sing	11	nmod	_	_
+15	ist	sein	AUX	VAFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	11	cop	_	SpaceAfter=No
+16	,	,	PUNCT	$,	_	17	punct	_	_
+17	ging	gehen	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	0	root	_	_
+18	auf	auf	ADP	APPR	_	26	case	_	_
+19	die	der	DET	ART	Case=Acc|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	26	det	_	_
+20	angeblich	angeblich	ADV	ADJD	_	24	advmod	_	_
+21	mit	mit	ADP	APPR	_	24	case	_	_
+22	einer	ein	NUM	ART	Case=Dat|Definite=Ind|Gender=Fem|Number=Sing|PronType=Art	23	nummod	_	_
+23	Milliarde	Milliarde	NUM	NN	Case=Dat|Gender=Fem|Number=Sing	24	nummod	_	_
+24	Mark	Mark	NOUN	NN	Case=Dat|Gender=Fem|Number=Sing	25	nmod	_	_
+25	dotierte	dotiert	ADJ	ADJA	Case=Acc|Gender=Fem|Number=Sing	26	amod	_	_
+26	Offerte	Offerte	NOUN	NN	Case=Acc|Gender=Fem|Number=Sing	17	obl	_	_
+27	nicht	nicht	PART	PTKNEG	Polarity=Neg	17	advmod	_	_
+28	ein	ein	ADV	PTKVZ	_	17	compound:prt	_	SpaceAfter=No
+29	.	.	PUNCT	$.	_	17	punct	_	_
 
 # sent_id = test-s411
-# text = Franzosen hatten in zahlreichen Konferenzen der EU-Mitgliedsstaaten in New York und anderen Städten versucht, in der UN-Abstimmung ``europäische Solidarität'' einzufordern, hatten damit aber nur begrenzten Erfolg.
-1	Franzosen	Franzose	NOUN	NN	Case=Nom|Gender=Masc|Number=Plur	16	nsubj	_	_
-2	hatten	haben	AUX	VAFIN	Mood=Ind|Number=Plur|Person=3|Tense=Past|VerbForm=Fin	16	aux	_	_
-3	in	in	ADP	APPR	_	5	case	_	_
-4	zahlreichen	zahlreich	ADJ	ADJA	Case=Dat|Gender=Fem|Number=Plur	5	amod	_	_
-5	Konferenzen	Konferenz	NOUN	NN	Case=Dat|Gender=Fem|Number=Plur	16	obl	_	_
-6	der	der	DET	ART	Case=Gen|Definite=Def|Gender=Masc|Number=Plur|PronType=Art	7	det	_	_
-7	EU	EU	PROPN	NN	Case=Gen|Gender=Masc|Number=Plur	9	compound	_	SpaceAfter=No
-8	-	-	PUNCT	$(	_	7	punct	_	SpaceAfter=No
-9	Mitgliedsstaaten	Mitgliedsstaat	NOUN	NN	Case=Gen|Gender=Masc|Number=Plur	5	nmod	_	_
-10	in	in	ADP	APPR	_	11	case	_	_
-11	New	New	PROPN	NE	_	5	nmod	_	_
-12	York	York	PROPN	NE	Case=Dat|Gender=Neut|Number=Sing	11	flat	_	_
-13	und	und	CCONJ	KON	_	15	cc	_	_
-14	anderen	anderer	ADJ	ADJA	Case=Dat|Gender=Fem|Number=Plur	15	amod	_	_
-15	Städten	Stadt	NOUN	NN	Case=Dat|Gender=Fem|Number=Plur	11	conj	_	_
-16	versucht	versuchen	VERB	VVPP	VerbForm=Part	0	root	_	SpaceAfter=No
-17	,	,	PUNCT	$,	_	16	punct	_	_
-18	in	in	ADP	APPR	_	22	case	_	_
-19	der	der	DET	ART	Case=Dat|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	22	det	_	_
-20	UN	UN	PROPN	NN	Case=Dat|Gender=Fem|Number=Sing	22	compound	_	SpaceAfter=No
-21	-	-	PUNCT	$(	_	20	punct	_	SpaceAfter=No
-22	Abstimmung	Abstimmung	NOUN	NN	Case=Dat|Gender=Fem|Number=Sing	27	obl	_	_
-23	``	``	PUNCT	$(	_	22	punct	_	SpaceAfter=No
-24	europäische	europäisch	ADJ	ADJA	Case=Acc|Gender=Fem|Number=Sing	25	amod	_	_
-25	Solidarität	Solidarität	NOUN	NN	Case=Acc|Gender=Fem|Number=Sing	27	obj	_	SpaceAfter=No
-26	''	''	PUNCT	$(	_	22	punct	_	_
-27	einzufordern	einfordern	VERB	VVIZU	VerbForm=Inf	16	xcomp	_	SpaceAfter=No
-28	,	,	PUNCT	$,	_	16	punct	_	_
-29	hatten	haben	VERB	VAFIN	Mood=Ind|Number=Plur|Person=3|Tense=Past|VerbForm=Fin	16	parataxis	_	_
-30	damit	damit	ADV	PAV	_	29	advmod	_	_
-31	aber	aber	ADV	ADV	_	29	advmod	_	_
-32	nur	nur	ADV	ADV	_	33	advmod	_	_
-33	begrenzten	begrenzt	ADJ	ADJA	Case=Acc|Gender=Masc|Number=Sing	34	amod	_	_
-34	Erfolg	Erfolg	NOUN	NN	Case=Acc|Gender=Masc|Number=Sing	29	obj	_	SpaceAfter=No
-35	.	.	PUNCT	$.	_	16	punct	_	_
+# text = Die Franzosen hatten in zahlreichen Konferenzen der EU-Mitgliedsstaaten in New York und anderen Städten versucht, in der UN-Abstimmung ``europäische Solidarität'' einzufordern, hatten damit aber nur begrenzten Erfolg.
+1	Die	der	DET	ART	Case=Nom|Definite=Def|Gender=Masc|Number=Plur|PronType=Art	2	dep	_	FixTigerDep=Yes
+2	Franzosen	Franzose	NOUN	NN	Case=Nom|Gender=Masc|Number=Plur	17	nsubj	_	_
+3	hatten	haben	AUX	VAFIN	Mood=Ind|Number=Plur|Person=3|Tense=Past|VerbForm=Fin	17	aux	_	_
+4	in	in	ADP	APPR	_	6	case	_	_
+5	zahlreichen	zahlreich	ADJ	ADJA	Case=Dat|Gender=Fem|Number=Plur	6	amod	_	_
+6	Konferenzen	Konferenz	NOUN	NN	Case=Dat|Gender=Fem|Number=Plur	17	obl	_	_
+7	der	der	DET	ART	Case=Gen|Definite=Def|Gender=Masc|Number=Plur|PronType=Art	8	det	_	_
+8	EU	EU	PROPN	NN	Case=Gen|Gender=Masc|Number=Plur	10	compound	_	SpaceAfter=No
+9	-	-	PUNCT	$(	_	8	punct	_	SpaceAfter=No
+10	Mitgliedsstaaten	Mitgliedsstaat	NOUN	NN	Case=Gen|Gender=Masc|Number=Plur	6	nmod	_	_
+11	in	in	ADP	APPR	_	12	case	_	_
+12	New	New	PROPN	NE	_	6	nmod	_	_
+13	York	York	PROPN	NE	Case=Dat|Gender=Neut|Number=Sing	12	flat	_	_
+14	und	und	CCONJ	KON	_	16	cc	_	_
+15	anderen	anderer	ADJ	ADJA	Case=Dat|Gender=Fem|Number=Plur	16	amod	_	_
+16	Städten	Stadt	NOUN	NN	Case=Dat|Gender=Fem|Number=Plur	12	conj	_	_
+17	versucht	versuchen	VERB	VVPP	VerbForm=Part	0	root	_	SpaceAfter=No
+18	,	,	PUNCT	$,	_	17	punct	_	_
+19	in	in	ADP	APPR	_	23	case	_	_
+20	der	der	DET	ART	Case=Dat|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	23	det	_	_
+21	UN	UN	PROPN	NN	Case=Dat|Gender=Fem|Number=Sing	23	compound	_	SpaceAfter=No
+22	-	-	PUNCT	$(	_	21	punct	_	SpaceAfter=No
+23	Abstimmung	Abstimmung	NOUN	NN	Case=Dat|Gender=Fem|Number=Sing	28	obl	_	_
+24	``	``	PUNCT	$(	_	23	punct	_	SpaceAfter=No
+25	europäische	europäisch	ADJ	ADJA	Case=Acc|Gender=Fem|Number=Sing	26	amod	_	_
+26	Solidarität	Solidarität	NOUN	NN	Case=Acc|Gender=Fem|Number=Sing	28	obj	_	SpaceAfter=No
+27	''	''	PUNCT	$(	_	23	punct	_	_
+28	einzufordern	einfordern	VERB	VVIZU	VerbForm=Inf	17	xcomp	_	SpaceAfter=No
+29	,	,	PUNCT	$,	_	17	punct	_	_
+30	hatten	haben	VERB	VAFIN	Mood=Ind|Number=Plur|Person=3|Tense=Past|VerbForm=Fin	17	parataxis	_	_
+31	damit	damit	ADV	PAV	_	30	advmod	_	_
+32	aber	aber	ADV	ADV	_	30	advmod	_	_
+33	nur	nur	ADV	ADV	_	34	advmod	_	_
+34	begrenzten	begrenzt	ADJ	ADJA	Case=Acc|Gender=Masc|Number=Sing	35	amod	_	_
+35	Erfolg	Erfolg	NOUN	NN	Case=Acc|Gender=Masc|Number=Sing	30	obj	_	SpaceAfter=No
+36	.	.	PUNCT	$.	_	17	punct	_	_
 
 # sent_id = test-s412
-# text = Friedensabkommen sei nur noch eine Frage von Tagen, hieß es.
-1	Friedensabkommen	Friedensabkommen	NOUN	NN	Case=Nom|Gender=Neut|Number=Sing	6	nsubj	_	_
-2	sei	sein	AUX	VAFIN	Mood=Sub|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	6	cop	_	_
-3	nur	nur	ADV	ADV	_	6	advmod	_	_
-4	noch	noch	ADV	ADV	_	3	advmod	_	_
-5	eine	ein	DET	ART	Case=Nom|Definite=Ind|Gender=Fem|Number=Sing|PronType=Art	6	det	_	_
-6	Frage	Frage	NOUN	NN	Case=Nom|Gender=Fem|Number=Sing	10	ccomp	_	_
-7	von	von	ADP	APPR	_	8	case	_	_
-8	Tagen	Tag	NOUN	NN	Case=Dat|Gender=Masc|Number=Plur	6	nmod	_	SpaceAfter=No
-9	,	,	PUNCT	$,	_	10	punct	_	_
-10	hieß	heißen	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	0	root	_	_
-11	es	es	PRON	PPER	Case=Nom|Gender=Neut|Number=Sing|Person=3|PronType=Prs	10	nsubj	_	SpaceAfter=No
-12	.	.	PUNCT	$.	_	10	punct	_	_
+# text = Ein Friedensabkommen sei nur noch eine Frage von Tagen, hieß es.
+1	Ein	ein	DET	ART	Case=Nom|Definite=Ind|Gender=Neut|Number=Sing|PronType=Art	2	dep	_	FixTigerDep=Yes
+2	Friedensabkommen	Friedensabkommen	NOUN	NN	Case=Nom|Gender=Neut|Number=Sing	7	nsubj	_	_
+3	sei	sein	AUX	VAFIN	Mood=Sub|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	7	cop	_	_
+4	nur	nur	ADV	ADV	_	7	advmod	_	_
+5	noch	noch	ADV	ADV	_	4	advmod	_	_
+6	eine	ein	DET	ART	Case=Nom|Definite=Ind|Gender=Fem|Number=Sing|PronType=Art	7	det	_	_
+7	Frage	Frage	NOUN	NN	Case=Nom|Gender=Fem|Number=Sing	11	ccomp	_	_
+8	von	von	ADP	APPR	_	9	case	_	_
+9	Tagen	Tag	NOUN	NN	Case=Dat|Gender=Masc|Number=Plur	7	nmod	_	SpaceAfter=No
+10	,	,	PUNCT	$,	_	11	punct	_	_
+11	hieß	heißen	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	0	root	_	_
+12	es	es	PRON	PPER	Case=Nom|Gender=Neut|Number=Sing|Person=3|PronType=Prs	11	nsubj	_	SpaceAfter=No
+13	.	.	PUNCT	$.	_	11	punct	_	_
 
 # sent_id = test-s413
-# text = Friedensprozeß in Nordirland ist nach Ansicht des Sinn-Fein-Präsidenten Gerry Adams in ernster Gefahr.
-1	Friedensprozeß	Friedensprozeß	NOUN	NN	Case=Nom|Gender=Masc|Number=Sing	4	nsubj	_	_
-2	in	in	ADP	APPR	_	3	case	_	_
-3	Nordirland	Nordirland	PROPN	NE	Case=Dat|Gender=Neut|Number=Sing	1	nmod	_	_
-4	ist	sein	VERB	VAFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	0	root	_	_
-5	nach	nach	ADP	APPR	_	6	case	_	_
-6	Ansicht	Ansicht	NOUN	NN	Case=Dat|Gender=Fem|Number=Sing	4	obl	_	_
-7	des	der	DET	ART	Case=Gen|Definite=Def|Gender=Masc|Number=Sing|PronType=Art	8	det	_	_
-8	Sinn	Sinn	PROPN	NN	Case=Gen|Gender=Masc|Number=Sing	10	compound	_	SpaceAfter=No
-9	-	-	PUNCT	$(	_	8	punct	_	SpaceAfter=No
-10	Fein	Fein	PROPN	NN	Case=Gen|Gender=Masc|Number=Sing	12	compound	_	SpaceAfter=No
-11	-	-	PUNCT	$(	_	10	punct	_	SpaceAfter=No
-12	Präsidenten	Präsident	NOUN	NN	Case=Gen|Gender=Masc|Number=Sing	6	nmod	_	_
-13	Gerry	Gerry	PROPN	NE	Case=Nom|Gender=Masc|Number=Sing	8	appos	_	_
-14	Adams	Adams	PROPN	NE	Case=Nom|Gender=Masc|Number=Sing	13	flat	_	_
-15	in	in	ADP	APPR	_	17	case	_	_
-16	ernster	ernst	ADJ	ADJA	Case=Dat|Gender=Fem|Number=Sing	17	amod	_	_
-17	Gefahr	Gefahr	NOUN	NN	Case=Dat|Gender=Fem|Number=Sing	4	obl	_	SpaceAfter=No
-18	.	.	PUNCT	$.	_	4	punct	_	_
+# text = Der Friedensprozeß in Nordirland ist nach Ansicht des Sinn-Fein-Präsidenten Gerry Adams in ernster Gefahr.
+1	Der	der	DET	ART	Case=Nom|Definite=Def|Gender=Masc|Number=Sing|PronType=Art	2	dep	_	FixTigerDep=Yes
+2	Friedensprozeß	Friedensprozeß	NOUN	NN	Case=Nom|Gender=Masc|Number=Sing	5	nsubj	_	_
+3	in	in	ADP	APPR	_	4	case	_	_
+4	Nordirland	Nordirland	PROPN	NE	Case=Dat|Gender=Neut|Number=Sing	2	nmod	_	_
+5	ist	sein	VERB	VAFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	0	root	_	_
+6	nach	nach	ADP	APPR	_	7	case	_	_
+7	Ansicht	Ansicht	NOUN	NN	Case=Dat|Gender=Fem|Number=Sing	5	obl	_	_
+8	des	der	DET	ART	Case=Gen|Definite=Def|Gender=Masc|Number=Sing|PronType=Art	9	det	_	_
+9	Sinn	Sinn	PROPN	NN	Case=Gen|Gender=Masc|Number=Sing	11	compound	_	SpaceAfter=No
+10	-	-	PUNCT	$(	_	9	punct	_	SpaceAfter=No
+11	Fein	Fein	PROPN	NN	Case=Gen|Gender=Masc|Number=Sing	13	compound	_	SpaceAfter=No
+12	-	-	PUNCT	$(	_	11	punct	_	SpaceAfter=No
+13	Präsidenten	Präsident	NOUN	NN	Case=Gen|Gender=Masc|Number=Sing	7	nmod	_	_
+14	Gerry	Gerry	PROPN	NE	Case=Nom|Gender=Masc|Number=Sing	9	appos	_	_
+15	Adams	Adams	PROPN	NE	Case=Nom|Gender=Masc|Number=Sing	14	flat	_	_
+16	in	in	ADP	APPR	_	18	case	_	_
+17	ernster	ernst	ADJ	ADJA	Case=Dat|Gender=Fem|Number=Sing	18	amod	_	_
+18	Gefahr	Gefahr	NOUN	NN	Case=Dat|Gender=Fem|Number=Sing	5	obl	_	SpaceAfter=No
+19	.	.	PUNCT	$.	_	5	punct	_	_
 
 # sent_id = test-s414
-# text = Für Frauen wurde nichts besser'
-1	Für	für	ADP	APPR	_	2	case	_	_
-2	Frauen	Frau	NOUN	NN	Case=Acc|Gender=Fem|Number=Plur	5	nmod	_	_
-3	wurde	werden	AUX	VAFIN	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	5	cop	_	_
-4	nichts	nichts	PRON	PIS	Definite=Ind|Gender=Neut|PronType=Ind	5	nsubj	_	_
-5	besser	gut	ADJ	ADJD	_	0	root	_	SpaceAfter=No
-6	'	'	PUNCT	$(	_	5	punct	_	_
+# text = ,Für Frauen wurde nichts besser'
+1	,	,	PUNCT	$,	_	2	punct	_	FixTigerDep=Yes|SpaceAfter=No
+2	Für	für	ADP	APPR	_	3	case	_	_
+3	Frauen	Frau	NOUN	NN	Case=Acc|Gender=Fem|Number=Plur	6	nmod	_	_
+4	wurde	werden	AUX	VAFIN	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	6	cop	_	_
+5	nichts	nichts	PRON	PIS	Definite=Ind|Gender=Neut|PronType=Ind	6	nsubj	_	_
+6	besser	gut	ADJ	ADJD	_	0	root	_	SpaceAfter=No
+7	'	'	PUNCT	$(	_	6	punct	_	_
 
 # sent_id = test-s415
-# text = Gastarbeiter sollen jederzeit nach Deutschland zurückkehren können, wenn sie mindestens 15 Jahre rechtmäßig hier gelebt haben und über ``ausreichend'' Rente sowie Krankheitsschutz verfügen.
-1	Gastarbeiter	Gastarbeiter	NOUN	NN	Case=Nom|Gender=Masc|Number=Plur	6	nsubj	_	_
-2	sollen	sollen	AUX	VMFIN	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	6	aux	_	_
-3	jederzeit	jederzeit	ADV	ADV	_	6	advmod	_	_
-4	nach	nach	ADP	APPR	_	5	case	_	_
-5	Deutschland	Deutschland	PROPN	NE	Case=Dat|Gender=Neut|Number=Sing	6	obl	_	_
-6	zurückkehren	zurückkehren	VERB	VVINF	VerbForm=Inf	0	root	_	_
-7	können	können	AUX	VMINF	VerbForm=Inf	6	aux	_	SpaceAfter=No
-8	,	,	PUNCT	$,	_	6	punct	_	_
-9	wenn	wenn	SCONJ	KOUS	_	16	mark	_	_
-10	sie	sie	PRON	PPER	Case=Nom|Gender=Masc|Number=Plur|Person=3|PronType=Prs	16	nsubj	_	_
-11	mindestens	mindestens	ADV	ADV	_	12	advmod	_	_
-12	15	15	NUM	CARD	NumType=Card	13	nummod	_	_
-13	Jahre	Jahr	NOUN	NN	Case=Acc|Gender=Neut|Number=Plur	16	obl	_	_
-14	rechtmäßig	rechtmäßig	ADV	ADJD	_	16	advmod	_	_
-15	hier	hier	ADV	ADV	_	16	advmod	_	_
-16	gelebt	leben	VERB	VVPP	VerbForm=Part	6	advcl	_	_
-17	haben	haben	AUX	VAFIN	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	16	aux	_	_
-18	und	und	CCONJ	KON	_	26	cc	_	_
-19	über	über	ADP	APPR	_	23	case	_	_
-20	``	``	PUNCT	$(	_	23	punct	_	SpaceAfter=No
-21	ausreichend	ausreichend	ADJ	ADJD	_	23	amod	_	SpaceAfter=No
-22	''	''	PUNCT	$(	_	23	punct	_	_
-23	Rente	Rente	NOUN	NN	Case=Acc|Gender=Fem|Number=Sing	26	obl	_	_
-24	sowie	sowie	CCONJ	KON	_	25	cc	_	_
-25	Krankheitsschutz	Krankheitsschutz	NOUN	NN	Case=Acc|Gender=Masc|Number=Sing	23	conj	_	_
-26	verfügen	verfügen	VERB	VVFIN	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	16	conj	_	SpaceAfter=No
-27	.	.	PUNCT	$.	_	6	punct	_	_
+# text = Sogenannte Gastarbeiter sollen jederzeit nach Deutschland zurückkehren können, wenn sie mindestens 15 Jahre rechtmäßig hier gelebt haben und über ``ausreichend'' Rente sowie Krankheitsschutz verfügen.
+1	Sogenannte	sogenannt	ADJ	ADJA	Case=Nom|Gender=Masc|Number=Plur	2	dep	_	FixTigerDep=Yes
+2	Gastarbeiter	Gastarbeiter	NOUN	NN	Case=Nom|Gender=Masc|Number=Plur	7	nsubj	_	_
+3	sollen	sollen	AUX	VMFIN	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	7	aux	_	_
+4	jederzeit	jederzeit	ADV	ADV	_	7	advmod	_	_
+5	nach	nach	ADP	APPR	_	6	case	_	_
+6	Deutschland	Deutschland	PROPN	NE	Case=Dat|Gender=Neut|Number=Sing	7	obl	_	_
+7	zurückkehren	zurückkehren	VERB	VVINF	VerbForm=Inf	0	root	_	_
+8	können	können	AUX	VMINF	VerbForm=Inf	7	aux	_	SpaceAfter=No
+9	,	,	PUNCT	$,	_	7	punct	_	_
+10	wenn	wenn	SCONJ	KOUS	_	17	mark	_	_
+11	sie	sie	PRON	PPER	Case=Nom|Gender=Masc|Number=Plur|Person=3|PronType=Prs	17	nsubj	_	_
+12	mindestens	mindestens	ADV	ADV	_	13	advmod	_	_
+13	15	15	NUM	CARD	NumType=Card	14	nummod	_	_
+14	Jahre	Jahr	NOUN	NN	Case=Acc|Gender=Neut|Number=Plur	17	obl	_	_
+15	rechtmäßig	rechtmäßig	ADV	ADJD	_	17	advmod	_	_
+16	hier	hier	ADV	ADV	_	17	advmod	_	_
+17	gelebt	leben	VERB	VVPP	VerbForm=Part	7	advcl	_	_
+18	haben	haben	AUX	VAFIN	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	17	aux	_	_
+19	und	und	CCONJ	KON	_	27	cc	_	_
+20	über	über	ADP	APPR	_	24	case	_	_
+21	``	``	PUNCT	$(	_	24	punct	_	SpaceAfter=No
+22	ausreichend	ausreichend	ADJ	ADJD	_	24	amod	_	SpaceAfter=No
+23	''	''	PUNCT	$(	_	24	punct	_	_
+24	Rente	Rente	NOUN	NN	Case=Acc|Gender=Fem|Number=Sing	27	obl	_	_
+25	sowie	sowie	CCONJ	KON	_	26	cc	_	_
+26	Krankheitsschutz	Krankheitsschutz	NOUN	NN	Case=Acc|Gender=Masc|Number=Sing	24	conj	_	_
+27	verfügen	verfügen	VERB	VVFIN	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	17	conj	_	SpaceAfter=No
+28	.	.	PUNCT	$.	_	7	punct	_	_
 
 # sent_id = test-s416
-# text = Geiseln seien nach Angaben der Entführer leicht erkrankt, würden aber behandelt, erklärte ein Behördensprecher.
-1	Geiseln	Geisel	NOUN	NN	Case=Nom|Gender=Fem|Number=Plur	8	nsubj	_	_
-2	seien	sein	AUX	VAFIN	Mood=Sub|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	8	aux	_	_
-3	nach	nach	ADP	APPR	_	4	case	_	_
-4	Angaben	Angabe	NOUN	NN	Case=Dat|Gender=Fem|Number=Plur	8	obl	_	_
-5	der	der	DET	ART	Case=Gen|Definite=Def|Gender=Masc|Number=Plur|PronType=Art	6	det	_	_
-6	Entführer	Entführer	NOUN	NN	Case=Gen|Gender=Masc|Number=Plur	4	nmod	_	_
-7	leicht	leicht	ADV	ADJD	_	8	advmod	_	_
-8	erkrankt	erkranken	VERB	VVPP	VerbForm=Part	14	ccomp	_	SpaceAfter=No
-9	,	,	PUNCT	$,	_	12	punct	_	_
-10	würden	werden	AUX	VAFIN	Mood=Sub|Number=Plur|Person=3|Tense=Past|VerbForm=Fin|Voice=Pass	12	aux:pass	_	_
-11	aber	aber	CCONJ	ADV	_	12	cc	_	_
-12	behandelt	behandeln	VERB	VVPP	VerbForm=Part	8	conj	_	SpaceAfter=No
-13	,	,	PUNCT	$,	_	14	punct	_	_
-14	erklärte	erklären	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	0	root	_	_
-15	ein	ein	DET	ART	Case=Nom|Definite=Ind|Gender=Masc|Number=Sing|PronType=Art	16	det	_	_
-16	Behördensprecher	Behördensprecher	NOUN	NN	Case=Nom|Gender=Masc|Number=Sing	14	nsubj	_	SpaceAfter=No
-17	.	.	PUNCT	$.	_	14	punct	_	_
+# text = Zwei Geiseln seien nach Angaben der Entführer leicht erkrankt, würden aber behandelt, erklärte ein Behördensprecher.
+1	Zwei	zwei	NUM	CARD	NumType=Card	2	dep	_	FixTigerDep=Yes
+2	Geiseln	Geisel	NOUN	NN	Case=Nom|Gender=Fem|Number=Plur	9	nsubj	_	_
+3	seien	sein	AUX	VAFIN	Mood=Sub|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	9	aux	_	_
+4	nach	nach	ADP	APPR	_	5	case	_	_
+5	Angaben	Angabe	NOUN	NN	Case=Dat|Gender=Fem|Number=Plur	9	obl	_	_
+6	der	der	DET	ART	Case=Gen|Definite=Def|Gender=Masc|Number=Plur|PronType=Art	7	det	_	_
+7	Entführer	Entführer	NOUN	NN	Case=Gen|Gender=Masc|Number=Plur	5	nmod	_	_
+8	leicht	leicht	ADV	ADJD	_	9	advmod	_	_
+9	erkrankt	erkranken	VERB	VVPP	VerbForm=Part	15	ccomp	_	SpaceAfter=No
+10	,	,	PUNCT	$,	_	13	punct	_	_
+11	würden	werden	AUX	VAFIN	Mood=Sub|Number=Plur|Person=3|Tense=Past|VerbForm=Fin|Voice=Pass	13	aux:pass	_	_
+12	aber	aber	CCONJ	ADV	_	13	cc	_	_
+13	behandelt	behandeln	VERB	VVPP	VerbForm=Part	9	conj	_	SpaceAfter=No
+14	,	,	PUNCT	$,	_	15	punct	_	_
+15	erklärte	erklären	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	0	root	_	_
+16	ein	ein	DET	ART	Case=Nom|Definite=Ind|Gender=Masc|Number=Sing|PronType=Art	17	det	_	_
+17	Behördensprecher	Behördensprecher	NOUN	NN	Case=Nom|Gender=Masc|Number=Sing	15	nsubj	_	SpaceAfter=No
+18	.	.	PUNCT	$.	_	15	punct	_	_
 
 # sent_id = test-s417
-# text = Gerichte, so die Konsumentenschützer, verpflichteten die Manager schon zu ``Bedingungen in Dur''.
-1	Gerichte	Gericht	NOUN	NN	Case=Nom|Gender=Neut|Number=Plur	7	nsubj	_	SpaceAfter=No
-2	,	,	PUNCT	$,	_	7	punct	_	_
-3	so	so	ADV	ADV	_	5	advmod	_	_
-4	die	der	DET	ART	Case=Nom|Definite=Def|Gender=Masc|Number=Plur|PronType=Art	5	det	_	_
-5	Konsumentenschützer	Konsumentenschützer	NOUN	NN	Case=Nom|Gender=Masc|Number=Plur	7	appos	_	SpaceAfter=No
-6	,	,	PUNCT	$,	_	7	punct	_	_
-7	verpflichteten	verpflichten	VERB	VVFIN	Mood=Ind|Number=Plur|Person=3|Tense=Past|VerbForm=Fin	0	root	_	_
-8	die	der	DET	ART	Case=Acc|Definite=Def|Gender=Masc|Number=Plur|PronType=Art	9	det	_	_
-9	Manager	Manager	NOUN	NN	Case=Acc|Gender=Masc|Number=Plur	7	obj	_	_
-10	schon	schon	ADV	ADV	_	7	advmod	_	_
-11	zu	zu	ADP	APPR	_	13	case	_	_
-12	``	``	PUNCT	$(	_	13	punct	_	SpaceAfter=No
-13	Bedingungen	Bedingung	NOUN	NN	Case=Dat|Gender=Fem|Number=Plur	7	obl	_	_
-14	in	in	ADP	APPR	_	15	case	_	_
-15	Dur	Dur	NOUN	NN	Case=Dat|Gender=Fem|Number=Sing	13	nmod	_	SpaceAfter=No
-16	''	''	PUNCT	$(	_	13	punct	_	SpaceAfter=No
-17	.	.	PUNCT	$.	_	7	punct	_	_
+# text = Viele Gerichte, so die Konsumentenschützer, verpflichteten die Manager schon zu ``Bedingungen in Dur''.
+1	Viele	vieler	DET	PIAT	Case=Nom|Definite=Ind|Gender=Neut|Number=Plur|PronType=Ind	2	dep	_	FixTigerDep=Yes
+2	Gerichte	Gericht	NOUN	NN	Case=Nom|Gender=Neut|Number=Plur	8	nsubj	_	SpaceAfter=No
+3	,	,	PUNCT	$,	_	8	punct	_	_
+4	so	so	ADV	ADV	_	6	advmod	_	_
+5	die	der	DET	ART	Case=Nom|Definite=Def|Gender=Masc|Number=Plur|PronType=Art	6	det	_	_
+6	Konsumentenschützer	Konsumentenschützer	NOUN	NN	Case=Nom|Gender=Masc|Number=Plur	8	appos	_	SpaceAfter=No
+7	,	,	PUNCT	$,	_	8	punct	_	_
+8	verpflichteten	verpflichten	VERB	VVFIN	Mood=Ind|Number=Plur|Person=3|Tense=Past|VerbForm=Fin	0	root	_	_
+9	die	der	DET	ART	Case=Acc|Definite=Def|Gender=Masc|Number=Plur|PronType=Art	10	det	_	_
+10	Manager	Manager	NOUN	NN	Case=Acc|Gender=Masc|Number=Plur	8	obj	_	_
+11	schon	schon	ADV	ADV	_	8	advmod	_	_
+12	zu	zu	ADP	APPR	_	14	case	_	_
+13	``	``	PUNCT	$(	_	14	punct	_	SpaceAfter=No
+14	Bedingungen	Bedingung	NOUN	NN	Case=Dat|Gender=Fem|Number=Plur	8	obl	_	_
+15	in	in	ADP	APPR	_	16	case	_	_
+16	Dur	Dur	NOUN	NN	Case=Dat|Gender=Fem|Number=Sing	14	nmod	_	SpaceAfter=No
+17	''	''	PUNCT	$(	_	14	punct	_	SpaceAfter=No
+18	.	.	PUNCT	$.	_	8	punct	_	_
 
 # sent_id = test-s418
-# text = Gesamtbetriebsratsvorsitzende Ingrid Lüllmann bestätigte, daß sich bei den abschließenden Gesprächen mit dem Vorstand an den wesentlichen Standpunkten beider Seiten nichts geändert habe, ``auch wenn sich hier und dort Spielräume'' ergeben hätten.
-1	Gesamtbetriebsratsvorsitzende	Gesamtbetriebsratsvorsitzender	NOUN	NN	Case=Nom|Gender=Fem|Number=Sing	4	nsubj	_	_
-2	Ingrid	Ingrid	PROPN	NE	Case=Nom|Gender=Fem|Number=Sing	1	appos	_	_
-3	Lüllmann	Lüllmann	PROPN	NE	Case=Nom|Gender=Fem|Number=Sing	2	flat	_	_
-4	bestätigte	bestätigen	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	0	root	_	SpaceAfter=No
-5	,	,	PUNCT	$,	_	4	punct	_	_
-6	daß	daß	SCONJ	KOUS	_	22	mark	_	_
-7	sich	er|es|sie	PRON	PRF	Case=Acc|Number=Sing|Person=3|PronType=Prs|Reflex=Yes	22	obj	_	_
-8	bei	bei	ADP	APPR	_	11	case	_	_
-9	den	der	DET	ART	Case=Dat|Definite=Def|Gender=Neut|Number=Plur|PronType=Art	11	det	_	_
-10	abschließenden	abschließend	ADJ	ADJA	Case=Dat|Gender=Neut|Number=Plur	11	amod	_	_
-11	Gesprächen	Gespräch	NOUN	NN	Case=Dat|Gender=Neut|Number=Plur	22	obl	_	_
-12	mit	mit	ADP	APPR	_	14	case	_	_
-13	dem	der	DET	ART	Case=Dat|Definite=Def|Gender=Masc|Number=Sing|PronType=Art	14	det	_	_
-14	Vorstand	Vorstand	NOUN	NN	Case=Dat|Gender=Masc|Number=Sing	11	nmod	_	_
-15	an	an	ADP	APPR	_	18	case	_	_
-16	den	der	DET	ART	Case=Dat|Definite=Def|Gender=Masc|Number=Plur|PronType=Art	18	det	_	_
-17	wesentlichen	wesentlich	ADJ	ADJA	Case=Dat|Gender=Masc|Number=Plur	18	amod	_	_
-18	Standpunkten	Standpunkt	NOUN	NN	Case=Dat|Gender=Masc|Number=Plur	22	obl	_	_
-19	beider	beide	PRON	PIAT	Case=Gen|Definite=Ind|Gender=Fem|Number=Plur|PronType=Ind	20	det	_	_
-20	Seiten	Seite	NOUN	NN	Case=Gen|Gender=Fem|Number=Plur	18	nmod	_	_
-21	nichts	nichts	PRON	PIS	Definite=Ind|Gender=Neut|PronType=Ind	22	nsubj	_	_
-22	geändert	ändern	VERB	VVPP	VerbForm=Part	4	ccomp	_	_
-23	habe	haben	AUX	VAFIN	Mood=Sub|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	22	aux	_	SpaceAfter=No
-24	,	,	PUNCT	$,	_	4	punct	_	_
-25	``	``	PUNCT	$(	_	4	punct	_	SpaceAfter=No
-26	auch	auch	ADV	ADV	_	27	advmod	_	_
-27	wenn	wenn	SCONJ	KOUS	_	34	mark	_	_
-28	sich	er|es|sie	PRON	PRF	Case=Acc|Number=Plur|Person=3|PronType=Prs|Reflex=Yes	34	obj	_	_
-29	hier	hier	ADV	ADV	_	34	advmod	_	_
-30	und	und	CCONJ	KON	_	31	cc	_	_
-31	dort	dort	ADV	ADV	_	29	conj	_	_
-32	Spielräume	Spielraum	NOUN	NN	Case=Nom|Gender=Masc|Number=Plur	34	nsubj	_	SpaceAfter=No
-33	''	''	PUNCT	$(	_	4	punct	_	_
-34	ergeben	ergeben	VERB	VVPP	VerbForm=Part	22	advcl	_	_
-35	hätten	haben	AUX	VAFIN	Mood=Sub|Number=Plur|Person=3|Tense=Past|VerbForm=Fin	34	aux	_	SpaceAfter=No
-36	.	.	PUNCT	$.	_	4	punct	_	_
+# text = Die Gesamtbetriebsratsvorsitzende Ingrid Lüllmann bestätigte, daß sich bei den abschließenden Gesprächen mit dem Vorstand an den wesentlichen Standpunkten beider Seiten nichts geändert habe, ``auch wenn sich hier und dort Spielräume'' ergeben hätten.
+1	Die	der	DET	ART	Case=Nom|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	2	dep	_	FixTigerDep=Yes
+2	Gesamtbetriebsratsvorsitzende	Gesamtbetriebsratsvorsitzender	NOUN	NN	Case=Nom|Gender=Fem|Number=Sing	5	nsubj	_	_
+3	Ingrid	Ingrid	PROPN	NE	Case=Nom|Gender=Fem|Number=Sing	2	appos	_	_
+4	Lüllmann	Lüllmann	PROPN	NE	Case=Nom|Gender=Fem|Number=Sing	3	flat	_	_
+5	bestätigte	bestätigen	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	0	root	_	SpaceAfter=No
+6	,	,	PUNCT	$,	_	5	punct	_	_
+7	daß	daß	SCONJ	KOUS	_	23	mark	_	_
+8	sich	er|es|sie	PRON	PRF	Case=Acc|Number=Sing|Person=3|PronType=Prs|Reflex=Yes	23	obj	_	_
+9	bei	bei	ADP	APPR	_	12	case	_	_
+10	den	der	DET	ART	Case=Dat|Definite=Def|Gender=Neut|Number=Plur|PronType=Art	12	det	_	_
+11	abschließenden	abschließend	ADJ	ADJA	Case=Dat|Gender=Neut|Number=Plur	12	amod	_	_
+12	Gesprächen	Gespräch	NOUN	NN	Case=Dat|Gender=Neut|Number=Plur	23	obl	_	_
+13	mit	mit	ADP	APPR	_	15	case	_	_
+14	dem	der	DET	ART	Case=Dat|Definite=Def|Gender=Masc|Number=Sing|PronType=Art	15	det	_	_
+15	Vorstand	Vorstand	NOUN	NN	Case=Dat|Gender=Masc|Number=Sing	12	nmod	_	_
+16	an	an	ADP	APPR	_	19	case	_	_
+17	den	der	DET	ART	Case=Dat|Definite=Def|Gender=Masc|Number=Plur|PronType=Art	19	det	_	_
+18	wesentlichen	wesentlich	ADJ	ADJA	Case=Dat|Gender=Masc|Number=Plur	19	amod	_	_
+19	Standpunkten	Standpunkt	NOUN	NN	Case=Dat|Gender=Masc|Number=Plur	23	obl	_	_
+20	beider	beide	PRON	PIAT	Case=Gen|Definite=Ind|Gender=Fem|Number=Plur|PronType=Ind	21	det	_	_
+21	Seiten	Seite	NOUN	NN	Case=Gen|Gender=Fem|Number=Plur	19	nmod	_	_
+22	nichts	nichts	PRON	PIS	Definite=Ind|Gender=Neut|PronType=Ind	23	nsubj	_	_
+23	geändert	ändern	VERB	VVPP	VerbForm=Part	5	ccomp	_	_
+24	habe	haben	AUX	VAFIN	Mood=Sub|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	23	aux	_	SpaceAfter=No
+25	,	,	PUNCT	$,	_	5	punct	_	_
+26	``	``	PUNCT	$(	_	5	punct	_	SpaceAfter=No
+27	auch	auch	ADV	ADV	_	28	advmod	_	_
+28	wenn	wenn	SCONJ	KOUS	_	35	mark	_	_
+29	sich	er|es|sie	PRON	PRF	Case=Acc|Number=Plur|Person=3|PronType=Prs|Reflex=Yes	35	obj	_	_
+30	hier	hier	ADV	ADV	_	35	advmod	_	_
+31	und	und	CCONJ	KON	_	32	cc	_	_
+32	dort	dort	ADV	ADV	_	30	conj	_	_
+33	Spielräume	Spielraum	NOUN	NN	Case=Nom|Gender=Masc|Number=Plur	35	nsubj	_	SpaceAfter=No
+34	''	''	PUNCT	$(	_	5	punct	_	_
+35	ergeben	ergeben	VERB	VVPP	VerbForm=Part	23	advcl	_	_
+36	hätten	haben	AUX	VAFIN	Mood=Sub|Number=Plur|Person=3|Tense=Past|VerbForm=Fin	35	aux	_	SpaceAfter=No
+37	.	.	PUNCT	$.	_	5	punct	_	_
 
 # sent_id = test-s419
 # text = Geschäfte, Restaurants und ein Fünf-Sterne-Hotel von Steigenberger feierten kürzlich Richtfest.
@@ -7887,68 +7979,72 @@
 16	.	.	PUNCT	$.	_	13	punct	_	_
 
 # sent_id = test-s420
-# text = Gesellschaft für Soziale Psychiatrie diskutierte langsame Fortschritte bei gemeindenaher Versorgung der Patienten
-1	Gesellschaft	Gesellschaft	PROPN	NN	Case=Nom|Gender=Fem|Number=Sing	5	nsubj	_	_
-2	für	für	PROPN	APPR	_	1	flat	_	_
-3	Soziale	sozial	PROPN	ADJA	Case=Acc|Gender=Fem|Number=Sing	1	flat	_	_
-4	Psychiatrie	Psychiatrie	PROPN	NN	Case=Acc|Gender=Fem|Number=Sing	1	flat	_	_
-5	diskutierte	diskutieren	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	0	root	_	_
-6	langsame	langsam	ADJ	ADJA	Case=Acc|Gender=Masc|Number=Plur	7	amod	_	_
-7	Fortschritte	Fortschritt	NOUN	NN	Case=Acc|Gender=Masc|Number=Plur	5	obj	_	_
-8	bei	bei	ADP	APPR	_	10	case	_	_
-9	gemeindenaher	gemeindenah	ADJ	ADJA	Case=Dat|Gender=Fem|Number=Sing	10	amod	_	_
-10	Versorgung	Versorgung	NOUN	NN	Case=Dat|Gender=Fem|Number=Sing	7	nmod	_	_
-11	der	der	DET	ART	Case=Gen|Definite=Def|Gender=Masc|Number=Plur|PronType=Art	12	det	_	_
-12	Patienten	Patient	NOUN	NN	Case=Gen|Gender=Masc|Number=Plur	10	nmod	_	_
+# text = Deutsche Gesellschaft für Soziale Psychiatrie diskutierte langsame Fortschritte bei gemeindenaher Versorgung der Patienten
+1	Deutsche	deutsch	ADJ	ADJA	Case=Nom|Gender=Fem|Number=Sing	2	dep	_	FixTigerDep=Yes
+2	Gesellschaft	Gesellschaft	PROPN	NN	Case=Nom|Gender=Fem|Number=Sing	6	nsubj	_	_
+3	für	für	PROPN	APPR	_	2	flat	_	_
+4	Soziale	sozial	PROPN	ADJA	Case=Acc|Gender=Fem|Number=Sing	2	flat	_	_
+5	Psychiatrie	Psychiatrie	PROPN	NN	Case=Acc|Gender=Fem|Number=Sing	2	flat	_	_
+6	diskutierte	diskutieren	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	0	root	_	_
+7	langsame	langsam	ADJ	ADJA	Case=Acc|Gender=Masc|Number=Plur	8	amod	_	_
+8	Fortschritte	Fortschritt	NOUN	NN	Case=Acc|Gender=Masc|Number=Plur	6	obj	_	_
+9	bei	bei	ADP	APPR	_	11	case	_	_
+10	gemeindenaher	gemeindenah	ADJ	ADJA	Case=Dat|Gender=Fem|Number=Sing	11	amod	_	_
+11	Versorgung	Versorgung	NOUN	NN	Case=Dat|Gender=Fem|Number=Sing	8	nmod	_	_
+12	der	der	DET	ART	Case=Gen|Definite=Def|Gender=Masc|Number=Plur|PronType=Art	13	det	_	_
+13	Patienten	Patient	NOUN	NN	Case=Gen|Gender=Masc|Number=Plur	11	nmod	_	_
 
 # sent_id = test-s421
-# text = Gläubigen hungern -- und die Mullahs bereichern sich
-1	Gläubigen	Gläubige	NOUN	NN	Case=Nom|Number=Plur	2	nsubj	_	_
-2	hungern	hungern	VERB	VVFIN	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	0	root	_	_
-3	--	--	PUNCT	$(	_	7	punct	_	_
-4	und	und	CCONJ	KON	_	7	cc	_	_
-5	die	der	DET	ART	Case=Nom|Definite=Def|Gender=Masc|Number=Plur|PronType=Art	6	det	_	_
-6	Mullahs	Mullah	NOUN	NN	Case=Nom|Gender=Masc|Number=Plur	7	nsubj	_	_
-7	bereichern	bereichern	VERB	VVFIN	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	2	conj	_	_
-8	sich	er|es|sie	PRON	PRF	Case=Acc|Number=Plur|Person=3|PronType=Prs|Reflex=Yes	7	obj	_	_
+# text = Die Gläubigen hungern -- und die Mullahs bereichern sich
+1	Die	der	DET	ART	Case=Nom|Definite=Def|Number=Plur|PronType=Art	2	dep	_	FixTigerDep=Yes
+2	Gläubigen	Gläubige	NOUN	NN	Case=Nom|Number=Plur	3	nsubj	_	_
+3	hungern	hungern	VERB	VVFIN	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	0	root	_	_
+4	--	--	PUNCT	$(	_	8	punct	_	_
+5	und	und	CCONJ	KON	_	8	cc	_	_
+6	die	der	DET	ART	Case=Nom|Definite=Def|Gender=Masc|Number=Plur|PronType=Art	7	det	_	_
+7	Mullahs	Mullah	NOUN	NN	Case=Nom|Gender=Masc|Number=Plur	8	nsubj	_	_
+8	bereichern	bereichern	VERB	VVFIN	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	3	conj	_	_
+9	sich	er|es|sie	PRON	PRF	Case=Acc|Number=Plur|Person=3|PronType=Prs|Reflex=Yes	8	obj	_	_
 
 # sent_id = test-s422
-# text = Göttinger ``Autonome'' laufen zur Zeit mit einem unguten Gefühl durch die Stadt.
-1	Göttinger	Göttinger	ADJ	ADJA	_	3	compound	_	_
-2	``	``	PUNCT	$(	_	3	punct	_	SpaceAfter=No
-3	Autonome	Autonome	PROPN	NN	Case=Nom|Number=Plur	5	nsubj	_	SpaceAfter=No
-4	''	''	PUNCT	$(	_	3	punct	_	_
-5	laufen	laufen	VERB	VVFIN	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	0	root	_	_
-6-7	zur	_	_	_	_	_	_	_	_
-6	zu	zu	ADP	APPR	_	8	case	_	_
-7	der	der	DET	ART	Case=Dat|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	8	det	_	_
-8	Zeit	Zeit	NOUN	NN	Case=Dat|Gender=Fem|Number=Sing	5	obl	_	_
-9	mit	mit	ADP	APPR	_	12	case	_	_
-10	einem	ein	DET	ART	Case=Dat|Definite=Ind|Gender=Neut|Number=Sing|PronType=Art	12	det	_	_
-11	unguten	ungut	ADJ	ADJA	Case=Dat|Gender=Neut|Number=Sing	12	amod	_	_
-12	Gefühl	Gefühl	NOUN	NN	Case=Dat|Gender=Neut|Number=Sing	5	obl	_	_
-13	durch	durch	ADP	APPR	_	15	case	_	_
-14	die	der	DET	ART	Case=Acc|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	15	det	_	_
-15	Stadt	Stadt	NOUN	NN	Case=Acc|Gender=Fem|Number=Sing	5	obl	_	SpaceAfter=No
-16	.	.	PUNCT	$.	_	5	punct	_	_
+# text = Viele Göttinger ``Autonome'' laufen zur Zeit mit einem unguten Gefühl durch die Stadt.
+1	Viele	vieler	DET	PIAT	Case=Nom|Definite=Ind|Number=Plur|PronType=Ind	2	dep	_	FixTigerDep=Yes
+2	Göttinger	Göttinger	ADJ	ADJA	_	4	compound	_	_
+3	``	``	PUNCT	$(	_	4	punct	_	SpaceAfter=No
+4	Autonome	autonome	PROPN	NN	Case=Nom|Number=Plur	6	nsubj	_	SpaceAfter=No
+5	''	''	PUNCT	$(	_	4	punct	_	_
+6	laufen	laufen	VERB	VVFIN	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	0	root	_	_
+7-8	zur	_	_	_	_	_	_	_	_
+7	zu	zu	ADP	APPR	_	9	case	_	_
+8	der	der	DET	ART	Case=Dat|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	9	det	_	_
+9	Zeit	Zeit	NOUN	NN	Case=Dat|Gender=Fem|Number=Sing	6	obl	_	_
+10	mit	mit	ADP	APPR	_	13	case	_	_
+11	einem	ein	DET	ART	Case=Dat|Definite=Ind|Gender=Neut|Number=Sing|PronType=Art	13	det	_	_
+12	unguten	ungut	ADJ	ADJA	Case=Dat|Gender=Neut|Number=Sing	13	amod	_	_
+13	Gefühl	Gefühl	NOUN	NN	Case=Dat|Gender=Neut|Number=Sing	6	obl	_	_
+14	durch	durch	ADP	APPR	_	16	case	_	_
+15	die	der	DET	ART	Case=Acc|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	16	det	_	_
+16	Stadt	Stadt	NOUN	NN	Case=Acc|Gender=Fem|Number=Sing	6	obl	_	SpaceAfter=No
+17	.	.	PUNCT	$.	_	6	punct	_	_
 
 # sent_id = test-s423
-# text = Gremium hofft, daß sich die zuständigen Behörden weltweit den neuen Mindestanforderungen anschließen werden.
-1	Gremium	Gremium	NOUN	NN	Case=Nom|Gender=Neut|Number=Sing	2	nsubj	_	_
-2	hofft	hoffen	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	0	root	_	SpaceAfter=No
-3	,	,	PUNCT	$,	_	2	punct	_	_
-4	daß	daß	SCONJ	KOUS	_	13	mark	_	_
-5	sich	er|es|sie	PRON	PRF	Case=Acc|Number=Plur|Person=3|PronType=Prs|Reflex=Yes	13	obj	_	_
-6	die	der	DET	ART	Case=Nom|Definite=Def|Gender=Fem|Number=Plur|PronType=Art	8	det	_	_
-7	zuständigen	zuständig	ADJ	ADJA	Case=Nom|Gender=Fem|Number=Plur	8	amod	_	_
-8	Behörden	Behörde	NOUN	NN	Case=Nom|Gender=Fem|Number=Plur	13	nsubj	_	_
-9	weltweit	weltweit	ADV	ADJD	_	13	advmod	_	_
-10	den	der	DET	ART	Case=Dat|Definite=Def|Gender=Fem|Number=Plur|PronType=Art	12	det	_	_
-11	neuen	neu	ADJ	ADJA	Case=Dat|Gender=Fem|Number=Plur	12	amod	_	_
-12	Mindestanforderungen	Mindestanforderung	NOUN	NN	Case=Dat|Gender=Fem|Number=Plur	13	iobj	_	_
-13	anschließen	anschließen	VERB	VVINF	VerbForm=Inf	2	ccomp	_	_
-14	werden	werden	AUX	VAFIN	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	13	aux	_	SpaceAfter=No
-15	.	.	PUNCT	$.	_	2	punct	_	_
+# text = Das Gremium hofft, daß sich die zuständigen Behörden weltweit den neuen Mindestanforderungen anschließen werden.
+1	Das	der	DET	ART	Case=Nom|Definite=Def|Gender=Neut|Number=Sing|PronType=Art	2	dep	_	FixTigerDep=Yes
+2	Gremium	Gremium	NOUN	NN	Case=Nom|Gender=Neut|Number=Sing	3	nsubj	_	_
+3	hofft	hoffen	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	0	root	_	SpaceAfter=No
+4	,	,	PUNCT	$,	_	3	punct	_	_
+5	daß	daß	SCONJ	KOUS	_	14	mark	_	_
+6	sich	er|es|sie	PRON	PRF	Case=Acc|Number=Plur|Person=3|PronType=Prs|Reflex=Yes	14	obj	_	_
+7	die	der	DET	ART	Case=Nom|Definite=Def|Gender=Fem|Number=Plur|PronType=Art	9	det	_	_
+8	zuständigen	zuständig	ADJ	ADJA	Case=Nom|Gender=Fem|Number=Plur	9	amod	_	_
+9	Behörden	Behörde	NOUN	NN	Case=Nom|Gender=Fem|Number=Plur	14	nsubj	_	_
+10	weltweit	weltweit	ADV	ADJD	_	14	advmod	_	_
+11	den	der	DET	ART	Case=Dat|Definite=Def|Gender=Fem|Number=Plur|PronType=Art	13	det	_	_
+12	neuen	neu	ADJ	ADJA	Case=Dat|Gender=Fem|Number=Plur	13	amod	_	_
+13	Mindestanforderungen	Mindestanforderung	NOUN	NN	Case=Dat|Gender=Fem|Number=Plur	14	iobj	_	_
+14	anschließen	anschließen	VERB	VVINF	VerbForm=Inf	3	ccomp	_	_
+15	werden	werden	AUX	VAFIN	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	14	aux	_	SpaceAfter=No
+16	.	.	PUNCT	$.	_	3	punct	_	_
 
 # sent_id = test-s424
 # text = Großbauern streichen viel ein, die kleinen bekommen wenig
@@ -7963,31 +8059,32 @@
 9	wenig	wenig	PRON	PIS	Definite=Ind|PronType=Ind	8	obj	_	_
 
 # sent_id = test-s425
-# text = große Gesellschaften heben zum Jahreswechsel die Beiträge in den Vollkosten-Tarifen an -- allerdings etwas moderater als in der Vergangenheit.
-1	große	groß	ADJ	ADJA	Case=Nom|Gender=Fem|Number=Plur	2	amod	_	_
-2	Gesellschaften	Gesellschaft	NOUN	NN	Case=Nom|Gender=Fem|Number=Plur	3	nsubj	_	_
-3	heben	heben	VERB	VVFIN	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	0	root	_	_
-4-5	zum	_	_	_	_	_	_	_	_
-4	zu	zu	ADP	APPR	_	6	case	_	_
-5	dem	der	DET	ART	Case=Dat|Definite=Def|Gender=Masc|Number=Sing|PronType=Art	6	det	_	_
-6	Jahreswechsel	Jahreswechsel	NOUN	NN	Case=Dat|Gender=Masc|Number=Sing	3	obl	_	_
-7	die	der	DET	ART	Case=Acc|Definite=Def|Gender=Masc|Number=Plur|PronType=Art	8	det	_	_
-8	Beiträge	Beitrag	NOUN	NN	Case=Acc|Gender=Masc|Number=Plur	3	obj	_	_
-9	in	in	ADP	APPR	_	13	case	_	_
-10	den	der	DET	ART	Case=Dat|Definite=Def|Gender=Masc|Number=Plur|PronType=Art	13	det	_	_
-11	Vollkosten	Vollkosten	NOUN	NN	Case=Dat|Gender=Masc|Number=Plur	13	compound	_	SpaceAfter=No
-12	-	-	PUNCT	$(	_	11	punct	_	SpaceAfter=No
-13	Tarifen	Tarif	NOUN	NN	Case=Dat|Gender=Masc|Number=Plur	8	nmod	_	_
-14	an	an	ADP	PTKVZ	_	3	compound:prt	_	_
-15	--	--	PUNCT	$(	_	3	punct	_	_
-16	allerdings	allerdings	CCONJ	ADV	_	3	cc	_	_
-17	etwas	etwas	ADV	ADV	_	18	advmod	_	_
-18	moderater	moderat	ADJ	ADJD	_	3	amod	_	_
-19	als	als	CCONJ	KOKOM	_	18	dep	_	_
-20	in	in	ADP	APPR	_	22	case	_	_
-21	der	der	DET	ART	Case=Dat|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	22	det	_	_
-22	Vergangenheit	Vergangenheit	NOUN	NN	Case=Dat|Gender=Fem|Number=Sing	19	nmod	_	SpaceAfter=No
-23	.	.	PUNCT	$.	_	3	punct	_	_
+# text = Mehrere große Gesellschaften heben zum Jahreswechsel die Beiträge in den Vollkosten-Tarifen an -- allerdings etwas moderater als in der Vergangenheit.
+1	Mehrere	mehrere	DET	PIAT	Case=Nom|Definite=Ind|Gender=Fem|Number=Plur|PronType=Ind	2	dep	_	FixTigerDep=Yes
+2	große	groß	ADJ	ADJA	Case=Nom|Gender=Fem|Number=Plur	3	amod	_	_
+3	Gesellschaften	Gesellschaft	NOUN	NN	Case=Nom|Gender=Fem|Number=Plur	4	nsubj	_	_
+4	heben	heben	VERB	VVFIN	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	0	root	_	_
+5-6	zum	_	_	_	_	_	_	_	_
+5	zu	zu	ADP	APPR	_	7	case	_	_
+6	dem	der	DET	ART	Case=Dat|Definite=Def|Gender=Masc|Number=Sing|PronType=Art	7	det	_	_
+7	Jahreswechsel	Jahreswechsel	NOUN	NN	Case=Dat|Gender=Masc|Number=Sing	4	obl	_	_
+8	die	der	DET	ART	Case=Acc|Definite=Def|Gender=Masc|Number=Plur|PronType=Art	9	det	_	_
+9	Beiträge	Beitrag	NOUN	NN	Case=Acc|Gender=Masc|Number=Plur	4	obj	_	_
+10	in	in	ADP	APPR	_	14	case	_	_
+11	den	der	DET	ART	Case=Dat|Definite=Def|Gender=Masc|Number=Plur|PronType=Art	14	det	_	_
+12	Vollkosten	Vollkosten	NOUN	NN	Case=Dat|Gender=Masc|Number=Plur	14	compound	_	SpaceAfter=No
+13	-	-	PUNCT	$(	_	12	punct	_	SpaceAfter=No
+14	Tarifen	Tarif	NOUN	NN	Case=Dat|Gender=Masc|Number=Plur	9	nmod	_	_
+15	an	an	ADP	PTKVZ	_	4	compound:prt	_	_
+16	--	--	PUNCT	$(	_	4	punct	_	_
+17	allerdings	allerdings	CCONJ	ADV	_	4	cc	_	_
+18	etwas	etwas	ADV	ADV	_	19	advmod	_	_
+19	moderater	moderat	ADJ	ADJD	_	4	amod	_	_
+20	als	als	CCONJ	KOKOM	_	19	dep	_	_
+21	in	in	ADP	APPR	_	23	case	_	_
+22	der	der	DET	ART	Case=Dat|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	23	det	_	_
+23	Vergangenheit	Vergangenheit	NOUN	NN	Case=Dat|Gender=Fem|Number=Sing	20	nmod	_	SpaceAfter=No
+24	.	.	PUNCT	$.	_	4	punct	_	_
 
 # sent_id = test-s426
 # text = Grund: am 6. Mai vergangenen Jahres erließen die Zollbehörden des Landes Vorarlberg eine ``Hofdüngereinfuhrsperre'' für Bauern aus der Schweizer Nachbarschaft, die jenseits der Landesgrenze auf österreichischem Hoheitsgebiet seit Jahrzehnten Pachtland bewirtschaften.
@@ -8032,20 +8129,21 @@
 38	.	.	PUNCT	$.	_	10	punct	_	_
 
 # sent_id = test-s427
-# text = Hintergründe des Mordes sind nach wie vor unklar.
-1	Hintergründe	Hintergrund	NOUN	NN	Case=Nom|Gender=Masc|Number=Plur	8	nsubj	_	_
-2	des	der	DET	ART	Case=Gen|Definite=Def|Gender=Masc|Number=Sing|PronType=Art	3	det	_	_
-3	Mordes	Mord	NOUN	NN	Case=Gen|Gender=Masc|Number=Sing	1	nmod	_	_
-4	sind	sein	AUX	VAFIN	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	8	cop	_	_
-5	nach	nach	ADP	ADV	_	8	case	_	_
-6	wie	wie	ADV	KON	_	5	fixed	_	_
-7	vor	vor	ADP	ADV	_	6	case	_	_
-8	unklar	unklar	ADJ	ADJD	_	0	root	_	SpaceAfter=No
-9	.	.	PUNCT	$.	_	8	punct	_	_
+# text = Die Hintergründe des Mordes sind nach wie vor unklar.
+1	Die	der	DET	ART	Case=Nom|Definite=Def|Gender=Masc|Number=Plur|PronType=Art	2	dep	_	FixTigerDep=Yes
+2	Hintergründe	Hintergrund	NOUN	NN	Case=Nom|Gender=Masc|Number=Plur	9	nsubj	_	_
+3	des	der	DET	ART	Case=Gen|Definite=Def|Gender=Masc|Number=Sing|PronType=Art	4	det	_	_
+4	Mordes	Mord	NOUN	NN	Case=Gen|Gender=Masc|Number=Sing	2	nmod	_	_
+5	sind	sein	AUX	VAFIN	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	9	cop	_	_
+6	nach	nach	ADP	ADV	_	9	case	_	_
+7	wie	wie	ADV	KON	_	6	fixed	_	_
+8	vor	vor	ADP	ADV	_	7	case	_	_
+9	unklar	unklar	ADJ	ADJD	_	0	root	_	SpaceAfter=No
+10	.	.	PUNCT	$.	_	9	punct	_	_
 
 # sent_id = test-s428
-# text = "Horse wurde am 5. September 1877 in Fort Robinson von einem Soldaten erstochen.
-1	"	"	PUNCT	$(	_	15	punct	_	SpaceAfter=No
+# text = Crazy Horse wurde am 5. September 1877 in Fort Robinson von einem Soldaten erstochen.
+1	Crazy	Crazy	PROPN	NE	Case=Nom|Number=Sing	2	dep	_	FixTigerDep=Yes
 2	Horse	Horse	PROPN	NE	Case=Nom|Number=Sing	15	nsubj:pass	_	_
 3	wurde	werden	AUX	VAFIN	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin|Voice=Pass	15	aux:pass	_	_
 4-5	am	_	_	_	_	_	_	_	_
@@ -8064,8 +8162,8 @@
 16	.	.	PUNCT	$.	_	15	punct	_	_
 
 # sent_id = test-s429
-# text = "Ich bin sehr traurig, schockiert über dieses furchtbare Verbrechen an einem der tapferen Führer Israels und der Friedensstifter.
-1	"	"	PUNCT	$(	_	5	punct	_	SpaceAfter=No
+# text = ``Ich bin sehr traurig, schockiert über dieses furchtbare Verbrechen an einem der tapferen Führer Israels und der Friedensstifter.
+1	``	"	PUNCT	$(	_	2	punct	_	FixTigerDep=Yes|SpaceAfter=No
 2	Ich	ich	PRON	PPER	Case=Nom|Number=Sing|Person=1|PronType=Prs	5	nsubj	_	_
 3	bin	sein	AUX	VAFIN	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	5	cop	_	_
 4	sehr	sehr	ADV	ADV	_	5	advmod	_	_
@@ -8088,20 +8186,21 @@
 21	.	.	PUNCT	$.	_	5	punct	_	_
 
 # sent_id = test-s430
-# text = Ich habe versucht, so stark wie nur irgend möglich zu sein.
-1	Ich	ich	PRON	PPER	Case=Nom|Number=Sing|Person=1|PronType=Prs	3	nsubj	_	_
-2	habe	haben	AUX	VAFIN	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	3	aux	_	_
-3	versucht	versuchen	VERB	VVPP	VerbForm=Part	0	root	_	SpaceAfter=No
-4	,	,	PUNCT	$,	_	3	punct	_	_
-5	so	so	ADV	ADV	_	6	advmod	_	_
-6	stark	stark	ADJ	ADJD	_	3	xcomp	_	_
-7	wie	wie	CCONJ	KOKOM	_	10	case	_	_
-8	nur	nur	ADV	ADV	_	10	advmod	_	_
-9	irgend	irgend	ADV	ADV	_	10	advmod	_	_
-10	möglich	möglich	ADV	ADJD	_	6	advmod	_	_
-11	zu	zu	PART	PTKZU	_	12	mark	_	_
-12	sein	sein	AUX	VAINF	VerbForm=Inf	6	cop	_	SpaceAfter=No
-13	.	.	PUNCT	$.	_	3	punct	_	_
+# text = ``Ich habe versucht, so stark wie nur irgend möglich zu sein.
+1	``	``	PUNCT	$(	_	2	punct	_	FixTigerDep=Yes|SpaceAfter=No
+2	Ich	ich	PRON	PPER	Case=Nom|Number=Sing|Person=1|PronType=Prs	4	nsubj	_	_
+3	habe	haben	AUX	VAFIN	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	4	aux	_	_
+4	versucht	versuchen	VERB	VVPP	VerbForm=Part	0	root	_	SpaceAfter=No
+5	,	,	PUNCT	$,	_	4	punct	_	_
+6	so	so	ADV	ADV	_	7	advmod	_	_
+7	stark	stark	ADJ	ADJD	_	4	xcomp	_	_
+8	wie	wie	CCONJ	KOKOM	_	11	case	_	_
+9	nur	nur	ADV	ADV	_	11	advmod	_	_
+10	irgend	irgend	ADV	ADV	_	11	advmod	_	_
+11	möglich	möglich	ADV	ADJD	_	7	advmod	_	_
+12	zu	zu	PART	PTKZU	_	13	mark	_	_
+13	sein	sein	AUX	VAINF	VerbForm=Inf	7	cop	_	SpaceAfter=No
+14	.	.	PUNCT	$.	_	4	punct	_	_
 
 # sent_id = test-s431
 # text = Ich zweifle, ob wir das überlebten, ob der Staat das überlebte.
@@ -8121,86 +8220,89 @@
 14	.	.	PUNCT	$.	_	2	punct	_	_
 
 # sent_id = test-s432
-# text = im Folgejahr soll ein operativer Gewinn und 1999 wieder eine Dividende herausspringen.
-1-2	im	_	_	_	_	_	_	_	_
-1	in	in	ADP	APPR	_	3	case	_	_
-2	dem	der	DET	ART	Case=Dat|Definite=Def|Gender=Neut|Number=Sing|PronType=Art	3	det	_	_
-3	Folgejahr	Folgejahr	NOUN	NN	Case=Dat|Gender=Neut|Number=Sing	13	obl	_	_
-4	soll	sollen	AUX	VMFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	13	aux	_	_
-5	ein	ein	DET	ART	Case=Nom|Definite=Ind|Gender=Masc|Number=Sing|PronType=Art	7	det	_	_
-6	operativer	operativ	ADJ	ADJA	Case=Nom|Gender=Masc|Number=Sing	7	amod	_	_
-7	Gewinn	Gewinn	NOUN	NN	Case=Nom|Gender=Masc|Number=Sing	13	nsubj	_	_
-8	und	und	CCONJ	KON	_	12	cc	_	_
-9	1999	1999	NUM	CARD	NumType=Card	13	obl	_	_
-10	wieder	wieder	ADV	ADV	_	9	advmod	_	_
-11	eine	ein	DET	ART	Case=Nom|Definite=Ind|Gender=Fem|Number=Sing|PronType=Art	12	det	_	_
-12	Dividende	Dividende	NOUN	NN	Case=Nom|Gender=Fem|Number=Sing	7	conj	_	_
-13	herausspringen	herausspringen	VERB	VVINF	VerbForm=Inf	0	root	_	SpaceAfter=No
-14	.	.	PUNCT	$.	_	13	punct	_	_
+# text = Spätestens im Folgejahr soll ein operativer Gewinn und 1999 wieder eine Dividende herausspringen.
+1	Spätestens	spätestens	ADV	ADV	_	2	dep	_	FixTigerDep=Yes
+2-3	im	_	_	_	_	_	_	_	_
+2	in	in	ADP	APPR	_	4	case	_	_
+3	dem	der	DET	ART	Case=Dat|Definite=Def|Gender=Neut|Number=Sing|PronType=Art	4	det	_	_
+4	Folgejahr	Folgejahr	NOUN	NN	Case=Dat|Gender=Neut|Number=Sing	14	obl	_	_
+5	soll	sollen	AUX	VMFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	14	aux	_	_
+6	ein	ein	DET	ART	Case=Nom|Definite=Ind|Gender=Masc|Number=Sing|PronType=Art	8	det	_	_
+7	operativer	operativ	ADJ	ADJA	Case=Nom|Gender=Masc|Number=Sing	8	amod	_	_
+8	Gewinn	Gewinn	NOUN	NN	Case=Nom|Gender=Masc|Number=Sing	14	nsubj	_	_
+9	und	und	CCONJ	KON	_	13	cc	_	_
+10	1999	1999	NUM	CARD	NumType=Card	14	obl	_	_
+11	wieder	wieder	ADV	ADV	_	10	advmod	_	_
+12	eine	ein	DET	ART	Case=Nom|Definite=Ind|Gender=Fem|Number=Sing|PronType=Art	13	det	_	_
+13	Dividende	Dividende	NOUN	NN	Case=Nom|Gender=Fem|Number=Sing	8	conj	_	_
+14	herausspringen	herausspringen	VERB	VVINF	VerbForm=Inf	0	root	_	SpaceAfter=No
+15	.	.	PUNCT	$.	_	14	punct	_	_
 
 # sent_id = test-s433
-# text = im vergangenen Sommer schien die Vertragsverlängerung (bis 2001) für Gérard Mortier, den Intendanten der Salzburger Festspiele seit 1991, unmittelbar bevorzustehen und gleichsam nur mehr eine Formsache.
-1-2	im	_	_	_	_	_	_	_	_
-1	in	in	ADP	APPR	_	4	case	_	_
-2	dem	der	DET	ART	Case=Dat|Definite=Def|Gender=Masc|Number=Sing|PronType=Art	4	det	_	_
-3	vergangenen	vergangen	ADJ	ADJA	Case=Dat|Gender=Masc|Number=Sing	4	amod	_	_
-4	Sommer	Sommer	NOUN	NN	Case=Dat|Gender=Masc|Number=Sing	5	obl	_	_
-5	schien	scheinen	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	0	root	_	_
-6	die	der	DET	ART	Case=Nom|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	7	det	_	_
-7	Vertragsverlängerung	Vertragsverlängerung	NOUN	NN	Case=Nom|Gender=Fem|Number=Sing	5	nsubj	_	_
-8	(	(	PUNCT	$(	_	9	punct	_	SpaceAfter=No
-9	bis	bis	ADP	APPR	_	7	appos	_	_
-10	2001	2001	NUM	CARD	NumType=Card	9	nmod	_	SpaceAfter=No
-11	)	)	PUNCT	$(	_	9	punct	_	_
-12	für	für	ADP	APPR	_	13	case	_	_
-13	Gérard	Gérard	PROPN	NE	Case=Nom|Gender=Masc|Number=Sing	7	nmod	_	_
-14	Mortier	Mortier	PROPN	NE	Case=Acc|Gender=Masc|Number=Sing	13	flat	_	SpaceAfter=No
-15	,	,	PUNCT	$,	_	5	punct	_	_
-16	den	der	DET	ART	Case=Acc|Definite=Def|Gender=Masc|Number=Sing|PronType=Art	17	det	_	_
-17	Intendanten	Intendant	NOUN	NN	Case=Acc|Gender=Masc|Number=Sing	13	appos	_	_
-18	der	der	DET	ART	Case=Gen|Definite=Def|Gender=Neut|Number=Plur|PronType=Art	20	det	_	_
-19	Salzburger	Salzburger	ADJ	ADJA	_	20	amod	_	_
-20	Festspiele	Festspiel	PROPN	NN	Case=Gen|Gender=Neut|Number=Plur	17	nmod	_	_
-21	seit	seit	ADP	APPR	_	22	case	_	_
-22	1991	1991	NUM	CARD	NumType=Card	17	nmod	_	SpaceAfter=No
-23	,	,	PUNCT	$,	_	5	punct	_	_
-24	unmittelbar	unmittelbar	ADV	ADJD	_	25	advmod	_	_
-25	bevorzustehen	bevorstehen	VERB	VVIZU	VerbForm=Inf	5	xcomp	_	_
-26	und	und	CCONJ	KON	_	31	cc	_	_
-27	gleichsam	gleichsam	ADV	ADJD	_	31	advmod	_	_
-28	nur	nur	ADV	ADV	_	31	advmod	_	_
-29	mehr	mehr	ADV	ADV	_	31	advmod	_	_
-30	eine	ein	DET	ART	Case=Nom|Definite=Ind|Gender=Fem|Number=Sing|PronType=Art	31	det	_	_
-31	Formsache	Formsache	NOUN	NN	Case=Nom|Gender=Fem|Number=Sing	25	conj	_	SpaceAfter=No
-32	.	.	PUNCT	$.	_	5	punct	_	_
+# text = Schon im vergangenen Sommer schien die Vertragsverlängerung (bis 2001) für Gérard Mortier, den Intendanten der Salzburger Festspiele seit 1991, unmittelbar bevorzustehen und gleichsam nur mehr eine Formsache.
+1	Schon	schon	ADV	ADV	_	2	dep	_	FixTigerDep=Yes
+2-3	im	_	_	_	_	_	_	_	_
+2	in	in	ADP	APPR	_	5	case	_	_
+3	dem	der	DET	ART	Case=Dat|Definite=Def|Gender=Masc|Number=Sing|PronType=Art	5	det	_	_
+4	vergangenen	vergangen	ADJ	ADJA	Case=Dat|Gender=Masc|Number=Sing	5	amod	_	_
+5	Sommer	Sommer	NOUN	NN	Case=Dat|Gender=Masc|Number=Sing	6	obl	_	_
+6	schien	scheinen	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	0	root	_	_
+7	die	der	DET	ART	Case=Nom|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	8	det	_	_
+8	Vertragsverlängerung	Vertragsverlängerung	NOUN	NN	Case=Nom|Gender=Fem|Number=Sing	6	nsubj	_	_
+9	(	(	PUNCT	$(	_	10	punct	_	SpaceAfter=No
+10	bis	bis	ADP	APPR	_	8	appos	_	_
+11	2001	2001	NUM	CARD	NumType=Card	10	nmod	_	SpaceAfter=No
+12	)	)	PUNCT	$(	_	10	punct	_	_
+13	für	für	ADP	APPR	_	14	case	_	_
+14	Gérard	Gérard	PROPN	NE	Case=Nom|Gender=Masc|Number=Sing	8	nmod	_	_
+15	Mortier	Mortier	PROPN	NE	Case=Acc|Gender=Masc|Number=Sing	14	flat	_	SpaceAfter=No
+16	,	,	PUNCT	$,	_	6	punct	_	_
+17	den	der	DET	ART	Case=Acc|Definite=Def|Gender=Masc|Number=Sing|PronType=Art	18	det	_	_
+18	Intendanten	Intendant	NOUN	NN	Case=Acc|Gender=Masc|Number=Sing	14	appos	_	_
+19	der	der	DET	ART	Case=Gen|Definite=Def|Gender=Neut|Number=Plur|PronType=Art	21	det	_	_
+20	Salzburger	Salzburger	ADJ	ADJA	_	21	amod	_	_
+21	Festspiele	Festspiel	PROPN	NN	Case=Gen|Gender=Neut|Number=Plur	18	nmod	_	_
+22	seit	seit	ADP	APPR	_	23	case	_	_
+23	1991	1991	NUM	CARD	NumType=Card	18	nmod	_	SpaceAfter=No
+24	,	,	PUNCT	$,	_	6	punct	_	_
+25	unmittelbar	unmittelbar	ADV	ADJD	_	26	advmod	_	_
+26	bevorzustehen	bevorstehen	VERB	VVIZU	VerbForm=Inf	6	xcomp	_	_
+27	und	und	CCONJ	KON	_	32	cc	_	_
+28	gleichsam	gleichsam	ADV	ADJD	_	32	advmod	_	_
+29	nur	nur	ADV	ADV	_	32	advmod	_	_
+30	mehr	mehr	ADV	ADV	_	32	advmod	_	_
+31	eine	ein	DET	ART	Case=Nom|Definite=Ind|Gender=Fem|Number=Sing|PronType=Art	32	det	_	_
+32	Formsache	Formsache	NOUN	NN	Case=Nom|Gender=Fem|Number=Sing	26	conj	_	SpaceAfter=No
+33	.	.	PUNCT	$.	_	6	punct	_	_
 
 # sent_id = test-s434
-# text = In den Monaten seit dem Regierungswechsel ist, im Gegensatz zu den Ankündigungen der neuen Regierung, kein Fortschritt in Menschenrechtsfragen festzustellen.
-1	In	in	ADP	APPR	_	3	case	_	_
-2	den	der	DET	ART	Case=Dat|Definite=Def|Gender=Masc|Number=Plur|PronType=Art	3	det	_	_
-3	Monaten	Monat	NOUN	NN	Case=Dat|Gender=Masc|Number=Plur	23	obl	_	_
-4	seit	seit	ADP	APPR	_	6	case	_	_
-5	dem	der	DET	ART	Case=Dat|Definite=Def|Gender=Masc|Number=Sing|PronType=Art	6	det	_	_
-6	Regierungswechsel	Regierungswechsel	NOUN	NN	Case=Dat|Gender=Masc|Number=Sing	3	nmod	_	_
-7	ist	sein	AUX	VAFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	23	aux:pass	_	SpaceAfter=No
-8	,	,	PUNCT	$,	_	23	punct	_	_
-9-10	im	_	_	_	_	_	_	_	_
-9	in	in	ADP	APPR	_	11	case	_	_
-10	dem	der	DET	ART	Case=Dat|Definite=Def|Gender=Masc|Number=Sing|PronType=Art	11	det	_	_
-11	Gegensatz	Gegensatz	NOUN	NN	Case=Dat|Gender=Masc|Number=Sing	23	obl	_	_
-12	zu	zu	ADP	APPR	_	14	case	_	_
-13	den	der	DET	ART	Case=Dat|Definite=Def|Gender=Fem|Number=Plur|PronType=Art	14	det	_	_
-14	Ankündigungen	Ankündigung	NOUN	NN	Case=Dat|Gender=Fem|Number=Plur	11	nmod	_	_
-15	der	der	DET	ART	Case=Gen|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	17	det	_	_
-16	neuen	neu	ADJ	ADJA	Case=Gen|Gender=Fem|Number=Sing	17	amod	_	_
-17	Regierung	Regierung	NOUN	NN	Case=Gen|Gender=Fem|Number=Sing	14	nmod	_	SpaceAfter=No
-18	,	,	PUNCT	$,	_	23	punct	_	_
-19	kein	kein	PRON	PIAT	Case=Nom|Definite=Ind|Gender=Masc|Number=Sing|Polarity=Neg|PronType=Neg	20	advmod	_	_
-20	Fortschritt	Fortschritt	NOUN	NN	Case=Nom|Gender=Masc|Number=Sing	23	nsubj:pass	_	_
-21	in	in	ADP	APPR	_	22	case	_	_
-22	Menschenrechtsfragen	Menschenrechtsfrage	NOUN	NN	Case=Dat|Gender=Fem|Number=Plur	20	nmod	_	_
-23	festzustellen	feststellen	VERB	VVIZU	VerbForm=Inf	0	root	_	SpaceAfter=No
-24	.	.	PUNCT	$.	_	23	punct	_	_
+# text = ``In den Monaten seit dem Regierungswechsel ist, im Gegensatz zu den Ankündigungen der neuen Regierung, kein Fortschritt in Menschenrechtsfragen festzustellen.
+1	``	``	PUNCT	$(	_	2	punct	_	FixTigerDep=Yes|SpaceAfter=No
+2	In	in	ADP	APPR	_	4	case	_	_
+3	den	der	DET	ART	Case=Dat|Definite=Def|Gender=Masc|Number=Plur|PronType=Art	4	det	_	_
+4	Monaten	Monat	NOUN	NN	Case=Dat|Gender=Masc|Number=Plur	24	obl	_	_
+5	seit	seit	ADP	APPR	_	7	case	_	_
+6	dem	der	DET	ART	Case=Dat|Definite=Def|Gender=Masc|Number=Sing|PronType=Art	7	det	_	_
+7	Regierungswechsel	Regierungswechsel	NOUN	NN	Case=Dat|Gender=Masc|Number=Sing	4	nmod	_	_
+8	ist	sein	AUX	VAFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	24	aux:pass	_	SpaceAfter=No
+9	,	,	PUNCT	$,	_	24	punct	_	_
+10-11	im	_	_	_	_	_	_	_	_
+10	in	in	ADP	APPR	_	12	case	_	_
+11	dem	der	DET	ART	Case=Dat|Definite=Def|Gender=Masc|Number=Sing|PronType=Art	12	det	_	_
+12	Gegensatz	Gegensatz	NOUN	NN	Case=Dat|Gender=Masc|Number=Sing	24	obl	_	_
+13	zu	zu	ADP	APPR	_	15	case	_	_
+14	den	der	DET	ART	Case=Dat|Definite=Def|Gender=Fem|Number=Plur|PronType=Art	15	det	_	_
+15	Ankündigungen	Ankündigung	NOUN	NN	Case=Dat|Gender=Fem|Number=Plur	12	nmod	_	_
+16	der	der	DET	ART	Case=Gen|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	18	det	_	_
+17	neuen	neu	ADJ	ADJA	Case=Gen|Gender=Fem|Number=Sing	18	amod	_	_
+18	Regierung	Regierung	NOUN	NN	Case=Gen|Gender=Fem|Number=Sing	15	nmod	_	SpaceAfter=No
+19	,	,	PUNCT	$,	_	24	punct	_	_
+20	kein	kein	PRON	PIAT	Case=Nom|Definite=Ind|Gender=Masc|Number=Sing|Polarity=Neg|PronType=Neg	21	advmod	_	_
+21	Fortschritt	Fortschritt	NOUN	NN	Case=Nom|Gender=Masc|Number=Sing	24	nsubj:pass	_	_
+22	in	in	ADP	APPR	_	23	case	_	_
+23	Menschenrechtsfragen	Menschenrechtsfrage	NOUN	NN	Case=Dat|Gender=Fem|Number=Plur	21	nmod	_	_
+24	festzustellen	feststellen	VERB	VVIZU	VerbForm=Inf	0	root	_	SpaceAfter=No
+25	.	.	PUNCT	$.	_	24	punct	_	_
 
 # sent_id = test-s435
 # text = In dieser Getto-Situation suchen sie Zuflucht in einer, kurdischen Identität, 'was zu einer wachsenden Radikalisierung führt'', heißt es in der Studie.
@@ -8235,24 +8337,25 @@
 29	.	.	PUNCT	$.	_	24	punct	_	_
 
 # sent_id = test-s436
-# text = Independent hatte berichtet, Irving habe die Tagebücher den russischen Archiven für eine sechsstellige Summe abgekauft.
-1	Independent	Independent	PROPN	NE	Case=Nom|Number=Sing	3	nsubj	_	_
-2	hatte	haben	AUX	VAFIN	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	3	aux	_	_
-3	berichtet	berichten	VERB	VVPP	VerbForm=Part	0	root	_	SpaceAfter=No
-4	,	,	PUNCT	$,	_	3	punct	_	_
-5	Irving	Irving	PROPN	NE	Case=Nom|Number=Sing	16	nsubj	_	_
-6	habe	haben	AUX	VAFIN	Mood=Sub|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	16	aux	_	_
-7	die	der	DET	ART	Case=Acc|Definite=Def|Gender=Neut|Number=Plur|PronType=Art	8	det	_	_
-8	Tagebücher	Tagebuch	NOUN	NN	Case=Acc|Gender=Neut|Number=Plur	16	obj	_	_
-9	den	der	DET	ART	Case=Dat|Definite=Def|Gender=Neut|Number=Plur|PronType=Art	11	det	_	_
-10	russischen	russisch	ADJ	ADJA	Case=Dat|Gender=Neut|Number=Plur	11	amod	_	_
-11	Archiven	Archiv	NOUN	NN	Case=Dat|Gender=Neut|Number=Plur	16	iobj	_	_
-12	für	für	ADP	APPR	_	15	case	_	_
-13	eine	ein	DET	ART	Case=Acc|Definite=Ind|Gender=Fem|Number=Sing|PronType=Art	15	det	_	_
-14	sechsstellige	sechsstellig	ADJ	ADJA	Case=Acc|Gender=Fem|Number=Sing	15	amod	_	_
-15	Summe	Summe	NOUN	NN	Case=Acc|Gender=Fem|Number=Sing	16	obl	_	_
-16	abgekauft	abkaufen	VERB	VVPP	VerbForm=Part	3	ccomp	_	SpaceAfter=No
-17	.	.	PUNCT	$.	_	3	punct	_	_
+# text = The Independent hatte berichtet, Irving habe die Tagebücher den russischen Archiven für eine sechsstellige Summe abgekauft.
+1	The	The	PROPN	NE	_	2	dep	_	FixTigerDep=Yes
+2	Independent	Independent	PROPN	NE	Case=Nom|Number=Sing	4	nsubj	_	_
+3	hatte	haben	AUX	VAFIN	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	4	aux	_	_
+4	berichtet	berichten	VERB	VVPP	VerbForm=Part	0	root	_	SpaceAfter=No
+5	,	,	PUNCT	$,	_	4	punct	_	_
+6	Irving	Irving	PROPN	NE	Case=Nom|Number=Sing	17	nsubj	_	_
+7	habe	haben	AUX	VAFIN	Mood=Sub|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	17	aux	_	_
+8	die	der	DET	ART	Case=Acc|Definite=Def|Gender=Neut|Number=Plur|PronType=Art	9	det	_	_
+9	Tagebücher	Tagebuch	NOUN	NN	Case=Acc|Gender=Neut|Number=Plur	17	obj	_	_
+10	den	der	DET	ART	Case=Dat|Definite=Def|Gender=Neut|Number=Plur|PronType=Art	12	det	_	_
+11	russischen	russisch	ADJ	ADJA	Case=Dat|Gender=Neut|Number=Plur	12	amod	_	_
+12	Archiven	Archiv	NOUN	NN	Case=Dat|Gender=Neut|Number=Plur	17	iobj	_	_
+13	für	für	ADP	APPR	_	16	case	_	_
+14	eine	ein	DET	ART	Case=Acc|Definite=Ind|Gender=Fem|Number=Sing|PronType=Art	16	det	_	_
+15	sechsstellige	sechsstellig	ADJ	ADJA	Case=Acc|Gender=Fem|Number=Sing	16	amod	_	_
+16	Summe	Summe	NOUN	NN	Case=Acc|Gender=Fem|Number=Sing	17	obl	_	_
+17	abgekauft	abkaufen	VERB	VVPP	VerbForm=Part	4	ccomp	_	SpaceAfter=No
+18	.	.	PUNCT	$.	_	4	punct	_	_
 
 # sent_id = test-s437
 # text = Informationen sind erhältlich bei Tel Dor -- Projekt, Erika und Walter Haury, Doninikus -- Zimmermann -- Str. 9, 88299 Leutkirch, Tel. und Fax 07561 / 3128.
@@ -8291,522 +8394,546 @@
 33	.	.	PUNCT	$.	_	3	punct	_	_
 
 # sent_id = test-s438
-# text = Informationsgesellschaft erst schafft neue Arbeitsplätze im Dienstleistungssektor.
-1	Informationsgesellschaft	Informationsgesellschaft	NOUN	NN	Case=Nom|Gender=Fem|Number=Sing	3	nsubj	_	_
-2	erst	erst	ADV	ADV	_	3	advmod	_	_
-3	schafft	schaffen	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	0	root	_	_
-4	neue	neu	ADJ	ADJA	Case=Acc|Gender=Masc|Number=Plur	5	amod	_	_
-5	Arbeitsplätze	Arbeitsplatz	NOUN	NN	Case=Acc|Gender=Masc|Number=Plur	3	obj	_	_
-6-7	im	_	_	_	_	_	_	_	_
-6	in	in	ADP	APPR	_	8	case	_	_
-7	dem	der	DET	ART	Case=Dat|Definite=Def|Gender=Masc|Number=Sing|PronType=Art	8	det	_	_
-8	Dienstleistungssektor	Dienstleistungssektor	NOUN	NN	Case=Dat|Gender=Masc|Number=Sing	3	obl	_	SpaceAfter=No
-9	.	.	PUNCT	$.	_	3	punct	_	_
-
-# sent_id = test-s439
-# text = Interesse sei eben ``ganz schön dünne, wenn mal was in Asien ist''.
-1	Interesse	Interesse	NOUN	NN	Case=Nom|Gender=Neut|Number=Sing	7	nsubj	_	_
-2	sei	sein	AUX	VAFIN	Mood=Sub|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	7	cop	_	_
-3	eben	eben	ADV	ADV	_	7	advmod	_	_
-4	``	``	PUNCT	$(	_	7	punct	_	SpaceAfter=No
-5	ganz	ganz	ADV	ADV	_	6	advmod	_	_
-6	schön	schön	ADV	ADJD	_	7	advmod	_	_
-7	dünne	dünn	ADJ	ADJD	_	0	root	_	SpaceAfter=No
-8	,	,	PUNCT	$,	_	7	punct	_	_
-9	wenn	wenn	SCONJ	KOUS	_	14	mark	_	_
-10	mal	mal	ADV	ADV	_	14	advmod	_	_
-11	was	was	PRON	PIS	Case=Nom|Definite=Ind|Gender=Neut|Number=Sing|PronType=Ind	14	nsubj	_	_
-12	in	in	ADP	APPR	_	13	case	_	_
-13	Asien	Asien	PROPN	NE	Case=Dat|Gender=Neut|Number=Sing	14	obl	_	_
-14	ist	sein	VERB	VAFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	7	advcl	_	SpaceAfter=No
-15	''	''	PUNCT	$(	_	7	punct	_	SpaceAfter=No
-16	.	.	PUNCT	$.	_	7	punct	_	_
-
-# sent_id = test-s440
-# text = Internationale Komitee des Roten Kreuz (IKRK) zog sich am Dienstag aus der umkämpften Tamilen-Hochburg Jaffna im Norden Sri Lankas zurück.
-1	Internationale	international	ADJ	ADJA	Case=Nom|Gender=Neut|Number=Sing	2	amod	_	_
-2	Komitee	Komitee	NOUN	NN	Case=Nom|Gender=Neut|Number=Sing	9	nsubj	_	_
-3	des	der	DET	ART	Case=Gen|Definite=Def|Gender=Neut|Number=Sing|PronType=Art	4	det	_	_
-4	Roten	rot	PROPN	ADJA	Case=Gen|Gender=Neut|Number=Sing	2	nmod	_	_
-5	Kreuz	Kreuz	PROPN	NN	Case=Gen|Gender=Neut|Number=Sing	4	flat	_	_
-6	(	(	PUNCT	$(	_	4	punct	_	SpaceAfter=No
-7	IKRK	IKRK	PROPN	NE	Case=Nom|Gender=Neut|Number=Sing	4	appos	_	SpaceAfter=No
-8	)	)	PUNCT	$(	_	4	punct	_	_
-9	zog	ziehen	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	0	root	_	_
-10	sich	er|es|sie	PRON	PRF	Case=Acc|Number=Sing|Person=3|PronType=Prs|Reflex=Yes	9	obj	_	_
-11-12	am	_	_	_	_	_	_	_	_
-11	an	an	ADP	APPR	_	13	case	_	_
-12	dem	der	DET	ART	Case=Dat|Definite=Def|Gender=Masc|Number=Sing|PronType=Art	13	det	_	_
-13	Dienstag	Dienstag	PROPN	NN	Case=Dat|Gender=Masc|Number=Sing	9	obl	_	_
-14	aus	aus	ADP	APPR	_	17	case	_	_
-15	der	der	DET	ART	Case=Dat|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	17	det	_	_
-16	umkämpften	umkämpft	ADJ	ADJA	Case=Dat|Gender=Fem|Number=Sing	17	amod	_	_
-17	Tamilen	Tamile	PROPN	NN	Case=Dat|Gender=Fem|Number=Sing	19	compound	_	SpaceAfter=No
-18	-	-	PUNCT	$(	_	17	punct	_	SpaceAfter=No
-19	Hochburg	Hochburg	NOUN	NN	Case=Dat|Gender=Fem|Number=Sing	9	obl	_	_
-20	Jaffna	Jaffna	PROPN	NE	Case=Nom|Gender=Neut|Number=Sing	17	appos	_	_
-21-22	im	_	_	_	_	_	_	_	_
-21	in	in	ADP	APPR	_	23	case	_	_
-22	dem	der	DET	ART	Case=Dat|Definite=Def|Gender=Masc|Number=Sing|PronType=Art	23	det	_	_
-23	Norden	Norden	NOUN	NN	Case=Dat|Gender=Masc|Number=Sing	17	nmod	_	_
-24	Sri	Sri	PROPN	NE	_	23	nmod	_	_
-25	Lankas	Lanka	PROPN	NE	Case=Gen|Gender=Neut|Number=Sing	24	flat	_	_
-26	zurück	zurück	ADV	PTKVZ	_	9	compound:prt	_	SpaceAfter=No
-27	.	.	PUNCT	$.	_	9	punct	_	_
-
-# sent_id = test-s441
-# text = Investitionen in China, die nun stark anziehen, sind mehr als nur wünschenswert.
-1	Investitionen	Investition	NOUN	NN	Case=Nom|Gender=Fem|Number=Plur	14	nsubj	_	_
-2	in	in	ADP	APPR	_	3	case	_	_
-3	China	China	PROPN	NE	Case=Dat|Gender=Neut|Number=Sing	1	nmod	_	SpaceAfter=No
-4	,	,	PUNCT	$,	_	14	punct	_	_
-5	die	der	PRON	PRELS	Case=Nom|Gender=Fem|Number=Plur|PronType=Rel	8	nsubj	_	_
-6	nun	nun	ADV	ADV	_	8	advmod	_	_
-7	stark	stark	ADV	ADJD	_	8	advmod	_	_
-8	anziehen	anziehen	VERB	VVFIN	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	1	acl	_	SpaceAfter=No
-9	,	,	PUNCT	$,	_	14	punct	_	_
-10	sind	sein	AUX	VAFIN	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	14	cop	_	_
-11	mehr	mehr	ADV	PIS	Definite=Ind|PronType=Ind	12	advmod	_	_
-12	als	als	CCONJ	KOKOM	_	13	dep	_	_
-13	nur	nur	ADV	ADV	_	14	advmod	_	_
-14	wünschenswert	wünschenswert	ADJ	ADJD	_	0	root	_	SpaceAfter=No
-15	.	.	PUNCT	$.	_	14	punct	_	_
-
-# sent_id = test-s442
-# text = Islam-Konferenz als solche ``ist und bleibt unumstritten'', sagte Kinkel am Sonntag.
-1	Islam	Islam	NOUN	NN	Case=Nom|Gender=Fem|Number=Sing	3	compound	_	SpaceAfter=No
-2	-	-	PUNCT	$(	_	1	punct	_	SpaceAfter=No
-3	Konferenz	Konferenz	NOUN	NN	Case=Nom|Gender=Fem|Number=Sing	10	nsubj	_	_
-4	als	als	ADP	APPR	_	5	case	_	_
-5	solche	solcher	ADV	PIS	Case=Nom|Definite=Ind|Gender=Fem|Number=Sing|PronType=Ind	3	advmod	_	_
-6	``	``	PUNCT	$(	_	13	punct	_	SpaceAfter=No
-7	ist	sein	AUX	VAFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	10	cop	_	_
-8	und	und	CCONJ	KON	_	9	cc	_	_
-9	bleibt	bleiben	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	13	ccomp	_	_
-10	unumstritten	unumstritten	ADJ	ADJD	_	9	conj	_	SpaceAfter=No
-11	''	''	PUNCT	$(	_	13	punct	_	SpaceAfter=No
-12	,	,	PUNCT	$,	_	13	punct	_	_
-13	sagte	sagen	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	0	root	_	_
-14	Kinkel	Kinkel	PROPN	NE	Case=Nom|Number=Sing	13	nsubj	_	_
-15-16	am	_	_	_	_	_	_	_	_
-15	an	an	ADP	APPR	_	17	case	_	_
-16	dem	der	DET	ART	Case=Dat|Definite=Def|Gender=Masc|Number=Sing|PronType=Art	17	det	_	_
-17	Sonntag	Sonntag	PROPN	NN	Case=Dat|Gender=Masc|Number=Sing	13	obl	_	SpaceAfter=No
-18	.	.	PUNCT	$.	_	13	punct	_	_
-
-# sent_id = test-s443
-# text = israelische Ministerpräsident Yitzhak Rabin ist nach Erkenntnissen der Polizei einer rechtsradikalen Verschwörung zum Opfer gefallen.
-1	israelische	israelisch	ADJ	ADJA	Case=Nom|Gender=Masc|Number=Sing	2	amod	_	_
-2	Ministerpräsident	Ministerpräsident	NOUN	NN	Case=Nom|Gender=Masc|Number=Sing	16	nsubj	_	_
-3	Yitzhak	Yitzhak	PROPN	NE	Case=Nom|Gender=Masc|Number=Sing	2	appos	_	_
-4	Rabin	Rabin	PROPN	NE	Case=Nom|Gender=Masc|Number=Sing	3	flat	_	_
-5	ist	sein	AUX	VAFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	16	aux	_	_
-6	nach	nach	ADP	APPR	_	7	case	_	_
-7	Erkenntnissen	Erkenntnis	NOUN	NN	Case=Dat|Gender=Fem|Number=Plur	16	obl	_	_
-8	der	der	DET	ART	Case=Gen|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	9	det	_	_
-9	Polizei	Polizei	NOUN	NN	Case=Gen|Gender=Fem|Number=Sing	7	nmod	_	_
-10	einer	ein	DET	ART	Case=Dat|Definite=Ind|Gender=Fem|Number=Sing|PronType=Art	12	det	_	_
-11	rechtsradikalen	rechtsradikal	ADJ	ADJA	Case=Dat|Gender=Fem|Number=Sing	12	amod	_	_
-12	Verschwörung	Verschwörung	NOUN	NN	Case=Dat|Gender=Fem|Number=Sing	16	iobj	_	_
-13-14	zum	_	_	_	_	_	_	_	_
-13	zu	zu	ADP	APPR	_	15	case	_	_
-14	dem	der	DET	ART	Case=Dat|Definite=Def|Gender=Neut|Number=Sing|PronType=Art	15	det	_	_
-15	Opfer	Opfer	NOUN	NN	Case=Dat|Gender=Neut|Number=Sing	16	obl	_	_
-16	gefallen	fallen	VERB	VVPP	VerbForm=Part	0	root	_	SpaceAfter=No
-17	.	.	PUNCT	$.	_	16	punct	_	_
-
-# sent_id = test-s444
-# text = Jahre später beschrieb Daniel Bell die post-industrielle Gesellschaft durch Wissensarbeit, Ressourcenschonung und die Verschiebung der Arbeit vom Produktions- in den Dienstleistungssektor.
-1	Jahre	Jahr	NOUN	NN	Case=Acc|Gender=Neut|Number=Plur	2	nmod	_	_
-2	später	spät	ADJ	ADJD	_	3	amod	_	_
-3	beschrieb	beschreiben	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	0	root	_	_
-4	Daniel	Daniel	PROPN	NE	Case=Nom|Gender=Masc|Number=Sing	3	nsubj	_	_
-5	Bell	Bell	PROPN	NE	Case=Nom|Gender=Masc|Number=Sing	4	flat	_	_
-6	die	der	DET	ART	Case=Acc|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	10	det	_	_
-7	post	Post	X	ADJA	Case=Acc|Gender=Fem|Number=Sing	9	compound	_	SpaceAfter=No
-8	-	-	PUNCT	$(	_	7	punct	_	SpaceAfter=No
-9	industrielle	industriell	ADJ	ADJA	Case=Acc|Gender=Fem|Number=Sing	10	amod	_	_
-10	Gesellschaft	Gesellschaft	NOUN	NN	Case=Acc|Gender=Fem|Number=Sing	3	obj	_	_
-11	durch	durch	ADP	APPR	_	12	case	_	_
-12	Wissensarbeit	Wissensarbeit	NOUN	NN	Case=Acc|Gender=Fem|Number=Sing	10	nmod	_	SpaceAfter=No
-13	,	,	PUNCT	$,	_	14	punct	_	_
-14	Ressourcenschonung	Ressourcenschonung	NOUN	NN	Case=Acc|Gender=Fem|Number=Sing	12	conj	_	_
-15	und	und	CCONJ	KON	_	17	cc	_	_
-16	die	der	DET	ART	Case=Acc|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	17	det	_	_
-17	Verschiebung	Verschiebung	NOUN	NN	Case=Acc|Gender=Fem|Number=Sing	12	conj	_	_
-18	der	der	DET	ART	Case=Gen|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	19	det	_	_
-19	Arbeit	Arbeit	NOUN	NN	Case=Gen|Gender=Fem|Number=Sing	17	nmod	_	_
-20-21	vom	_	_	_	_	_	_	_	_
-20	von	von	ADP	APPR	_	22	case	_	_
-21	dem	der	DET	ART	Case=Dat|Definite=Def|Gender=Masc|Number=Sing|PronType=Art	22	det	_	_
-22	Produktions	Produktions	NOUN	NN	Case=Dat|Gender=Masc|Number=Sing	19	compound	_	SpaceAfter=No
-23	-	-	PUNCT	$(	_	22	punct	_	_
-24	in	in	ADP	APPR	_	26	case	_	_
-25	den	der	DET	ART	Case=Acc|Definite=Def|Gender=Masc|Number=Sing|PronType=Art	26	det	_	_
-26	Dienstleistungssektor	Dienstleistungssektor	NOUN	NN	Case=Acc|Gender=Masc|Number=Sing	22	nmod	_	SpaceAfter=No
-27	.	.	PUNCT	$.	_	3	punct	_	_
-
-# sent_id = test-s445
-# text = Jelzin könne sich eine definitive Zusage im Moment aus innenpolitischen Gründen nicht leisten.
-1	Jelzin	Jelzin	PROPN	NE	Case=Nom|Gender=Masc|Number=Sing	14	nsubj	_	_
-2	könne	können	AUX	VMFIN	Mood=Sub|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	14	aux	_	_
-3	sich	er|es|sie	PRON	PRF	Case=Dat|Number=Sing|Person=3|PronType=Prs|Reflex=Yes	14	iobj	_	_
-4	eine	ein	DET	ART	Case=Acc|Definite=Ind|Gender=Fem|Number=Sing|PronType=Art	6	det	_	_
-5	definitive	definitiv	ADJ	ADJA	Case=Acc|Gender=Fem|Number=Sing	6	amod	_	_
-6	Zusage	Zusage	NOUN	NN	Case=Acc|Gender=Fem|Number=Sing	14	obj	_	_
+# text = Die Informationsgesellschaft erst schafft neue Arbeitsplätze im Dienstleistungssektor.
+1	Die	der	DET	ART	Case=Nom|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	2	dep	_	FixTigerDep=Yes
+2	Informationsgesellschaft	Informationsgesellschaft	NOUN	NN	Case=Nom|Gender=Fem|Number=Sing	4	nsubj	_	_
+3	erst	erst	ADV	ADV	_	4	advmod	_	_
+4	schafft	schaffen	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	0	root	_	_
+5	neue	neu	ADJ	ADJA	Case=Acc|Gender=Masc|Number=Plur	6	amod	_	_
+6	Arbeitsplätze	Arbeitsplatz	NOUN	NN	Case=Acc|Gender=Masc|Number=Plur	4	obj	_	_
 7-8	im	_	_	_	_	_	_	_	_
 7	in	in	ADP	APPR	_	9	case	_	_
 8	dem	der	DET	ART	Case=Dat|Definite=Def|Gender=Masc|Number=Sing|PronType=Art	9	det	_	_
-9	Moment	Moment	NOUN	NN	Case=Dat|Gender=Masc|Number=Sing	14	obl	_	_
-10	aus	aus	ADP	APPR	_	12	case	_	_
-11	innenpolitischen	innenpolitisch	ADJ	ADJA	Case=Dat|Gender=Masc|Number=Plur	12	amod	_	_
-12	Gründen	Grund	NOUN	NN	Case=Dat|Gender=Masc|Number=Plur	14	obl	_	_
-13	nicht	nicht	PART	PTKNEG	Polarity=Neg	14	advmod	_	_
-14	leisten	leisten	VERB	VVINF	VerbForm=Inf	0	root	_	SpaceAfter=No
-15	.	.	PUNCT	$.	_	14	punct	_	_
+9	Dienstleistungssektor	Dienstleistungssektor	NOUN	NN	Case=Dat|Gender=Masc|Number=Sing	4	obl	_	SpaceAfter=No
+10	.	.	PUNCT	$.	_	4	punct	_	_
+
+# sent_id = test-s439
+# text = Das Interesse sei eben ``ganz schön dünne, wenn mal was in Asien ist''.
+1	Das	der	DET	ART	Case=Nom|Definite=Def|Gender=Neut|Number=Sing|PronType=Art	2	dep	_	FixTigerDep=Yes
+2	Interesse	Interesse	NOUN	NN	Case=Nom|Gender=Neut|Number=Sing	8	nsubj	_	_
+3	sei	sein	AUX	VAFIN	Mood=Sub|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	8	cop	_	_
+4	eben	eben	ADV	ADV	_	8	advmod	_	_
+5	``	``	PUNCT	$(	_	8	punct	_	SpaceAfter=No
+6	ganz	ganz	ADV	ADV	_	7	advmod	_	_
+7	schön	schön	ADV	ADJD	_	8	advmod	_	_
+8	dünne	dünn	ADJ	ADJD	_	0	root	_	SpaceAfter=No
+9	,	,	PUNCT	$,	_	8	punct	_	_
+10	wenn	wenn	SCONJ	KOUS	_	15	mark	_	_
+11	mal	mal	ADV	ADV	_	15	advmod	_	_
+12	was	was	PRON	PIS	Case=Nom|Definite=Ind|Gender=Neut|Number=Sing|PronType=Ind	15	nsubj	_	_
+13	in	in	ADP	APPR	_	14	case	_	_
+14	Asien	Asien	PROPN	NE	Case=Dat|Gender=Neut|Number=Sing	15	obl	_	_
+15	ist	sein	VERB	VAFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	8	advcl	_	SpaceAfter=No
+16	''	''	PUNCT	$(	_	8	punct	_	SpaceAfter=No
+17	.	.	PUNCT	$.	_	8	punct	_	_
+
+# sent_id = test-s440
+# text = Das Internationale Komitee des Roten Kreuz (IKRK) zog sich am Dienstag aus der umkämpften Tamilen-Hochburg Jaffna im Norden Sri Lankas zurück.
+1	Das	der	DET	ART	Case=Nom|Definite=Def|Gender=Neut|Number=Sing|PronType=Art	2	dep	_	FixTigerDep=Yes
+2	Internationale	international	ADJ	ADJA	Case=Nom|Gender=Neut|Number=Sing	3	amod	_	_
+3	Komitee	Komitee	NOUN	NN	Case=Nom|Gender=Neut|Number=Sing	10	nsubj	_	_
+4	des	der	DET	ART	Case=Gen|Definite=Def|Gender=Neut|Number=Sing|PronType=Art	5	det	_	_
+5	Roten	rot	PROPN	ADJA	Case=Gen|Gender=Neut|Number=Sing	3	nmod	_	_
+6	Kreuz	Kreuz	PROPN	NN	Case=Gen|Gender=Neut|Number=Sing	5	flat	_	_
+7	(	(	PUNCT	$(	_	5	punct	_	SpaceAfter=No
+8	IKRK	IKRK	PROPN	NE	Case=Nom|Gender=Neut|Number=Sing	5	appos	_	SpaceAfter=No
+9	)	)	PUNCT	$(	_	5	punct	_	_
+10	zog	ziehen	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	0	root	_	_
+11	sich	er|es|sie	PRON	PRF	Case=Acc|Number=Sing|Person=3|PronType=Prs|Reflex=Yes	10	obj	_	_
+12-13	am	_	_	_	_	_	_	_	_
+12	an	an	ADP	APPR	_	14	case	_	_
+13	dem	der	DET	ART	Case=Dat|Definite=Def|Gender=Masc|Number=Sing|PronType=Art	14	det	_	_
+14	Dienstag	Dienstag	PROPN	NN	Case=Dat|Gender=Masc|Number=Sing	10	obl	_	_
+15	aus	aus	ADP	APPR	_	18	case	_	_
+16	der	der	DET	ART	Case=Dat|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	18	det	_	_
+17	umkämpften	umkämpft	ADJ	ADJA	Case=Dat|Gender=Fem|Number=Sing	18	amod	_	_
+18	Tamilen	Tamile	PROPN	NN	Case=Dat|Gender=Fem|Number=Sing	20	compound	_	SpaceAfter=No
+19	-	-	PUNCT	$(	_	18	punct	_	SpaceAfter=No
+20	Hochburg	Hochburg	NOUN	NN	Case=Dat|Gender=Fem|Number=Sing	10	obl	_	_
+21	Jaffna	Jaffna	PROPN	NE	Case=Nom|Gender=Neut|Number=Sing	18	appos	_	_
+22-23	im	_	_	_	_	_	_	_	_
+22	in	in	ADP	APPR	_	24	case	_	_
+23	dem	der	DET	ART	Case=Dat|Definite=Def|Gender=Masc|Number=Sing|PronType=Art	24	det	_	_
+24	Norden	Norden	NOUN	NN	Case=Dat|Gender=Masc|Number=Sing	18	nmod	_	_
+25	Sri	Sri	PROPN	NE	_	24	nmod	_	_
+26	Lankas	Lanka	PROPN	NE	Case=Gen|Gender=Neut|Number=Sing	25	flat	_	_
+27	zurück	zurück	ADV	PTKVZ	_	10	compound:prt	_	SpaceAfter=No
+28	.	.	PUNCT	$.	_	10	punct	_	_
+
+# sent_id = test-s441
+# text = Deutsche Investitionen in China, die nun stark anziehen, sind mehr als nur wünschenswert.
+1	Deutsche	deutsch	ADJ	ADJA	Case=Nom|Gender=Fem|Number=Plur	2	dep	_	FixTigerDep=Yes
+2	Investitionen	Investition	NOUN	NN	Case=Nom|Gender=Fem|Number=Plur	15	nsubj	_	_
+3	in	in	ADP	APPR	_	4	case	_	_
+4	China	China	PROPN	NE	Case=Dat|Gender=Neut|Number=Sing	2	nmod	_	SpaceAfter=No
+5	,	,	PUNCT	$,	_	15	punct	_	_
+6	die	der	PRON	PRELS	Case=Nom|Gender=Fem|Number=Plur|PronType=Rel	9	nsubj	_	_
+7	nun	nun	ADV	ADV	_	9	advmod	_	_
+8	stark	stark	ADV	ADJD	_	9	advmod	_	_
+9	anziehen	anziehen	VERB	VVFIN	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	2	acl	_	SpaceAfter=No
+10	,	,	PUNCT	$,	_	15	punct	_	_
+11	sind	sein	AUX	VAFIN	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	15	cop	_	_
+12	mehr	mehr	ADV	PIS	Definite=Ind|PronType=Ind	13	advmod	_	_
+13	als	als	CCONJ	KOKOM	_	14	dep	_	_
+14	nur	nur	ADV	ADV	_	15	advmod	_	_
+15	wünschenswert	wünschenswert	ADJ	ADJD	_	0	root	_	SpaceAfter=No
+16	.	.	PUNCT	$.	_	15	punct	_	_
+
+# sent_id = test-s442
+# text = Die Islam-Konferenz als solche ``ist und bleibt unumstritten'', sagte Kinkel am Sonntag.
+1	Die	der	DET	ART	Case=Nom|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	2	dep	_	FixTigerDep=Yes
+2	Islam	Islam	NOUN	NN	Case=Nom|Gender=Fem|Number=Sing	4	compound	_	SpaceAfter=No
+3	-	-	PUNCT	$(	_	2	punct	_	SpaceAfter=No
+4	Konferenz	Konferenz	NOUN	NN	Case=Nom|Gender=Fem|Number=Sing	11	nsubj	_	_
+5	als	als	ADP	APPR	_	6	case	_	_
+6	solche	solcher	ADV	PIS	Case=Nom|Definite=Ind|Gender=Fem|Number=Sing|PronType=Ind	4	advmod	_	_
+7	``	``	PUNCT	$(	_	14	punct	_	SpaceAfter=No
+8	ist	sein	AUX	VAFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	11	cop	_	_
+9	und	und	CCONJ	KON	_	10	cc	_	_
+10	bleibt	bleiben	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	14	ccomp	_	_
+11	unumstritten	unumstritten	ADJ	ADJD	_	10	conj	_	SpaceAfter=No
+12	''	''	PUNCT	$(	_	14	punct	_	SpaceAfter=No
+13	,	,	PUNCT	$,	_	14	punct	_	_
+14	sagte	sagen	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	0	root	_	_
+15	Kinkel	Kinkel	PROPN	NE	Case=Nom|Number=Sing	14	nsubj	_	_
+16-17	am	_	_	_	_	_	_	_	_
+16	an	an	ADP	APPR	_	18	case	_	_
+17	dem	der	DET	ART	Case=Dat|Definite=Def|Gender=Masc|Number=Sing|PronType=Art	18	det	_	_
+18	Sonntag	Sonntag	PROPN	NN	Case=Dat|Gender=Masc|Number=Sing	14	obl	_	SpaceAfter=No
+19	.	.	PUNCT	$.	_	14	punct	_	_
+
+# sent_id = test-s443
+# text = Der israelische Ministerpräsident Yitzhak Rabin ist nach Erkenntnissen der Polizei einer rechtsradikalen Verschwörung zum Opfer gefallen.
+1	Der	der	DET	ART	Case=Nom|Definite=Def|Gender=Masc|Number=Sing|PronType=Art	2	dep	_	FixTigerDep=Yes
+2	israelische	israelisch	ADJ	ADJA	Case=Nom|Gender=Masc|Number=Sing	3	amod	_	_
+3	Ministerpräsident	Ministerpräsident	NOUN	NN	Case=Nom|Gender=Masc|Number=Sing	17	nsubj	_	_
+4	Yitzhak	Yitzhak	PROPN	NE	Case=Nom|Gender=Masc|Number=Sing	3	appos	_	_
+5	Rabin	Rabin	PROPN	NE	Case=Nom|Gender=Masc|Number=Sing	4	flat	_	_
+6	ist	sein	AUX	VAFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	17	aux	_	_
+7	nach	nach	ADP	APPR	_	8	case	_	_
+8	Erkenntnissen	Erkenntnis	NOUN	NN	Case=Dat|Gender=Fem|Number=Plur	17	obl	_	_
+9	der	der	DET	ART	Case=Gen|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	10	det	_	_
+10	Polizei	Polizei	NOUN	NN	Case=Gen|Gender=Fem|Number=Sing	8	nmod	_	_
+11	einer	ein	DET	ART	Case=Dat|Definite=Ind|Gender=Fem|Number=Sing|PronType=Art	13	det	_	_
+12	rechtsradikalen	rechtsradikal	ADJ	ADJA	Case=Dat|Gender=Fem|Number=Sing	13	amod	_	_
+13	Verschwörung	Verschwörung	NOUN	NN	Case=Dat|Gender=Fem|Number=Sing	17	iobj	_	_
+14-15	zum	_	_	_	_	_	_	_	_
+14	zu	zu	ADP	APPR	_	16	case	_	_
+15	dem	der	DET	ART	Case=Dat|Definite=Def|Gender=Neut|Number=Sing|PronType=Art	16	det	_	_
+16	Opfer	Opfer	NOUN	NN	Case=Dat|Gender=Neut|Number=Sing	17	obl	_	_
+17	gefallen	fallen	VERB	VVPP	VerbForm=Part	0	root	_	SpaceAfter=No
+18	.	.	PUNCT	$.	_	17	punct	_	_
+
+# sent_id = test-s444
+# text = Wenige Jahre später beschrieb Daniel Bell die post-industrielle Gesellschaft durch Wissensarbeit, Ressourcenschonung und die Verschiebung der Arbeit vom Produktions- in den Dienstleistungssektor.
+1	Wenige	wenig	DET	PIAT	Case=Acc|Definite=Ind|Gender=Neut|Number=Plur|PronType=Ind	2	dep	_	FixTigerDep=Yes
+2	Jahre	Jahr	NOUN	NN	Case=Acc|Gender=Neut|Number=Plur	3	nmod	_	_
+3	später	spät	ADJ	ADJD	_	4	amod	_	_
+4	beschrieb	beschreiben	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	0	root	_	_
+5	Daniel	Daniel	PROPN	NE	Case=Nom|Gender=Masc|Number=Sing	4	nsubj	_	_
+6	Bell	Bell	PROPN	NE	Case=Nom|Gender=Masc|Number=Sing	5	flat	_	_
+7	die	der	DET	ART	Case=Acc|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	11	det	_	_
+8	post	Post	X	ADJA	Case=Acc|Gender=Fem|Number=Sing	10	compound	_	SpaceAfter=No
+9	-	-	PUNCT	$(	_	8	punct	_	SpaceAfter=No
+10	industrielle	industriell	ADJ	ADJA	Case=Acc|Gender=Fem|Number=Sing	11	amod	_	_
+11	Gesellschaft	Gesellschaft	NOUN	NN	Case=Acc|Gender=Fem|Number=Sing	4	obj	_	_
+12	durch	durch	ADP	APPR	_	13	case	_	_
+13	Wissensarbeit	Wissensarbeit	NOUN	NN	Case=Acc|Gender=Fem|Number=Sing	11	nmod	_	SpaceAfter=No
+14	,	,	PUNCT	$,	_	15	punct	_	_
+15	Ressourcenschonung	Ressourcenschonung	NOUN	NN	Case=Acc|Gender=Fem|Number=Sing	13	conj	_	_
+16	und	und	CCONJ	KON	_	18	cc	_	_
+17	die	der	DET	ART	Case=Acc|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	18	det	_	_
+18	Verschiebung	Verschiebung	NOUN	NN	Case=Acc|Gender=Fem|Number=Sing	13	conj	_	_
+19	der	der	DET	ART	Case=Gen|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	20	det	_	_
+20	Arbeit	Arbeit	NOUN	NN	Case=Gen|Gender=Fem|Number=Sing	18	nmod	_	_
+21-22	vom	_	_	_	_	_	_	_	_
+21	von	von	ADP	APPR	_	23	case	_	_
+22	dem	der	DET	ART	Case=Dat|Definite=Def|Gender=Masc|Number=Sing|PronType=Art	23	det	_	_
+23	Produktions	Produktions	NOUN	NN	Case=Dat|Gender=Masc|Number=Sing	20	compound	_	SpaceAfter=No
+24	-	-	PUNCT	$(	_	23	punct	_	_
+25	in	in	ADP	APPR	_	27	case	_	_
+26	den	der	DET	ART	Case=Acc|Definite=Def|Gender=Masc|Number=Sing|PronType=Art	27	det	_	_
+27	Dienstleistungssektor	Dienstleistungssektor	NOUN	NN	Case=Acc|Gender=Masc|Number=Sing	23	nmod	_	SpaceAfter=No
+28	.	.	PUNCT	$.	_	4	punct	_	_
+
+# sent_id = test-s445
+# text = Boris Jelzin könne sich eine definitive Zusage im Moment aus innenpolitischen Gründen nicht leisten.
+1	Boris	Boris	PROPN	NE	Case=Nom|Gender=Masc|Number=Sing	2	dep	_	FixTigerDep=Yes
+2	Jelzin	Jelzin	PROPN	NE	Case=Nom|Gender=Masc|Number=Sing	15	nsubj	_	_
+3	könne	können	AUX	VMFIN	Mood=Sub|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	15	aux	_	_
+4	sich	er|es|sie	PRON	PRF	Case=Dat|Number=Sing|Person=3|PronType=Prs|Reflex=Yes	15	iobj	_	_
+5	eine	ein	DET	ART	Case=Acc|Definite=Ind|Gender=Fem|Number=Sing|PronType=Art	7	det	_	_
+6	definitive	definitiv	ADJ	ADJA	Case=Acc|Gender=Fem|Number=Sing	7	amod	_	_
+7	Zusage	Zusage	NOUN	NN	Case=Acc|Gender=Fem|Number=Sing	15	obj	_	_
+8-9	im	_	_	_	_	_	_	_	_
+8	in	in	ADP	APPR	_	10	case	_	_
+9	dem	der	DET	ART	Case=Dat|Definite=Def|Gender=Masc|Number=Sing|PronType=Art	10	det	_	_
+10	Moment	Moment	NOUN	NN	Case=Dat|Gender=Masc|Number=Sing	15	obl	_	_
+11	aus	aus	ADP	APPR	_	13	case	_	_
+12	innenpolitischen	innenpolitisch	ADJ	ADJA	Case=Dat|Gender=Masc|Number=Plur	13	amod	_	_
+13	Gründen	Grund	NOUN	NN	Case=Dat|Gender=Masc|Number=Plur	15	obl	_	_
+14	nicht	nicht	PART	PTKNEG	Polarity=Neg	15	advmod	_	_
+15	leisten	leisten	VERB	VVINF	VerbForm=Inf	0	root	_	SpaceAfter=No
+16	.	.	PUNCT	$.	_	15	punct	_	_
 
 # sent_id = test-s446
-# text = Jochen Borchert (CDU) ging davon aus, daß die Änderung so rechtzeitig in Kraft tritt, daß eine Aussaat schon für die Ernte 1996 möglich ist.
-1	Jochen	Jochen	PROPN	NE	Case=Nom|Gender=Masc|Number=Sing	6	nsubj	_	_
-2	Borchert	Borchert	PROPN	NE	Case=Nom|Gender=Masc|Number=Sing	1	flat	_	_
-3	(	(	PUNCT	$(	_	1	punct	_	SpaceAfter=No
-4	CDU	CDU	PROPN	NE	Case=Nom|Gender=Fem|Number=Sing	1	appos	_	SpaceAfter=No
-5	)	)	PUNCT	$(	_	1	punct	_	_
-6	ging	gehen	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	0	root	_	_
-7	davon	davon	ADV	PAV	_	6	advmod	_	_
-8	aus	aus	ADP	PTKVZ	_	6	compound:prt	_	SpaceAfter=No
-9	,	,	PUNCT	$,	_	6	punct	_	_
-10	daß	daß	SCONJ	KOUS	_	17	mark	_	_
-11	die	der	DET	ART	Case=Nom|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	12	det	_	_
-12	Änderung	Änderung	NOUN	NN	Case=Nom|Gender=Fem|Number=Sing	17	nsubj	_	_
-13	so	so	ADV	ADV	_	14	advmod	_	_
-14	rechtzeitig	rechtzeitig	ADJ	ADV	_	17	xcomp	_	_
-15	in	in	ADP	APPR	_	16	case	_	_
-16	Kraft	Kraft	NOUN	NN	Case=Acc|Gender=Fem|Number=Sing	17	obl	_	_
-17	tritt	treten	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	6	ccomp	_	SpaceAfter=No
-18	,	,	PUNCT	$,	_	6	punct	_	_
-19	daß	daß	SCONJ	KOUS	_	27	mark	_	_
-20	eine	ein	DET	ART	Case=Nom|Definite=Ind|Gender=Fem|Number=Sing|PronType=Art	21	det	_	_
-21	Aussaat	Aussaat	NOUN	NN	Case=Nom|Gender=Fem|Number=Sing	27	nsubj	_	_
-22	schon	schon	ADV	ADV	_	27	advmod	_	_
-23	für	für	ADP	APPR	_	25	case	_	_
-24	die	der	DET	ART	Case=Acc|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	25	det	_	_
-25	Ernte	Ernte	NOUN	NN	Case=Acc|Gender=Fem|Number=Sing	27	nmod	_	_
-26	1996	1996	NUM	CARD	NumType=Card	25	nmod	_	_
-27	möglich	möglich	ADJ	ADJD	_	17	ccomp	_	_
-28	ist	sein	AUX	VAFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	27	cop	_	SpaceAfter=No
-29	.	.	PUNCT	$.	_	6	punct	_	_
+# text = Bundesernährungsminister Jochen Borchert (CDU) ging davon aus, daß die Änderung so rechtzeitig in Kraft tritt, daß eine Aussaat schon für die Ernte 1996 möglich ist.
+1	Bundesernährungsminister	Bundesernährungsminister	NOUN	NN	Case=Nom|Gender=Masc|Number=Sing	2	dep	_	FixTigerDep=Yes
+2	Jochen	Jochen	PROPN	NE	Case=Nom|Gender=Masc|Number=Sing	7	nsubj	_	_
+3	Borchert	Borchert	PROPN	NE	Case=Nom|Gender=Masc|Number=Sing	2	flat	_	_
+4	(	(	PUNCT	$(	_	2	punct	_	SpaceAfter=No
+5	CDU	CDU	PROPN	NE	Case=Nom|Gender=Fem|Number=Sing	2	appos	_	SpaceAfter=No
+6	)	)	PUNCT	$(	_	2	punct	_	_
+7	ging	gehen	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	0	root	_	_
+8	davon	davon	ADV	PAV	_	7	advmod	_	_
+9	aus	aus	ADP	PTKVZ	_	7	compound:prt	_	SpaceAfter=No
+10	,	,	PUNCT	$,	_	7	punct	_	_
+11	daß	daß	SCONJ	KOUS	_	18	mark	_	_
+12	die	der	DET	ART	Case=Nom|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	13	det	_	_
+13	Änderung	Änderung	NOUN	NN	Case=Nom|Gender=Fem|Number=Sing	18	nsubj	_	_
+14	so	so	ADV	ADV	_	15	advmod	_	_
+15	rechtzeitig	rechtzeitig	ADJ	ADV	_	18	xcomp	_	_
+16	in	in	ADP	APPR	_	17	case	_	_
+17	Kraft	Kraft	NOUN	NN	Case=Acc|Gender=Fem|Number=Sing	18	obl	_	_
+18	tritt	treten	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	7	ccomp	_	SpaceAfter=No
+19	,	,	PUNCT	$,	_	7	punct	_	_
+20	daß	daß	SCONJ	KOUS	_	28	mark	_	_
+21	eine	ein	DET	ART	Case=Nom|Definite=Ind|Gender=Fem|Number=Sing|PronType=Art	22	det	_	_
+22	Aussaat	Aussaat	NOUN	NN	Case=Nom|Gender=Fem|Number=Sing	28	nsubj	_	_
+23	schon	schon	ADV	ADV	_	28	advmod	_	_
+24	für	für	ADP	APPR	_	26	case	_	_
+25	die	der	DET	ART	Case=Acc|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	26	det	_	_
+26	Ernte	Ernte	NOUN	NN	Case=Acc|Gender=Fem|Number=Sing	28	nmod	_	_
+27	1996	1996	NUM	CARD	NumType=Card	26	nmod	_	_
+28	möglich	möglich	ADJ	ADJD	_	18	ccomp	_	_
+29	ist	sein	AUX	VAFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	28	cop	_	SpaceAfter=No
+30	.	.	PUNCT	$.	_	7	punct	_	_
 
 # sent_id = test-s447
-# text = Johannesburger Tageszeitung Beeld berichtete jedoch am Donnerstag, daß die Villa Ende September von der Allied Bank gepfändet wurde, weil Frau Mandela die Zinsen für die Hypothek nicht mehr zahlen konnte.
-1	Johannesburger	Johannesburger	ADJ	ADJA	_	2	amod	_	_
-2	Tageszeitung	Tageszeitung	NOUN	NN	Case=Nom|Gender=Fem|Number=Sing	4	nsubj	_	_
-3	Beeld	Beeld	PROPN	NE	Case=Nom|Number=Sing	2	appos	_	_
-4	berichtete	berichten	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	0	root	_	_
-5	jedoch	jedoch	ADV	ADV	_	4	advmod	_	_
-6-7	am	_	_	_	_	_	_	_	_
-6	an	an	ADP	APPR	_	8	case	_	_
-7	dem	der	DET	ART	Case=Dat|Definite=Def|Gender=Masc|Number=Sing|PronType=Art	8	det	_	_
-8	Donnerstag	Donnerstag	PROPN	NN	Case=Dat|Gender=Masc|Number=Sing	4	obl	_	SpaceAfter=No
-9	,	,	PUNCT	$,	_	4	punct	_	_
-10	daß	daß	SCONJ	KOUS	_	19	mark	_	_
-11	die	der	DET	ART	Case=Nom|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	12	det	_	_
-12	Villa	Villa	NOUN	NN	Case=Nom|Gender=Fem|Number=Sing	19	nsubj:pass	_	_
-13	Ende	Ende	NOUN	NN	Gender=Neut|Number=Sing	14	compound	_	_
-14	September	September	NOUN	NN	Gender=Masc|Number=Sing	19	obl	_	_
-15	von	von	ADP	APPR	_	17	case	_	_
-16	der	der	DET	ART	Case=Dat|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	17	det	_	_
-17	Allied	Allied	PROPN	NE	_	19	obl	_	_
-18	Bank	Bank	PROPN	NE	Case=Dat|Gender=Fem|Number=Sing	17	flat	_	_
-19	gepfändet	pfänden	VERB	VVPP	VerbForm=Part	4	ccomp	_	_
-20	wurde	werden	AUX	VAFIN	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin|Voice=Pass	19	aux:pass	_	SpaceAfter=No
-21	,	,	PUNCT	$,	_	4	punct	_	_
-22	weil	weil	SCONJ	KOUS	_	32	mark	_	_
-23	Frau	Frau	NOUN	NN	Case=Nom|Gender=Fem|Number=Sing	24	compound	_	_
-24	Mandela	Mandela	PROPN	NE	Case=Nom|Gender=Fem|Number=Sing	32	nsubj	_	_
-25	die	der	DET	ART	Case=Acc|Definite=Def|Gender=Masc|Number=Plur|PronType=Art	26	det	_	_
-26	Zinsen	Zins	NOUN	NN	Case=Acc|Gender=Masc|Number=Plur	32	obj	_	_
-27	für	für	ADP	APPR	_	29	case	_	_
-28	die	der	DET	ART	Case=Acc|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	29	det	_	_
-29	Hypothek	Hypothek	NOUN	NN	Case=Acc|Gender=Fem|Number=Sing	26	nmod	_	_
-30	nicht	nicht	PART	PTKNEG	Polarity=Neg	32	advmod	_	_
-31	mehr	mehr	ADV	ADV	_	30	advmod	_	_
-32	zahlen	zahlen	VERB	VVINF	VerbForm=Inf	19	advcl	_	_
-33	konnte	können	AUX	VMFIN	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	32	aux	_	SpaceAfter=No
-34	.	.	PUNCT	$.	_	4	punct	_	_
+# text = Die Johannesburger Tageszeitung Beeld berichtete jedoch am Donnerstag, daß die Villa Ende September von der Allied Bank gepfändet wurde, weil Frau Mandela die Zinsen für die Hypothek nicht mehr zahlen konnte.
+1	Die	der	DET	ART	Case=Nom|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	2	dep	_	FixTigerDep=Yes
+2	Johannesburger	Johannesburger	ADJ	ADJA	_	3	amod	_	_
+3	Tageszeitung	Tageszeitung	NOUN	NN	Case=Nom|Gender=Fem|Number=Sing	5	nsubj	_	_
+4	Beeld	Beeld	PROPN	NE	Case=Nom|Number=Sing	3	appos	_	_
+5	berichtete	berichten	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	0	root	_	_
+6	jedoch	jedoch	ADV	ADV	_	5	advmod	_	_
+7-8	am	_	_	_	_	_	_	_	_
+7	an	an	ADP	APPR	_	9	case	_	_
+8	dem	der	DET	ART	Case=Dat|Definite=Def|Gender=Masc|Number=Sing|PronType=Art	9	det	_	_
+9	Donnerstag	Donnerstag	PROPN	NN	Case=Dat|Gender=Masc|Number=Sing	5	obl	_	SpaceAfter=No
+10	,	,	PUNCT	$,	_	5	punct	_	_
+11	daß	daß	SCONJ	KOUS	_	20	mark	_	_
+12	die	der	DET	ART	Case=Nom|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	13	det	_	_
+13	Villa	Villa	NOUN	NN	Case=Nom|Gender=Fem|Number=Sing	20	nsubj:pass	_	_
+14	Ende	Ende	NOUN	NN	Gender=Neut|Number=Sing	15	compound	_	_
+15	September	September	NOUN	NN	Gender=Masc|Number=Sing	20	obl	_	_
+16	von	von	ADP	APPR	_	18	case	_	_
+17	der	der	DET	ART	Case=Dat|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	18	det	_	_
+18	Allied	Allied	PROPN	NE	_	20	obl	_	_
+19	Bank	Bank	PROPN	NE	Case=Dat|Gender=Fem|Number=Sing	18	flat	_	_
+20	gepfändet	pfänden	VERB	VVPP	VerbForm=Part	5	ccomp	_	_
+21	wurde	werden	AUX	VAFIN	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin|Voice=Pass	20	aux:pass	_	SpaceAfter=No
+22	,	,	PUNCT	$,	_	5	punct	_	_
+23	weil	weil	SCONJ	KOUS	_	33	mark	_	_
+24	Frau	Frau	NOUN	NN	Case=Nom|Gender=Fem|Number=Sing	25	compound	_	_
+25	Mandela	Mandela	PROPN	NE	Case=Nom|Gender=Fem|Number=Sing	33	nsubj	_	_
+26	die	der	DET	ART	Case=Acc|Definite=Def|Gender=Masc|Number=Plur|PronType=Art	27	det	_	_
+27	Zinsen	Zins	NOUN	NN	Case=Acc|Gender=Masc|Number=Plur	33	obj	_	_
+28	für	für	ADP	APPR	_	30	case	_	_
+29	die	der	DET	ART	Case=Acc|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	30	det	_	_
+30	Hypothek	Hypothek	NOUN	NN	Case=Acc|Gender=Fem|Number=Sing	27	nmod	_	_
+31	nicht	nicht	PART	PTKNEG	Polarity=Neg	33	advmod	_	_
+32	mehr	mehr	ADV	ADV	_	31	advmod	_	_
+33	zahlen	zahlen	VERB	VVINF	VerbForm=Inf	20	advcl	_	_
+34	konnte	können	AUX	VMFIN	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	33	aux	_	SpaceAfter=No
+35	.	.	PUNCT	$.	_	5	punct	_	_
 
 # sent_id = test-s448
-# text = Jugoslawiens neuer Ministerpräsident ist ein alter Bekannter der US-amerikanischen Börsenaufsichtsbeamten.
-1	Jugoslawiens	Jugoslawien	PROPN	NE	Case=Gen|Gender=Neut|Number=Sing	3	nmod	_	_
-2	neuer	neu	ADJ	ADJA	Case=Nom|Gender=Masc|Number=Sing	3	amod	_	_
-3	Ministerpräsident	Ministerpräsident	NOUN	NN	Case=Nom|Gender=Masc|Number=Sing	7	nsubj	_	_
-4	ist	sein	AUX	VAFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	7	cop	_	_
-5	ein	ein	DET	ART	Case=Nom|Definite=Ind|Gender=Masc|Number=Sing|PronType=Art	7	det	_	_
-6	alter	alt	ADJ	ADJA	Case=Nom|Gender=Masc|Number=Sing	7	amod	_	_
-7	Bekannter	Bekannte	NOUN	NN	Case=Nom|Gender=Masc|Number=Sing	0	root	_	_
-8	der	der	DET	ART	Case=Gen|Definite=Def|Gender=Masc|Number=Plur|PronType=Art	12	det	_	_
-9	US	US	PROPN	ADJA	Case=Gen|Gender=Masc|Number=Plur	11	compound	_	SpaceAfter=No
-10	-	-	PUNCT	$(	_	9	punct	_	SpaceAfter=No
-11	amerikanischen	amerikanisch	ADJ	ADJA	Case=Gen|Gender=Masc|Number=Plur	12	amod	_	_
-12	Börsenaufsichtsbeamten	Börsenaufsichtsbeamter	NOUN	NN	Case=Gen|Gender=Masc|Number=Plur	7	nmod	_	SpaceAfter=No
-13	.	.	PUNCT	$.	_	7	punct	_	_
+# text = Rest-Jugoslawiens neuer Ministerpräsident ist ein alter Bekannter der US-amerikanischen Börsenaufsichtsbeamten.
+1	Rest	Rest	PROPN	NE	Case=Gen|Gender=Neut|Number=Sing	4	dep	_	FixTigerDep=Yes|SpaceAfter=No
+2	-	-	PUNCT	_	_	1	punct	_	FixTigerDep=Yes|SpaceAfter=No
+3	Jugoslawiens	Jugoslawiens	PROPN	NE	Case=Gen|Gender=Neut|Number=Sing	1	flat	_	FixTigerDep=Yes
+4	neuer	neu	ADJ	ADJA	Case=Nom|Gender=Masc|Number=Sing	5	amod	_	_
+5	Ministerpräsident	Ministerpräsident	NOUN	NN	Case=Nom|Gender=Masc|Number=Sing	9	nsubj	_	_
+6	ist	sein	AUX	VAFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	9	cop	_	_
+7	ein	ein	DET	ART	Case=Nom|Definite=Ind|Gender=Masc|Number=Sing|PronType=Art	9	det	_	_
+8	alter	alt	ADJ	ADJA	Case=Nom|Gender=Masc|Number=Sing	9	amod	_	_
+9	Bekannter	Bekannte	NOUN	NN	Case=Nom|Gender=Masc|Number=Sing	0	root	_	_
+10	der	der	DET	ART	Case=Gen|Definite=Def|Gender=Masc|Number=Plur|PronType=Art	14	det	_	_
+11	US	US	PROPN	ADJA	Case=Gen|Gender=Masc|Number=Plur	13	compound	_	SpaceAfter=No
+12	-	-	PUNCT	$(	_	11	punct	_	SpaceAfter=No
+13	amerikanischen	amerikanisch	ADJ	ADJA	Case=Gen|Gender=Masc|Number=Plur	14	amod	_	_
+14	Börsenaufsichtsbeamten	Börsenaufsichtsbeamter	NOUN	NN	Case=Gen|Gender=Masc|Number=Plur	9	nmod	_	SpaceAfter=No
+15	.	.	PUNCT	$.	_	9	punct	_	_
 
 # sent_id = test-s449
-# text = Junta fühlt sich mißverstanden
-1	Junta	Junta	PROPN	NN	Case=Nom|Gender=Fem|Number=Sing	2	nsubj	_	_
-2	fühlt	fühlen	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	0	root	_	_
-3	sich	er|es|sie	PRON	PRF	Case=Acc|Number=Sing|Person=3|PronType=Prs|Reflex=Yes	2	obj	_	_
-4	mißverstanden	mißverstehen	ADJ	VVPP	VerbForm=Part	2	xcomp	_	_
+# text = Die Junta fühlt sich mißverstanden
+1	Die	der	DET	ART	Case=Nom|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	2	dep	_	FixTigerDep=Yes
+2	Junta	Junta	PROPN	NN	Case=Nom|Gender=Fem|Number=Sing	3	nsubj	_	_
+3	fühlt	fühlen	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	0	root	_	_
+4	sich	er|es|sie	PRON	PRF	Case=Acc|Number=Sing|Person=3|PronType=Prs|Reflex=Yes	3	obj	_	_
+5	mißverstanden	mißverstehen	ADJ	VVPP	VerbForm=Part	3	xcomp	_	_
 
 # sent_id = test-s450
-# text = Junta richtet Oppositionelle hin
-1	Junta	Junta	NOUN	NN	Case=Nom|Gender=Fem|Number=Sing	2	nsubj	_	_
-2	richtet	richten	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	0	root	_	_
-3	Oppositionelle	Oppositionelle	NOUN	NN	Case=Acc|Number=Plur	2	obj	_	_
-4	hin	hin	ADV	PTKVZ	_	2	compound:prt	_	_
+# text = Nigerias Junta richtet Oppositionelle hin
+1	Nigerias	Nigeria	PROPN	NE	Case=Gen|Gender=Neut|Number=Sing	2	dep	_	FixTigerDep=Yes
+2	Junta	Junta	NOUN	NN	Case=Nom|Gender=Fem|Number=Sing	3	nsubj	_	_
+3	richtet	richten	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	0	root	_	_
+4	Oppositionelle	Oppositionelle	NOUN	NN	Case=Acc|Number=Plur	3	obj	_	_
+5	hin	hin	ADV	PTKVZ	_	3	compound:prt	_	_
 
 # sent_id = test-s451
-# text = Kampagne mag in der Stichwahl zwischen den beiden Spitzenreitern des ersten Wahlgangs erbittert sein;
-1	Kampagne	Kampagne	NOUN	NN	Case=Nom|Gender=Fem|Number=Sing	13	nsubj	_	_
-2	mag	mögen	AUX	VMFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	14	aux	_	_
-3	in	in	ADP	APPR	_	5	case	_	_
-4	der	der	DET	ART	Case=Dat|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	5	det	_	_
-5	Stichwahl	Stichwahl	NOUN	NN	Case=Dat|Gender=Fem|Number=Sing	13	nmod	_	_
-6	zwischen	zwischen	ADP	APPR	_	9	case	_	_
-7	den	der	DET	ART	Case=Dat|Definite=Def|Gender=Masc|Number=Plur|PronType=Art	9	det	_	_
-8	beiden	beide	PRON	PIAT	Case=Dat|Definite=Ind|Gender=Masc|Number=Plur|PronType=Ind	9	det	_	_
-9	Spitzenreitern	Spitzenreiter	NOUN	NN	Case=Dat|Gender=Masc|Number=Plur	13	nmod	_	_
-10	des	der	DET	ART	Case=Gen|Definite=Def|Gender=Masc|Number=Sing|PronType=Art	12	det	_	_
-11	ersten	erster	ADJ	ADJA	Case=Gen|Gender=Masc|Number=Sing	12	amod	_	_
-12	Wahlgangs	Wahlgang	NOUN	NN	Case=Gen|Gender=Masc|Number=Sing	9	nmod	_	_
-13	erbittert	erbittert	ADJ	ADJD	_	0	root	_	_
-14	sein	sein	AUX	VAINF	VerbForm=Inf	13	cop	_	SpaceAfter=No
-15	;	;	PUNCT	$.	_	13	punct	_	_
+# text = Die Kampagne mag in der Stichwahl zwischen den beiden Spitzenreitern des ersten Wahlgangs erbittert sein;
+1	Die	der	DET	ART	Case=Nom|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	2	dep	_	FixTigerDep=Yes
+2	Kampagne	Kampagne	NOUN	NN	Case=Nom|Gender=Fem|Number=Sing	14	nsubj	_	_
+3	mag	mögen	AUX	VMFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	15	aux	_	_
+4	in	in	ADP	APPR	_	6	case	_	_
+5	der	der	DET	ART	Case=Dat|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	6	det	_	_
+6	Stichwahl	Stichwahl	NOUN	NN	Case=Dat|Gender=Fem|Number=Sing	14	nmod	_	_
+7	zwischen	zwischen	ADP	APPR	_	10	case	_	_
+8	den	der	DET	ART	Case=Dat|Definite=Def|Gender=Masc|Number=Plur|PronType=Art	10	det	_	_
+9	beiden	beide	PRON	PIAT	Case=Dat|Definite=Ind|Gender=Masc|Number=Plur|PronType=Ind	10	det	_	_
+10	Spitzenreitern	Spitzenreiter	NOUN	NN	Case=Dat|Gender=Masc|Number=Plur	14	nmod	_	_
+11	des	der	DET	ART	Case=Gen|Definite=Def|Gender=Masc|Number=Sing|PronType=Art	13	det	_	_
+12	ersten	erster	ADJ	ADJA	Case=Gen|Gender=Masc|Number=Sing	13	amod	_	_
+13	Wahlgangs	Wahlgang	NOUN	NN	Case=Gen|Gender=Masc|Number=Sing	10	nmod	_	_
+14	erbittert	erbittert	ADJ	ADJD	_	0	root	_	_
+15	sein	sein	AUX	VAINF	VerbForm=Inf	14	cop	_	SpaceAfter=No
+16	;	;	PUNCT	$.	_	14	punct	_	_
 
 # sent_id = test-s452
-# text = Kindergarten für drei Gruppen wurde in Niedrigenergiebauweise als kompaktes Gebäude angelegt, das im Norden der Witterung nur geringe Angriffsfläche bietet, während es sich im Südosten und Südwesten der Sonne öffnet.
-1	Kindergarten	Kindergarten	NOUN	NN	Case=Nom|Gender=Masc|Number=Sing	11	nsubj:pass	_	_
-2	für	für	ADP	APPR	_	4	case	_	_
-3	drei	drei	NUM	CARD	NumType=Card	4	nummod	_	_
-4	Gruppen	Gruppe	NOUN	NN	Case=Acc|Gender=Fem|Number=Plur	1	nmod	_	_
-5	wurde	werden	AUX	VAFIN	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin|Voice=Pass	11	aux:pass	_	_
-6	in	in	ADP	APPR	_	7	case	_	_
-7	Niedrigenergiebauweise	Niedrigenergiebauweise	NOUN	NN	Case=Dat|Gender=Fem|Number=Sing	11	obl	_	_
-8	als	als	ADP	APPR	_	10	case	_	_
-9	kompaktes	kompakt	ADJ	ADJA	Case=Acc|Gender=Neut|Number=Sing	10	amod	_	_
-10	Gebäude	Gebäude	NOUN	NN	Case=Acc|Gender=Neut|Number=Sing	11	obl	_	_
-11	angelegt	anlegen	VERB	VVPP	VerbForm=Part	0	root	_	SpaceAfter=No
-12	,	,	PUNCT	$,	_	11	punct	_	_
-13	das	der	PRON	PRELS	Case=Nom|Gender=Neut|Number=Sing|PronType=Rel	22	nsubj	_	_
-14-15	im	_	_	_	_	_	_	_	_
-14	in	in	ADP	APPR	_	16	case	_	_
-15	dem	der	DET	ART	Case=Dat|Definite=Def|Gender=Masc|Number=Sing|PronType=Art	16	det	_	_
-16	Norden	Norden	NOUN	NN	Case=Dat|Gender=Masc|Number=Sing	22	obl	_	_
-17	der	der	DET	ART	Case=Acc|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	18	det	_	_
-18	Witterung	Witterung	NOUN	NN	Case=Acc|Gender=Fem|Number=Sing	22	iobj	_	_
-19	nur	nur	ADV	ADV	_	21	advmod	_	_
-20	geringe	gering	ADJ	ADJA	Case=Acc|Gender=Fem|Number=Sing	21	amod	_	_
-21	Angriffsfläche	Angriffsfläche	NOUN	NN	Case=Acc|Gender=Fem|Number=Sing	22	obj	_	_
-22	bietet	bieten	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	10	acl	_	SpaceAfter=No
-23	,	,	PUNCT	$,	_	11	punct	_	_
-24	während	während	SCONJ	KOUS	_	34	mark	_	_
-25	es	es	PRON	PPER	Case=Nom|Gender=Neut|Number=Sing|Person=3|PronType=Prs	34	nsubj	_	_
-26	sich	er|es|sie	PRON	PRF	Case=Acc|Number=Sing|Person=3|PronType=Prs|Reflex=Yes	34	obj	_	_
-27-28	im	_	_	_	_	_	_	_	_
-27	in	in	ADP	APPR	_	29	case	_	_
-28	dem	der	DET	ART	Case=Dat|Definite=Def|Gender=Masc|Number=Sing|PronType=Art	29	det	_	_
-29	Südosten	Südosten	NOUN	NN	Case=Dat|Gender=Masc|Number=Sing	34	obl	_	_
-30	und	und	CCONJ	KON	_	31	cc	_	_
-31	Südwesten	Südwesten	NOUN	NN	Case=Dat|Gender=Masc|Number=Sing	29	conj	_	_
-32	der	der	DET	ART	Case=Dat|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	33	det	_	_
-33	Sonne	Sonne	NOUN	NN	Case=Dat|Gender=Fem|Number=Sing	34	iobj	_	_
-34	öffnet	öffnen	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	22	advcl	_	SpaceAfter=No
-35	.	.	PUNCT	$.	_	11	punct	_	_
+# text = Der Kindergarten für drei Gruppen wurde in Niedrigenergiebauweise als kompaktes Gebäude angelegt, das im Norden der Witterung nur geringe Angriffsfläche bietet, während es sich im Südosten und Südwesten der Sonne öffnet.
+1	Der	der	DET	ART	Case=Nom|Definite=Def|Gender=Masc|Number=Sing|PronType=Art	2	dep	_	FixTigerDep=Yes
+2	Kindergarten	Kindergarten	NOUN	NN	Case=Nom|Gender=Masc|Number=Sing	12	nsubj:pass	_	_
+3	für	für	ADP	APPR	_	5	case	_	_
+4	drei	drei	NUM	CARD	NumType=Card	5	nummod	_	_
+5	Gruppen	Gruppe	NOUN	NN	Case=Acc|Gender=Fem|Number=Plur	2	nmod	_	_
+6	wurde	werden	AUX	VAFIN	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin|Voice=Pass	12	aux:pass	_	_
+7	in	in	ADP	APPR	_	8	case	_	_
+8	Niedrigenergiebauweise	Niedrigenergiebauweise	NOUN	NN	Case=Dat|Gender=Fem|Number=Sing	12	obl	_	_
+9	als	als	ADP	APPR	_	11	case	_	_
+10	kompaktes	kompakt	ADJ	ADJA	Case=Acc|Gender=Neut|Number=Sing	11	amod	_	_
+11	Gebäude	Gebäude	NOUN	NN	Case=Acc|Gender=Neut|Number=Sing	12	obl	_	_
+12	angelegt	anlegen	VERB	VVPP	VerbForm=Part	0	root	_	SpaceAfter=No
+13	,	,	PUNCT	$,	_	12	punct	_	_
+14	das	der	PRON	PRELS	Case=Nom|Gender=Neut|Number=Sing|PronType=Rel	23	nsubj	_	_
+15-16	im	_	_	_	_	_	_	_	_
+15	in	in	ADP	APPR	_	17	case	_	_
+16	dem	der	DET	ART	Case=Dat|Definite=Def|Gender=Masc|Number=Sing|PronType=Art	17	det	_	_
+17	Norden	Norden	NOUN	NN	Case=Dat|Gender=Masc|Number=Sing	23	obl	_	_
+18	der	der	DET	ART	Case=Acc|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	19	det	_	_
+19	Witterung	Witterung	NOUN	NN	Case=Acc|Gender=Fem|Number=Sing	23	iobj	_	_
+20	nur	nur	ADV	ADV	_	22	advmod	_	_
+21	geringe	gering	ADJ	ADJA	Case=Acc|Gender=Fem|Number=Sing	22	amod	_	_
+22	Angriffsfläche	Angriffsfläche	NOUN	NN	Case=Acc|Gender=Fem|Number=Sing	23	obj	_	_
+23	bietet	bieten	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	11	acl	_	SpaceAfter=No
+24	,	,	PUNCT	$,	_	12	punct	_	_
+25	während	während	SCONJ	KOUS	_	35	mark	_	_
+26	es	es	PRON	PPER	Case=Nom|Gender=Neut|Number=Sing|Person=3|PronType=Prs	35	nsubj	_	_
+27	sich	er|es|sie	PRON	PRF	Case=Acc|Number=Sing|Person=3|PronType=Prs|Reflex=Yes	35	obj	_	_
+28-29	im	_	_	_	_	_	_	_	_
+28	in	in	ADP	APPR	_	30	case	_	_
+29	dem	der	DET	ART	Case=Dat|Definite=Def|Gender=Masc|Number=Sing|PronType=Art	30	det	_	_
+30	Südosten	Südosten	NOUN	NN	Case=Dat|Gender=Masc|Number=Sing	35	obl	_	_
+31	und	und	CCONJ	KON	_	32	cc	_	_
+32	Südwesten	Südwesten	NOUN	NN	Case=Dat|Gender=Masc|Number=Sing	30	conj	_	_
+33	der	der	DET	ART	Case=Dat|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	34	det	_	_
+34	Sonne	Sonne	NOUN	NN	Case=Dat|Gender=Fem|Number=Sing	35	iobj	_	_
+35	öffnet	öffnen	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	23	advcl	_	SpaceAfter=No
+36	.	.	PUNCT	$.	_	12	punct	_	_
 
 # sent_id = test-s453
-# text = Kleinaktionäre sollen als Abfindung für ein Boge-Papier eine halbe Mannesmann-Aktie oder 150 Mark bekommen.
-1	Kleinaktionäre	Kleinaktionär	NOUN	NN	Case=Nom|Gender=Masc|Number=Plur	18	nsubj	_	_
-2	sollen	sollen	AUX	VMFIN	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	18	aux	_	_
-3	als	als	ADP	APPR	_	4	case	_	_
-4	Abfindung	Abfindung	NOUN	NN	Case=Acc|Gender=Fem|Number=Sing	18	obl	_	_
-5	für	für	ADP	APPR	_	7	case	_	_
-6	ein	ein	DET	ART	Case=Acc|Definite=Ind|Gender=Neut|Number=Sing|PronType=Art	7	det	_	_
-7	Boge	Boge	PROPN	NN	Case=Acc|Gender=Neut|Number=Sing	9	compound	_	SpaceAfter=No
-8	-	-	PUNCT	$(	_	7	punct	_	SpaceAfter=No
-9	Papier	Papier	PROPN	NN	Case=Acc|Gender=Neut|Number=Sing	4	nmod	_	_
-10	eine	ein	DET	ART	Case=Acc|Definite=Ind|Gender=Fem|Number=Sing|PronType=Art	12	det	_	_
-11	halbe	halb	ADJ	ADJA	Case=Acc|Gender=Fem|Number=Sing	12	amod	_	_
-12	Mannesmann	Mannesmann	PROPN	NN	Case=Acc|Gender=Fem|Number=Sing	14	compound	_	SpaceAfter=No
-13	-	-	PUNCT	$(	_	12	punct	_	SpaceAfter=No
-14	Aktie	Aktie	NOUN	NN	Case=Acc|Gender=Fem|Number=Sing	18	obj	_	_
-15	oder	oder	CCONJ	KON	_	17	cc	_	_
-16	150	150	NUM	CARD	NumType=Card	17	nummod	_	_
-17	Mark	Mark	NOUN	NN	Gender=Fem	12	conj	_	_
-18	bekommen	bekommen	VERB	VVINF	VerbForm=Inf	0	root	_	SpaceAfter=No
-19	.	.	PUNCT	$.	_	18	punct	_	_
+# text = Die Kleinaktionäre sollen als Abfindung für ein Boge-Papier eine halbe Mannesmann-Aktie oder 150 Mark bekommen.
+1	Die	der	DET	ART	Case=Nom|Definite=Def|Gender=Masc|Number=Plur|PronType=Art	2	dep	_	FixTigerDep=Yes
+2	Kleinaktionäre	Kleinaktionär	NOUN	NN	Case=Nom|Gender=Masc|Number=Plur	19	nsubj	_	_
+3	sollen	sollen	AUX	VMFIN	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	19	aux	_	_
+4	als	als	ADP	APPR	_	5	case	_	_
+5	Abfindung	Abfindung	NOUN	NN	Case=Acc|Gender=Fem|Number=Sing	19	obl	_	_
+6	für	für	ADP	APPR	_	8	case	_	_
+7	ein	ein	DET	ART	Case=Acc|Definite=Ind|Gender=Neut|Number=Sing|PronType=Art	8	det	_	_
+8	Boge	Boge	PROPN	NN	Case=Acc|Gender=Neut|Number=Sing	10	compound	_	SpaceAfter=No
+9	-	-	PUNCT	$(	_	8	punct	_	SpaceAfter=No
+10	Papier	Papier	PROPN	NN	Case=Acc|Gender=Neut|Number=Sing	5	nmod	_	_
+11	eine	ein	DET	ART	Case=Acc|Definite=Ind|Gender=Fem|Number=Sing|PronType=Art	13	det	_	_
+12	halbe	halb	ADJ	ADJA	Case=Acc|Gender=Fem|Number=Sing	13	amod	_	_
+13	Mannesmann	Mannesmann	PROPN	NN	Case=Acc|Gender=Fem|Number=Sing	15	compound	_	SpaceAfter=No
+14	-	-	PUNCT	$(	_	13	punct	_	SpaceAfter=No
+15	Aktie	Aktie	NOUN	NN	Case=Acc|Gender=Fem|Number=Sing	19	obj	_	_
+16	oder	oder	CCONJ	KON	_	18	cc	_	_
+17	150	150	NUM	CARD	NumType=Card	18	nummod	_	_
+18	Mark	Mark	NOUN	NN	Gender=Fem	13	conj	_	_
+19	bekommen	bekommen	VERB	VVINF	VerbForm=Inf	0	root	_	SpaceAfter=No
+20	.	.	PUNCT	$.	_	19	punct	_	_
 
 # sent_id = test-s454
-# text = Klerk versuche die Gewalt in den Schwarzensiedlungen als internen Machtkampf unter Schwarzen darzustellen, statt sich der ``zentralen Rolle der Sicherheitskräfte'' bei den Unruhen zuzuwenden, denen in drei Jahren 8000 Menschen zum Opfer fielen.
-1	Klerk	Klerk	PROPN	NE	Case=Nom|Number=Sing	2	nsubj	_	_
-2	versuche	versuchen	VERB	VVFIN	Mood=Sub|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	0	root	_	_
-3	die	der	DET	ART	Case=Acc|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	4	det	_	_
-4	Gewalt	Gewalt	NOUN	NN	Case=Acc|Gender=Fem|Number=Sing	2	obj	_	_
-5	in	in	ADP	APPR	_	7	case	_	_
-6	den	der	DET	ART	Case=Dat|Definite=Def|Gender=Fem|Number=Plur|PronType=Art	7	det	_	_
-7	Schwarzensiedlungen	Schwarzensiedlung	NOUN	NN	Case=Dat|Gender=Fem|Number=Plur	4	nmod	_	_
-8	als	als	ADP	APPR	_	10	case	_	_
-9	internen	intern	ADJ	ADJA	Case=Acc|Gender=Masc|Number=Sing	10	amod	_	_
-10	Machtkampf	Machtkampf	NOUN	NN	Case=Acc|Gender=Masc|Number=Sing	13	obl	_	_
-11	unter	unter	ADP	APPR	_	12	case	_	_
-12	Schwarzen	Schwarze	NOUN	NN	Case=Dat|Number=Plur	10	nmod	_	_
-13	darzustellen	darstellen	VERB	VVIZU	VerbForm=Inf	2	xcomp	_	SpaceAfter=No
-14	,	,	PUNCT	$,	_	2	punct	_	_
-15	statt	statt	CCONJ	KOUI	_	27	cc	_	_
-16	sich	er|es|sie	PRON	PRF	Case=Acc|Number=Sing|Person=3|PronType=Prs|Reflex=Yes	27	obj	_	_
-17	der	der	DET	ART	Case=Dat|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	20	det	_	_
-18	``	``	PUNCT	$(	_	20	punct	_	SpaceAfter=No
-19	zentralen	zentral	ADJ	ADJA	Case=Dat|Gender=Fem|Number=Sing	20	amod	_	_
-20	Rolle	Rolle	NOUN	NN	Case=Dat|Gender=Fem|Number=Sing	27	iobj	_	_
-21	der	der	DET	ART	Case=Gen|Definite=Def|Gender=Fem|Number=Plur|PronType=Art	22	det	_	_
-22	Sicherheitskräfte	Sicherheitskraft	NOUN	NN	Case=Gen|Gender=Fem|Number=Plur	20	nmod	_	SpaceAfter=No
-23	''	''	PUNCT	$(	_	20	punct	_	_
-24	bei	bei	ADP	APPR	_	26	case	_	_
-25	den	der	DET	ART	Case=Dat|Definite=Def|Gender=Fem|Number=Plur|PronType=Art	26	det	_	_
-26	Unruhen	Unruhe	NOUN	NN	Case=Dat|Gender=Fem|Number=Plur	20	nmod	_	_
-27	zuzuwenden	zuwenden	VERB	VVIZU	VerbForm=Inf	2	xcomp	_	SpaceAfter=No
-28	,	,	PUNCT	$,	_	2	punct	_	_
-29	denen	der	PRON	PRELS	Case=Dat|Gender=Fem|Number=Plur|PronType=Rel	38	iobj	_	_
-30	in	in	ADP	APPR	_	32	case	_	_
-31	drei	drei	NUM	CARD	NumType=Card	32	nummod	_	_
-32	Jahren	Jahr	NOUN	NN	Case=Dat|Gender=Neut|Number=Plur	38	obl	_	_
-33	8000	8000	NUM	CARD	NumType=Card	34	nummod	_	_
-34	Menschen	Mensch	NOUN	NN	Case=Nom|Gender=Masc|Number=Plur	38	nsubj	_	_
-35-36	zum	_	_	_	_	_	_	_	_
-35	zu	zu	ADP	APPR	_	37	case	_	_
-36	dem	der	DET	ART	Case=Dat|Definite=Def|Gender=Neut|Number=Sing|PronType=Art	37	det	_	_
-37	Opfer	Opfer	NOUN	NN	Case=Dat|Gender=Neut|Number=Sing	38	obl	_	_
-38	fielen	fallen	VERB	VVFIN	Mood=Ind|Number=Plur|Person=3|Tense=Past|VerbForm=Fin	26	acl	_	SpaceAfter=No
-39	.	.	PUNCT	$.	_	2	punct	_	_
+# text = De Klerk versuche die Gewalt in den Schwarzensiedlungen als internen Machtkampf unter Schwarzen darzustellen, statt sich der ``zentralen Rolle der Sicherheitskräfte'' bei den Unruhen zuzuwenden, denen in drei Jahren 8000 Menschen zum Opfer fielen.
+1	De	De	PROPN	NE	_	2	dep	_	FixTigerDep=Yes
+2	Klerk	Klerk	PROPN	NE	Case=Nom|Number=Sing	3	nsubj	_	_
+3	versuche	versuchen	VERB	VVFIN	Mood=Sub|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	0	root	_	_
+4	die	der	DET	ART	Case=Acc|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	5	det	_	_
+5	Gewalt	Gewalt	NOUN	NN	Case=Acc|Gender=Fem|Number=Sing	3	obj	_	_
+6	in	in	ADP	APPR	_	8	case	_	_
+7	den	der	DET	ART	Case=Dat|Definite=Def|Gender=Fem|Number=Plur|PronType=Art	8	det	_	_
+8	Schwarzensiedlungen	Schwarzensiedlung	NOUN	NN	Case=Dat|Gender=Fem|Number=Plur	5	nmod	_	_
+9	als	als	ADP	APPR	_	11	case	_	_
+10	internen	intern	ADJ	ADJA	Case=Acc|Gender=Masc|Number=Sing	11	amod	_	_
+11	Machtkampf	Machtkampf	NOUN	NN	Case=Acc|Gender=Masc|Number=Sing	14	obl	_	_
+12	unter	unter	ADP	APPR	_	13	case	_	_
+13	Schwarzen	Schwarze	NOUN	NN	Case=Dat|Number=Plur	11	nmod	_	_
+14	darzustellen	darstellen	VERB	VVIZU	VerbForm=Inf	3	xcomp	_	SpaceAfter=No
+15	,	,	PUNCT	$,	_	3	punct	_	_
+16	statt	statt	CCONJ	KOUI	_	28	cc	_	_
+17	sich	er|es|sie	PRON	PRF	Case=Acc|Number=Sing|Person=3|PronType=Prs|Reflex=Yes	28	obj	_	_
+18	der	der	DET	ART	Case=Dat|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	21	det	_	_
+19	``	``	PUNCT	$(	_	21	punct	_	SpaceAfter=No
+20	zentralen	zentral	ADJ	ADJA	Case=Dat|Gender=Fem|Number=Sing	21	amod	_	_
+21	Rolle	Rolle	NOUN	NN	Case=Dat|Gender=Fem|Number=Sing	28	iobj	_	_
+22	der	der	DET	ART	Case=Gen|Definite=Def|Gender=Fem|Number=Plur|PronType=Art	23	det	_	_
+23	Sicherheitskräfte	Sicherheitskraft	NOUN	NN	Case=Gen|Gender=Fem|Number=Plur	21	nmod	_	SpaceAfter=No
+24	''	''	PUNCT	$(	_	21	punct	_	_
+25	bei	bei	ADP	APPR	_	27	case	_	_
+26	den	der	DET	ART	Case=Dat|Definite=Def|Gender=Fem|Number=Plur|PronType=Art	27	det	_	_
+27	Unruhen	Unruhe	NOUN	NN	Case=Dat|Gender=Fem|Number=Plur	21	nmod	_	_
+28	zuzuwenden	zuwenden	VERB	VVIZU	VerbForm=Inf	3	xcomp	_	SpaceAfter=No
+29	,	,	PUNCT	$,	_	3	punct	_	_
+30	denen	der	PRON	PRELS	Case=Dat|Gender=Fem|Number=Plur|PronType=Rel	39	iobj	_	_
+31	in	in	ADP	APPR	_	33	case	_	_
+32	drei	drei	NUM	CARD	NumType=Card	33	nummod	_	_
+33	Jahren	Jahr	NOUN	NN	Case=Dat|Gender=Neut|Number=Plur	39	obl	_	_
+34	8000	8000	NUM	CARD	NumType=Card	35	nummod	_	_
+35	Menschen	Mensch	NOUN	NN	Case=Nom|Gender=Masc|Number=Plur	39	nsubj	_	_
+36-37	zum	_	_	_	_	_	_	_	_
+36	zu	zu	ADP	APPR	_	38	case	_	_
+37	dem	der	DET	ART	Case=Dat|Definite=Def|Gender=Neut|Number=Sing|PronType=Art	38	det	_	_
+38	Opfer	Opfer	NOUN	NN	Case=Dat|Gender=Neut|Number=Sing	39	obl	_	_
+39	fielen	fallen	VERB	VVFIN	Mood=Ind|Number=Plur|Person=3|Tense=Past|VerbForm=Fin	27	acl	_	SpaceAfter=No
+40	.	.	PUNCT	$.	_	3	punct	_	_
 
 # sent_id = test-s455
-# text = Kompanien der Bereitschaftspolizei CRS, ausgerüstet mit Schutzschilden und Tränengasgranaten marschierten auf.
-1	Kompanien	Kompanie	NOUN	NN	Case=Nom|Gender=Fem|Number=Plur	11	nsubj	_	_
-2	der	der	DET	ART	Case=Gen|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	3	det	_	_
-3	Bereitschaftspolizei	Bereitschaftspolizei	NOUN	NN	Case=Gen|Gender=Fem|Number=Sing	1	nmod	_	_
-4	CRS	CRS	PROPN	NE	Case=Nom|Number=Sing	3	appos	_	SpaceAfter=No
-5	,	,	PUNCT	$,	_	11	punct	_	_
-6	ausgerüstet	ausrüsten	VERB	VVPP	VerbForm=Part	1	acl	_	_
-7	mit	mit	ADP	APPR	_	8	case	_	_
-8	Schutzschilden	Schutzschild	NOUN	NN	Case=Dat|Gender=Masc|Number=Plur	6	obl	_	_
-9	und	und	CCONJ	KON	_	10	cc	_	_
-10	Tränengasgranaten	Tränengasgranate	NOUN	NN	Case=Dat|Gender=Fem|Number=Plur	8	conj	_	_
-11	marschierten	marschieren	VERB	VVFIN	Mood=Ind|Number=Plur|Person=3|Tense=Past|VerbForm=Fin	0	root	_	_
-12	auf	auf	ADP	PTKVZ	_	11	compound:prt	_	SpaceAfter=No
-13	.	.	PUNCT	$.	_	11	punct	_	_
+# text = Mehrere Kompanien der Bereitschaftspolizei CRS, ausgerüstet mit Schutzschilden und Tränengasgranaten marschierten auf.
+1	Mehrere	mehrere	DET	PIAT	Case=Nom|Definite=Ind|Gender=Fem|Number=Plur|PronType=Ind	2	dep	_	FixTigerDep=Yes
+2	Kompanien	Kompanie	NOUN	NN	Case=Nom|Gender=Fem|Number=Plur	12	nsubj	_	_
+3	der	der	DET	ART	Case=Gen|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	4	det	_	_
+4	Bereitschaftspolizei	Bereitschaftspolizei	NOUN	NN	Case=Gen|Gender=Fem|Number=Sing	2	nmod	_	_
+5	CRS	CRS	PROPN	NE	Case=Nom|Number=Sing	4	appos	_	SpaceAfter=No
+6	,	,	PUNCT	$,	_	12	punct	_	_
+7	ausgerüstet	ausrüsten	VERB	VVPP	VerbForm=Part	2	acl	_	_
+8	mit	mit	ADP	APPR	_	9	case	_	_
+9	Schutzschilden	Schutzschild	NOUN	NN	Case=Dat|Gender=Masc|Number=Plur	7	obl	_	_
+10	und	und	CCONJ	KON	_	11	cc	_	_
+11	Tränengasgranaten	Tränengasgranate	NOUN	NN	Case=Dat|Gender=Fem|Number=Plur	9	conj	_	_
+12	marschierten	marschieren	VERB	VVFIN	Mood=Ind|Number=Plur|Person=3|Tense=Past|VerbForm=Fin	0	root	_	_
+13	auf	auf	ADP	PTKVZ	_	12	compound:prt	_	SpaceAfter=No
+14	.	.	PUNCT	$.	_	12	punct	_	_
 
 # sent_id = test-s456
-# text = Komplex startet im Herbst
-1	Komplex	Komplex	NOUN	NN	Case=Nom|Gender=Masc|Number=Sing	2	nsubj	_	_
-2	startet	starten	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	0	root	_	_
-3-4	im	_	_	_	_	_	_	_	_
-3	in	in	ADP	APPR	_	5	case	_	_
-4	dem	der	DET	ART	Case=Dat|Definite=Def|Gender=Masc|Number=Sing|PronType=Art	5	det	_	_
-5	Herbst	Herbst	NOUN	NN	Case=Dat|Gender=Masc|Number=Sing	2	obl	_	_
+# text = Neuer Komplex startet im Herbst
+1	Neuer	neu	ADJ	ADJA	Case=Nom|Gender=Masc|Number=Sing	2	dep	_	FixTigerDep=Yes
+2	Komplex	Komplex	NOUN	NN	Case=Nom|Gender=Masc|Number=Sing	3	nsubj	_	_
+3	startet	starten	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	0	root	_	_
+4-5	im	_	_	_	_	_	_	_	_
+4	in	in	ADP	APPR	_	6	case	_	_
+5	dem	der	DET	ART	Case=Dat|Definite=Def|Gender=Masc|Number=Sing|PronType=Art	6	det	_	_
+6	Herbst	Herbst	NOUN	NN	Case=Dat|Gender=Masc|Number=Sing	3	obl	_	_
 
 # sent_id = test-s457
-# text = Konkurrent Optik Becker will abwarten.
-1	Konkurrent	Konkurrent	NOUN	NN	Case=Nom|Gender=Masc|Number=Sing	5	nsubj	_	_
-2	Optik	Optik	PROPN	NN	Case=Nom|Gender=Fem|Number=Sing	1	appos	_	_
-3	Becker	Becker	PROPN	NE	Case=Nom|Number=Sing	2	flat	_	_
-4	will	wollen	AUX	VMFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	5	aux	_	_
-5	abwarten	abwarten	VERB	VVINF	VerbForm=Inf	0	root	_	SpaceAfter=No
-6	.	.	PUNCT	$.	_	5	punct	_	_
+# text = Der Konkurrent Optik Becker will abwarten.
+1	Der	der	DET	ART	Case=Nom|Definite=Def|Gender=Masc|Number=Sing|PronType=Art	2	dep	_	FixTigerDep=Yes
+2	Konkurrent	Konkurrent	NOUN	NN	Case=Nom|Gender=Masc|Number=Sing	6	nsubj	_	_
+3	Optik	Optik	PROPN	NN	Case=Nom|Gender=Fem|Number=Sing	2	appos	_	_
+4	Becker	Becker	PROPN	NE	Case=Nom|Number=Sing	3	flat	_	_
+5	will	wollen	AUX	VMFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	6	aux	_	_
+6	abwarten	abwarten	VERB	VVINF	VerbForm=Inf	0	root	_	SpaceAfter=No
+7	.	.	PUNCT	$.	_	6	punct	_	_
 
 # sent_id = test-s458
-# text = können sie ihren Kunden künftig auch das ``Bagger-Anschlußprogramm'', die von Komatsu produzierten Abräumfahrzeuge, anbieten.
-1	können	können	AUX	VMFIN	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	20	aux	_	_
-2	sie	sie	PRON	PPER	Case=Nom|Number=Plur|Person=3|PronType=Prs	20	nsubj	_	_
-3	ihren	ihr	PRON	PPOSAT	Case=Dat|Gender=Masc|Number=Plur|Poss=Yes	4	det:poss	_	_
-4	Kunden	Kunde	NOUN	NN	Case=Dat|Gender=Masc|Number=Plur	20	iobj	_	_
-5	künftig	künftig	ADJ	ADJD	_	20	amod	_	_
-6	auch	auch	ADV	ADV	_	20	advmod	_	_
-7	das	der	DET	ART	Case=Acc|Definite=Def|Gender=Neut|Number=Sing|PronType=Art	11	det	_	_
-8	``	``	PUNCT	$(	_	20	punct	_	SpaceAfter=No
-9	Bagger	Bagger	NOUN	NN	Case=Acc|Gender=Neut|Number=Sing	11	compound	_	SpaceAfter=No
-10	-	-	PUNCT	$(	_	9	punct	_	SpaceAfter=No
-11	Anschlußprogramm	Anschlußprogramm	NOUN	NN	Case=Acc|Gender=Neut|Number=Sing	20	obj	_	SpaceAfter=No
-12	''	''	PUNCT	$(	_	20	punct	_	SpaceAfter=No
-13	,	,	PUNCT	$,	_	11	punct	_	_
-14	die	der	PRON	ART	Case=Acc|Definite=Def|Gender=Neut|Number=Plur|PronType=Art	18	nsubj	_	_
-15	von	von	ADP	APPR	_	16	case	_	_
-16	Komatsu	Komatsu	PROPN	NE	Case=Dat|Number=Sing	18	nmod	_	_
-17	produzierten	produziert	ADJ	ADJA	Case=Acc|Gender=Neut|Number=Plur	18	amod	_	_
-18	Abräumfahrzeuge	Abräumfahrzeug	NOUN	NN	Case=Acc|Gender=Neut|Number=Plur	11	appos	_	SpaceAfter=No
-19	,	,	PUNCT	$,	_	20	punct	_	_
-20	anbieten	anbieten	VERB	VVINF	VerbForm=Inf	0	root	_	SpaceAfter=No
-21	.	.	PUNCT	$.	_	20	punct	_	_
+# text = Außerdem können sie ihren Kunden künftig auch das ``Bagger-Anschlußprogramm'', die von Komatsu produzierten Abräumfahrzeuge, anbieten.
+1	Außerdem	außerdem	ADV	PAV	_	2	dep	_	FixTigerDep=Yes
+2	können	können	AUX	VMFIN	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	21	aux	_	_
+3	sie	sie	PRON	PPER	Case=Nom|Number=Plur|Person=3|PronType=Prs	21	nsubj	_	_
+4	ihren	ihr	PRON	PPOSAT	Case=Dat|Gender=Masc|Number=Plur|Poss=Yes	5	det:poss	_	_
+5	Kunden	Kunde	NOUN	NN	Case=Dat|Gender=Masc|Number=Plur	21	iobj	_	_
+6	künftig	künftig	ADJ	ADJD	_	21	amod	_	_
+7	auch	auch	ADV	ADV	_	21	advmod	_	_
+8	das	der	DET	ART	Case=Acc|Definite=Def|Gender=Neut|Number=Sing|PronType=Art	12	det	_	_
+9	``	``	PUNCT	$(	_	21	punct	_	SpaceAfter=No
+10	Bagger	Bagger	NOUN	NN	Case=Acc|Gender=Neut|Number=Sing	12	compound	_	SpaceAfter=No
+11	-	-	PUNCT	$(	_	10	punct	_	SpaceAfter=No
+12	Anschlußprogramm	Anschlußprogramm	NOUN	NN	Case=Acc|Gender=Neut|Number=Sing	21	obj	_	SpaceAfter=No
+13	''	''	PUNCT	$(	_	21	punct	_	SpaceAfter=No
+14	,	,	PUNCT	$,	_	12	punct	_	_
+15	die	der	PRON	ART	Case=Acc|Definite=Def|Gender=Neut|Number=Plur|PronType=Art	19	nsubj	_	_
+16	von	von	ADP	APPR	_	17	case	_	_
+17	Komatsu	Komatsu	PROPN	NE	Case=Dat|Number=Sing	19	nmod	_	_
+18	produzierten	produziert	ADJ	ADJA	Case=Acc|Gender=Neut|Number=Plur	19	amod	_	_
+19	Abräumfahrzeuge	Abräumfahrzeug	NOUN	NN	Case=Acc|Gender=Neut|Number=Plur	12	appos	_	SpaceAfter=No
+20	,	,	PUNCT	$,	_	21	punct	_	_
+21	anbieten	anbieten	VERB	VVINF	VerbForm=Inf	0	root	_	SpaceAfter=No
+22	.	.	PUNCT	$.	_	21	punct	_	_
 
 # sent_id = test-s459
-# text = korrupter Richter in Brasilien hat nach Angaben eines hohen venezolanischen Beamten die Freilassung von drei brasilianischen Goldsuchern angeordnet, die wegen Mordes an mindestens 17 Indios zu lebenslanger Haft verurteilt worden waren.
-1	korrupter	korrupt	ADJ	ADJA	Case=Nom|Gender=Masc|Number=Sing	2	amod	_	_
-2	Richter	Richter	NOUN	NN	Case=Nom|Gender=Masc|Number=Sing	18	nsubj	_	_
-3	in	in	ADP	APPR	_	4	case	_	_
-4	Brasilien	Brasilien	PROPN	NE	Case=Dat|Gender=Neut|Number=Sing	2	nmod	_	_
-5	hat	haben	AUX	VAFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	18	aux	_	_
-6	nach	nach	ADP	APPR	_	7	case	_	_
-7	Angaben	Angabe	NOUN	NN	Case=Dat|Gender=Fem|Number=Plur	18	obl	_	_
-8	eines	ein	DET	ART	Case=Gen|Definite=Ind|Gender=Masc|Number=Sing|PronType=Art	11	det	_	_
-9	hohen	hoch	ADJ	ADJA	Case=Gen|Gender=Masc|Number=Sing	11	amod	_	_
-10	venezolanischen	venezolanisch	ADJ	ADJA	Case=Gen|Gender=Masc|Number=Sing	11	amod	_	_
-11	Beamten	Beamter	NOUN	NN	Case=Gen|Gender=Masc|Number=Sing	7	nmod	_	_
-12	die	der	DET	ART	Case=Acc|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	13	det	_	_
-13	Freilassung	Freilassung	NOUN	NN	Case=Acc|Gender=Fem|Number=Sing	18	obj	_	_
-14	von	von	ADP	APPR	_	17	case	_	_
-15	drei	drei	NUM	CARD	NumType=Card	17	nummod	_	_
-16	brasilianischen	brasilianisch	ADJ	ADJA	Case=Dat|Gender=Masc|Number=Plur	17	amod	_	_
-17	Goldsuchern	Goldsucher	NOUN	NN	Case=Dat|Gender=Masc|Number=Plur	13	nmod	_	_
-18	angeordnet	anordnen	VERB	VVPP	VerbForm=Part	0	root	_	SpaceAfter=No
-19	,	,	PUNCT	$,	_	18	punct	_	_
-20	die	der	PRON	PRELS	Case=Nom|Gender=Masc|Number=Plur|PronType=Rel	30	nsubj:pass	_	_
-21	wegen	wegen	ADP	APPR	_	22	case	_	_
-22	Mordes	Mord	NOUN	NN	Case=Gen|Gender=Masc|Number=Sing	30	obl	_	_
-23	an	an	ADP	APPR	_	26	case	_	_
-24	mindestens	mindestens	ADV	ADV	_	25	advmod	_	_
-25	17	17	NUM	CARD	NumType=Card	26	nummod	_	_
-26	Indios	Indio	NOUN	NN	Case=Dat|Gender=Masc|Number=Plur	22	nmod	_	_
-27	zu	zu	ADP	APPR	_	29	case	_	_
-28	lebenslanger	lebenslang	ADJ	ADJA	Case=Dat|Gender=Fem|Number=Sing	29	amod	_	_
-29	Haft	Haft	NOUN	NN	Case=Dat|Gender=Fem|Number=Sing	30	obl	_	_
-30	verurteilt	verurteilen	VERB	VVPP	VerbForm=Part	17	acl	_	_
-31	worden	werden	AUX	VAPP	VerbForm=Part|Voice=Pass	30	aux:pass	_	_
-32	waren	sein	AUX	VAFIN	Mood=Ind|Number=Plur|Person=3|Tense=Past|VerbForm=Fin	30	aux	_	SpaceAfter=No
-33	.	.	PUNCT	$.	_	18	punct	_	_
+# text = Ein korrupter Richter in Brasilien hat nach Angaben eines hohen venezolanischen Beamten die Freilassung von drei brasilianischen Goldsuchern angeordnet, die wegen Mordes an mindestens 17 Indios zu lebenslanger Haft verurteilt worden waren.
+1	Ein	ein	DET	ART	Case=Nom|Definite=Ind|Gender=Masc|Number=Sing|PronType=Art	2	dep	_	FixTigerDep=Yes
+2	korrupter	korrupt	ADJ	ADJA	Case=Nom|Gender=Masc|Number=Sing	3	amod	_	_
+3	Richter	Richter	NOUN	NN	Case=Nom|Gender=Masc|Number=Sing	19	nsubj	_	_
+4	in	in	ADP	APPR	_	5	case	_	_
+5	Brasilien	Brasilien	PROPN	NE	Case=Dat|Gender=Neut|Number=Sing	3	nmod	_	_
+6	hat	haben	AUX	VAFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	19	aux	_	_
+7	nach	nach	ADP	APPR	_	8	case	_	_
+8	Angaben	Angabe	NOUN	NN	Case=Dat|Gender=Fem|Number=Plur	19	obl	_	_
+9	eines	ein	DET	ART	Case=Gen|Definite=Ind|Gender=Masc|Number=Sing|PronType=Art	12	det	_	_
+10	hohen	hoch	ADJ	ADJA	Case=Gen|Gender=Masc|Number=Sing	12	amod	_	_
+11	venezolanischen	venezolanisch	ADJ	ADJA	Case=Gen|Gender=Masc|Number=Sing	12	amod	_	_
+12	Beamten	Beamter	NOUN	NN	Case=Gen|Gender=Masc|Number=Sing	8	nmod	_	_
+13	die	der	DET	ART	Case=Acc|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	14	det	_	_
+14	Freilassung	Freilassung	NOUN	NN	Case=Acc|Gender=Fem|Number=Sing	19	obj	_	_
+15	von	von	ADP	APPR	_	18	case	_	_
+16	drei	drei	NUM	CARD	NumType=Card	18	nummod	_	_
+17	brasilianischen	brasilianisch	ADJ	ADJA	Case=Dat|Gender=Masc|Number=Plur	18	amod	_	_
+18	Goldsuchern	Goldsucher	NOUN	NN	Case=Dat|Gender=Masc|Number=Plur	14	nmod	_	_
+19	angeordnet	anordnen	VERB	VVPP	VerbForm=Part	0	root	_	SpaceAfter=No
+20	,	,	PUNCT	$,	_	19	punct	_	_
+21	die	der	PRON	PRELS	Case=Nom|Gender=Masc|Number=Plur|PronType=Rel	31	nsubj:pass	_	_
+22	wegen	wegen	ADP	APPR	_	23	case	_	_
+23	Mordes	Mord	NOUN	NN	Case=Gen|Gender=Masc|Number=Sing	31	obl	_	_
+24	an	an	ADP	APPR	_	27	case	_	_
+25	mindestens	mindestens	ADV	ADV	_	26	advmod	_	_
+26	17	17	NUM	CARD	NumType=Card	27	nummod	_	_
+27	Indios	Indio	NOUN	NN	Case=Dat|Gender=Masc|Number=Plur	23	nmod	_	_
+28	zu	zu	ADP	APPR	_	30	case	_	_
+29	lebenslanger	lebenslang	ADJ	ADJA	Case=Dat|Gender=Fem|Number=Sing	30	amod	_	_
+30	Haft	Haft	NOUN	NN	Case=Dat|Gender=Fem|Number=Sing	31	obl	_	_
+31	verurteilt	verurteilen	VERB	VVPP	VerbForm=Part	18	acl	_	_
+32	worden	werden	AUX	VAPP	VerbForm=Part|Voice=Pass	31	aux:pass	_	_
+33	waren	sein	AUX	VAFIN	Mood=Ind|Number=Plur|Person=3|Tense=Past|VerbForm=Fin	31	aux	_	SpaceAfter=No
+34	.	.	PUNCT	$.	_	19	punct	_	_
 
 # sent_id = test-s460
-# text = KRAUSE, ostdeutscher CDU-Bundestagsabgeordneter, hat als Konsequenz aus mangelnder Investitionsbereitschaft einen Boykott westdeutscher Waren in den neuen Ländern befürwortet.
-1	KRAUSE	Krause	NOUN	NE	Case=Nom|Gender=Masc|Number=Sing	22	nsubj	_	SpaceAfter=No
-2	,	,	PUNCT	$,	_	22	punct	_	_
-3	ostdeutscher	ostdeutsch	ADJ	ADJA	Case=Nom|Gender=Masc|Number=Sing	4	amod	_	_
-4	CDU	CDU	PROPN	NN	Case=Nom|Gender=Masc|Number=Sing	6	compound	_	SpaceAfter=No
-5	-	-	PUNCT	$(	_	4	punct	_	SpaceAfter=No
-6	Bundestagsabgeordneter	Bundestagsabgeordnete	NOUN	NN	Case=Nom|Gender=Masc|Number=Sing	1	appos	_	SpaceAfter=No
-7	,	,	PUNCT	$,	_	22	punct	_	_
-8	hat	haben	AUX	VAFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	22	aux	_	_
-9	als	als	ADP	APPR	_	10	case	_	_
-10	Konsequenz	Konsequenz	NOUN	NN	Case=Acc|Gender=Fem|Number=Sing	22	obl	_	_
-11	aus	aus	ADP	APPR	_	13	case	_	_
-12	mangelnder	mangelnd	ADJ	ADJA	Case=Dat|Gender=Fem|Number=Sing	13	amod	_	_
-13	Investitionsbereitschaft	Investitionsbereitschaft	NOUN	NN	Case=Dat|Gender=Fem|Number=Sing	10	nmod	_	_
-14	einen	ein	DET	ART	Case=Acc|Definite=Ind|Gender=Masc|Number=Sing|PronType=Art	15	det	_	_
-15	Boykott	Boykott	NOUN	NN	Case=Acc|Gender=Masc|Number=Sing	22	obj	_	_
-16	westdeutscher	westdeutsch	ADJ	ADJA	Case=Gen|Gender=Fem|Number=Plur	17	amod	_	_
-17	Waren	Ware	NOUN	NN	Case=Gen|Gender=Fem|Number=Plur	15	nmod	_	_
-18	in	in	ADP	APPR	_	21	case	_	_
-19	den	der	DET	ART	Case=Dat|Definite=Def|Gender=Neut|Number=Plur|PronType=Art	21	det	_	_
-20	neuen	neu	ADJ	ADJA	Case=Dat|Gender=Neut|Number=Plur	21	amod	_	_
-21	Ländern	Land	NOUN	NN	Case=Dat|Gender=Neut|Number=Plur	15	nmod	_	_
-22	befürwortet	befürworten	VERB	VVPP	VerbForm=Part	0	root	_	SpaceAfter=No
-23	.	.	PUNCT	$.	_	22	punct	_	_
+# text = RUDOLF KRAUSE, ostdeutscher CDU-Bundestagsabgeordneter, hat als Konsequenz aus mangelnder Investitionsbereitschaft einen Boykott westdeutscher Waren in den neuen Ländern befürwortet.
+1	RUDOLF	Rudolf	PROPN	NE	Case=Nom|Gender=Masc|Number=Sing	2	dep	_	FixTigerDep=Yes
+2	KRAUSE	Krause	NOUN	NE	Case=Nom|Gender=Masc|Number=Sing	23	nsubj	_	SpaceAfter=No
+3	,	,	PUNCT	$,	_	23	punct	_	_
+4	ostdeutscher	ostdeutsch	ADJ	ADJA	Case=Nom|Gender=Masc|Number=Sing	5	amod	_	_
+5	CDU	CDU	PROPN	NN	Case=Nom|Gender=Masc|Number=Sing	7	compound	_	SpaceAfter=No
+6	-	-	PUNCT	$(	_	5	punct	_	SpaceAfter=No
+7	Bundestagsabgeordneter	Bundestagsabgeordnete	NOUN	NN	Case=Nom|Gender=Masc|Number=Sing	2	appos	_	SpaceAfter=No
+8	,	,	PUNCT	$,	_	23	punct	_	_
+9	hat	haben	AUX	VAFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	23	aux	_	_
+10	als	als	ADP	APPR	_	11	case	_	_
+11	Konsequenz	Konsequenz	NOUN	NN	Case=Acc|Gender=Fem|Number=Sing	23	obl	_	_
+12	aus	aus	ADP	APPR	_	14	case	_	_
+13	mangelnder	mangelnd	ADJ	ADJA	Case=Dat|Gender=Fem|Number=Sing	14	amod	_	_
+14	Investitionsbereitschaft	Investitionsbereitschaft	NOUN	NN	Case=Dat|Gender=Fem|Number=Sing	11	nmod	_	_
+15	einen	ein	DET	ART	Case=Acc|Definite=Ind|Gender=Masc|Number=Sing|PronType=Art	16	det	_	_
+16	Boykott	Boykott	NOUN	NN	Case=Acc|Gender=Masc|Number=Sing	23	obj	_	_
+17	westdeutscher	westdeutsch	ADJ	ADJA	Case=Gen|Gender=Fem|Number=Plur	18	amod	_	_
+18	Waren	Ware	NOUN	NN	Case=Gen|Gender=Fem|Number=Plur	16	nmod	_	_
+19	in	in	ADP	APPR	_	22	case	_	_
+20	den	der	DET	ART	Case=Dat|Definite=Def|Gender=Neut|Number=Plur|PronType=Art	22	det	_	_
+21	neuen	neu	ADJ	ADJA	Case=Dat|Gender=Neut|Number=Plur	22	amod	_	_
+22	Ländern	Land	NOUN	NN	Case=Dat|Gender=Neut|Number=Plur	16	nmod	_	_
+23	befürwortet	befürworten	VERB	VVPP	VerbForm=Part	0	root	_	SpaceAfter=No
+24	.	.	PUNCT	$.	_	23	punct	_	_
 
 # sent_id = test-s461
 # text = Laß die erst mal die Klingel suchen.
@@ -8820,283 +8947,295 @@
 8	.	.	PUNCT	$.	_	1	punct	_	_
 
 # sent_id = test-s462
-# text = Lastwagenkolonne wurde von rund zehn Polizeifahrzeugen zu ihrem Ziel 335 Kilometer westlich von Tokio eskortiert.
-1	Lastwagenkolonne	Lastwagenkolonne	NOUN	NN	Case=Nom|Gender=Fem|Number=Sing	15	nsubj:pass	_	_
-2	wurde	werden	AUX	VAFIN	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin|Voice=Pass	15	aux:pass	_	_
-3	von	von	ADP	APPR	_	6	case	_	_
-4	rund	rund	ADV	ADJD	_	5	advmod	_	_
-5	zehn	zehn	NUM	CARD	NumType=Card	6	nummod	_	_
-6	Polizeifahrzeugen	Polizeifahrzeug	NOUN	NN	Case=Dat|Gender=Neut|Number=Plur	15	obl	_	_
-7	zu	zu	ADP	APPR	_	9	case	_	_
-8	ihrem	ihr	PRON	PPOSAT	Case=Dat|Gender=Neut|Number=Sing|Poss=Yes	9	det:poss	_	_
-9	Ziel	Ziel	NOUN	NN	Case=Dat|Gender=Neut|Number=Sing	15	obl	_	_
-10	335	335	NUM	CARD	NumType=Card	11	nummod	_	_
-11	Kilometer	Kilometer	NOUN	NN	Case=Acc|Gender=Masc|Number=Plur	9	compound	_	_
-12	westlich	westlich	ADV	ADJD	_	11	advmod	_	_
-13	von	von	ADP	APPR	_	14	case	_	_
-14	Tokio	Tokio	PROPN	NE	Case=Dat|Gender=Neut|Number=Sing	12	nmod	_	_
-15	eskortiert	eskortieren	VERB	VVPP	VerbForm=Part	0	root	_	SpaceAfter=No
-16	.	.	PUNCT	$.	_	15	punct	_	_
+# text = Die Lastwagenkolonne wurde von rund zehn Polizeifahrzeugen zu ihrem Ziel 335 Kilometer westlich von Tokio eskortiert.
+1	Die	der	DET	ART	Case=Nom|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	2	dep	_	FixTigerDep=Yes
+2	Lastwagenkolonne	Lastwagenkolonne	NOUN	NN	Case=Nom|Gender=Fem|Number=Sing	16	nsubj:pass	_	_
+3	wurde	werden	AUX	VAFIN	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin|Voice=Pass	16	aux:pass	_	_
+4	von	von	ADP	APPR	_	7	case	_	_
+5	rund	rund	ADV	ADJD	_	6	advmod	_	_
+6	zehn	zehn	NUM	CARD	NumType=Card	7	nummod	_	_
+7	Polizeifahrzeugen	Polizeifahrzeug	NOUN	NN	Case=Dat|Gender=Neut|Number=Plur	16	obl	_	_
+8	zu	zu	ADP	APPR	_	10	case	_	_
+9	ihrem	ihr	PRON	PPOSAT	Case=Dat|Gender=Neut|Number=Sing|Poss=Yes	10	det:poss	_	_
+10	Ziel	Ziel	NOUN	NN	Case=Dat|Gender=Neut|Number=Sing	16	obl	_	_
+11	335	335	NUM	CARD	NumType=Card	12	nummod	_	_
+12	Kilometer	Kilometer	NOUN	NN	Case=Acc|Gender=Masc|Number=Plur	10	compound	_	_
+13	westlich	westlich	ADV	ADJD	_	12	advmod	_	_
+14	von	von	ADP	APPR	_	15	case	_	_
+15	Tokio	Tokio	PROPN	NE	Case=Dat|Gender=Neut|Number=Sing	13	nmod	_	_
+16	eskortiert	eskortieren	VERB	VVPP	VerbForm=Part	0	root	_	SpaceAfter=No
+17	.	.	PUNCT	$.	_	16	punct	_	_
 
 # sent_id = test-s463
-# text = Lehmann beleuchtete vor einem zweifelnden Publikum biographische Bezüge in Max Webers Protestantischer Ethik;
-1	Lehmann	Lehmann	PROPN	NE	Case=Nom|Gender=Masc|Number=Sing	2	nsubj	_	_
-2	beleuchtete	beleuchten	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	0	root	_	_
-3	vor	vor	ADP	APPR	_	6	case	_	_
-4	einem	ein	DET	ART	Case=Dat|Definite=Ind|Gender=Neut|Number=Sing|PronType=Art	6	det	_	_
-5	zweifelnden	zweifelnd	ADJ	ADJA	Case=Dat|Gender=Neut|Number=Sing	6	amod	_	_
-6	Publikum	Publikum	NOUN	NN	Case=Dat|Gender=Neut|Number=Sing	2	obl	_	_
-7	biographische	biographisch	ADJ	ADJA	Case=Acc|Gender=Masc|Number=Plur	8	amod	_	_
-8	Bezüge	Bezug	NOUN	NN	Case=Acc|Gender=Masc|Number=Plur	2	obj	_	_
-9	in	in	ADP	APPR	_	13	case	_	_
-10	Max	Max	PROPN	NE	Case=Nom|Gender=Masc|Number=Sing	13	nmod	_	_
-11	Webers	Weber	PROPN	NE	Case=Gen|Gender=Masc|Number=Sing	10	flat	_	_
-12	Protestantischer	protestantisch	ADJ	ADJA	Case=Dat|Gender=Fem|Number=Sing	13	amod	_	_
-13	Ethik	Ethik	NOUN	NN	Case=Dat|Gender=Fem|Number=Sing	8	nmod	_	SpaceAfter=No
-14	;	;	PUNCT	$.	_	2	punct	_	_
+# text = Hartmut Lehmann beleuchtete vor einem zweifelnden Publikum biographische Bezüge in Max Webers Protestantischer Ethik;
+1	Hartmut	Hartmut	PROPN	NE	Case=Nom|Gender=Masc|Number=Sing	2	dep	_	FixTigerDep=Yes
+2	Lehmann	Lehmann	PROPN	NE	Case=Nom|Gender=Masc|Number=Sing	3	nsubj	_	_
+3	beleuchtete	beleuchten	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	0	root	_	_
+4	vor	vor	ADP	APPR	_	7	case	_	_
+5	einem	ein	DET	ART	Case=Dat|Definite=Ind|Gender=Neut|Number=Sing|PronType=Art	7	det	_	_
+6	zweifelnden	zweifelnd	ADJ	ADJA	Case=Dat|Gender=Neut|Number=Sing	7	amod	_	_
+7	Publikum	Publikum	NOUN	NN	Case=Dat|Gender=Neut|Number=Sing	3	obl	_	_
+8	biographische	biographisch	ADJ	ADJA	Case=Acc|Gender=Masc|Number=Plur	9	amod	_	_
+9	Bezüge	Bezug	NOUN	NN	Case=Acc|Gender=Masc|Number=Plur	3	obj	_	_
+10	in	in	ADP	APPR	_	14	case	_	_
+11	Max	Max	PROPN	NE	Case=Nom|Gender=Masc|Number=Sing	14	nmod	_	_
+12	Webers	Weber	PROPN	NE	Case=Gen|Gender=Masc|Number=Sing	11	flat	_	_
+13	Protestantischer	protestantisch	ADJ	ADJA	Case=Dat|Gender=Fem|Number=Sing	14	amod	_	_
+14	Ethik	Ethik	NOUN	NN	Case=Dat|Gender=Fem|Number=Sing	9	nmod	_	SpaceAfter=No
+15	;	;	PUNCT	$.	_	3	punct	_	_
 
 # sent_id = test-s464
-# text = Lira, die derzeit innerhalb des EWS auf dem vorletzten Platz liegt, neigte bereits seit dem dänischen Volksentscheid gegen den Vertrag von Maastricht zur Schwäche.
-1	Lira	Lira	NOUN	NN	Case=Nom|Gender=Fem|Number=Sing	14	nsubj	_	SpaceAfter=No
-2	,	,	PUNCT	$,	_	14	punct	_	_
-3	die	der	PRON	PRELS	Case=Nom|Gender=Fem|Number=Sing|PronType=Rel	12	nsubj	_	_
-4	derzeit	derzeit	ADV	ADV	_	12	advmod	_	_
-5	innerhalb	innerhalb	ADP	APPR	_	7	case	_	_
-6	des	der	DET	ART	Case=Gen|Definite=Def|Gender=Neut|Number=Sing|PronType=Art	7	det	_	_
-7	EWS	EWS	PROPN	NE	Case=Gen|Gender=Neut|Number=Sing	12	obl	_	_
-8	auf	auf	ADP	APPR	_	11	case	_	_
-9	dem	der	DET	ART	Case=Dat|Definite=Def|Gender=Masc|Number=Sing|PronType=Art	11	det	_	_
-10	vorletzten	vorletzter	ADJ	ADJA	Case=Dat|Gender=Masc|Number=Sing	11	amod	_	_
-11	Platz	Platz	NOUN	NN	Case=Dat|Gender=Masc|Number=Sing	12	obl	_	_
-12	liegt	liegen	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	1	acl	_	SpaceAfter=No
-13	,	,	PUNCT	$,	_	14	punct	_	_
-14	neigte	neigen	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	0	root	_	_
-15	bereits	bereits	ADV	ADV	_	14	advmod	_	_
-16	seit	seit	ADP	APPR	_	19	case	_	_
-17	dem	der	DET	ART	Case=Dat|Definite=Def|Gender=Masc|Number=Sing|PronType=Art	19	det	_	_
-18	dänischen	dänisch	ADJ	ADJA	Case=Dat|Gender=Masc|Number=Sing	19	amod	_	_
-19	Volksentscheid	Volksentscheid	NOUN	NN	Case=Dat|Gender=Masc|Number=Sing	14	obl	_	_
-20	gegen	gegen	ADP	APPR	_	22	case	_	_
-21	den	der	DET	ART	Case=Acc|Definite=Def|Gender=Masc|Number=Sing|PronType=Art	22	det	_	_
-22	Vertrag	Vertrag	NOUN	NN	Case=Acc|Gender=Masc|Number=Sing	19	nmod	_	_
-23	von	von	ADP	APPR	_	24	case	_	_
-24	Maastricht	Maastricht	PROPN	NE	Case=Dat|Gender=Neut|Number=Sing	22	nmod	_	_
-25-26	zur	_	_	_	_	_	_	_	_
-25	zu	zu	ADP	APPR	_	27	case	_	_
-26	der	der	DET	ART	Case=Dat|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	27	det	_	_
-27	Schwäche	Schwäche	NOUN	NN	Case=Dat|Gender=Fem|Number=Sing	14	obl	_	SpaceAfter=No
-28	.	.	PUNCT	$.	_	14	punct	_	_
+# text = Die Lira, die derzeit innerhalb des EWS auf dem vorletzten Platz liegt, neigte bereits seit dem dänischen Volksentscheid gegen den Vertrag von Maastricht zur Schwäche.
+1	Die	der	DET	ART	Case=Nom|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	2	dep	_	FixTigerDep=Yes
+2	Lira	Lira	NOUN	NN	Case=Nom|Gender=Fem|Number=Sing	15	nsubj	_	SpaceAfter=No
+3	,	,	PUNCT	$,	_	15	punct	_	_
+4	die	der	PRON	PRELS	Case=Nom|Gender=Fem|Number=Sing|PronType=Rel	13	nsubj	_	_
+5	derzeit	derzeit	ADV	ADV	_	13	advmod	_	_
+6	innerhalb	innerhalb	ADP	APPR	_	8	case	_	_
+7	des	der	DET	ART	Case=Gen|Definite=Def|Gender=Neut|Number=Sing|PronType=Art	8	det	_	_
+8	EWS	EWS	PROPN	NE	Case=Gen|Gender=Neut|Number=Sing	13	obl	_	_
+9	auf	auf	ADP	APPR	_	12	case	_	_
+10	dem	der	DET	ART	Case=Dat|Definite=Def|Gender=Masc|Number=Sing|PronType=Art	12	det	_	_
+11	vorletzten	vorletzter	ADJ	ADJA	Case=Dat|Gender=Masc|Number=Sing	12	amod	_	_
+12	Platz	Platz	NOUN	NN	Case=Dat|Gender=Masc|Number=Sing	13	obl	_	_
+13	liegt	liegen	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	2	acl	_	SpaceAfter=No
+14	,	,	PUNCT	$,	_	15	punct	_	_
+15	neigte	neigen	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	0	root	_	_
+16	bereits	bereits	ADV	ADV	_	15	advmod	_	_
+17	seit	seit	ADP	APPR	_	20	case	_	_
+18	dem	der	DET	ART	Case=Dat|Definite=Def|Gender=Masc|Number=Sing|PronType=Art	20	det	_	_
+19	dänischen	dänisch	ADJ	ADJA	Case=Dat|Gender=Masc|Number=Sing	20	amod	_	_
+20	Volksentscheid	Volksentscheid	NOUN	NN	Case=Dat|Gender=Masc|Number=Sing	15	obl	_	_
+21	gegen	gegen	ADP	APPR	_	23	case	_	_
+22	den	der	DET	ART	Case=Acc|Definite=Def|Gender=Masc|Number=Sing|PronType=Art	23	det	_	_
+23	Vertrag	Vertrag	NOUN	NN	Case=Acc|Gender=Masc|Number=Sing	20	nmod	_	_
+24	von	von	ADP	APPR	_	25	case	_	_
+25	Maastricht	Maastricht	PROPN	NE	Case=Dat|Gender=Neut|Number=Sing	23	nmod	_	_
+26-27	zur	_	_	_	_	_	_	_	_
+26	zu	zu	ADP	APPR	_	28	case	_	_
+27	der	der	DET	ART	Case=Dat|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	28	det	_	_
+28	Schwäche	Schwäche	NOUN	NN	Case=Dat|Gender=Fem|Number=Sing	15	obl	_	SpaceAfter=No
+29	.	.	PUNCT	$.	_	15	punct	_	_
 
 # sent_id = test-s465
-# text = Londoner Finanzministerium sprach sich allerdings gleichzeitig für die Aufgabe des Projekts aus.
-1	Londoner	Londoner	ADJ	ADJA	_	2	amod	_	_
-2	Finanzministerium	Finanzministerium	NOUN	NN	Case=Nom|Gender=Neut|Number=Sing	3	nsubj	_	_
-3	sprach	sprechen	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	0	root	_	_
-4	sich	er|es|sie	PRON	PRF	Case=Acc|Number=Sing|Person=3|PronType=Prs|Reflex=Yes	3	obj	_	_
-5	allerdings	allerdings	ADV	ADV	_	3	advmod	_	_
-6	gleichzeitig	gleichzeitig	ADV	ADJD	_	3	advmod	_	_
-7	für	für	ADP	APPR	_	9	case	_	_
-8	die	der	DET	ART	Case=Acc|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	9	det	_	_
-9	Aufgabe	Aufgabe	NOUN	NN	Case=Acc|Gender=Fem|Number=Sing	3	obl	_	_
-10	des	der	DET	ART	Case=Gen|Definite=Def|Gender=Neut|Number=Sing|PronType=Art	11	det	_	_
-11	Projekts	Projekt	NOUN	NN	Case=Gen|Gender=Neut|Number=Sing	9	nmod	_	_
-12	aus	aus	ADP	PTKVZ	_	3	compound:prt	_	SpaceAfter=No
-13	.	.	PUNCT	$.	_	3	punct	_	_
+# text = Das Londoner Finanzministerium sprach sich allerdings gleichzeitig für die Aufgabe des Projekts aus.
+1	Das	der	DET	ART	Case=Nom|Definite=Def|Gender=Neut|Number=Sing|PronType=Art	2	dep	_	FixTigerDep=Yes
+2	Londoner	Londoner	ADJ	ADJA	_	3	amod	_	_
+3	Finanzministerium	Finanzministerium	NOUN	NN	Case=Nom|Gender=Neut|Number=Sing	4	nsubj	_	_
+4	sprach	sprechen	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	0	root	_	_
+5	sich	er|es|sie	PRON	PRF	Case=Acc|Number=Sing|Person=3|PronType=Prs|Reflex=Yes	4	obj	_	_
+6	allerdings	allerdings	ADV	ADV	_	4	advmod	_	_
+7	gleichzeitig	gleichzeitig	ADV	ADJD	_	4	advmod	_	_
+8	für	für	ADP	APPR	_	10	case	_	_
+9	die	der	DET	ART	Case=Acc|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	10	det	_	_
+10	Aufgabe	Aufgabe	NOUN	NN	Case=Acc|Gender=Fem|Number=Sing	4	obl	_	_
+11	des	der	DET	ART	Case=Gen|Definite=Def|Gender=Neut|Number=Sing|PronType=Art	12	det	_	_
+12	Projekts	Projekt	NOUN	NN	Case=Gen|Gender=Neut|Number=Sing	10	nmod	_	_
+13	aus	aus	ADP	PTKVZ	_	4	compound:prt	_	SpaceAfter=No
+14	.	.	PUNCT	$.	_	4	punct	_	_
 
 # sent_id = test-s466
-# text = Madigan und ihr Forschungsteam vom Nationalen Krebs-Institut der USA in Bethesda zählt dazu Kinderlosigkeit, die Geburt des ersten Kindes nach dem 19. Lebensjahr, ein hohes Einkommen und ein an Krebs erkrankter Verwandter ersten Grades.
-1	Madigan	Madigan	PROPN	NE	Case=Nom|Gender=Fem|Number=Sing	15	nsubj	_	_
-2	und	und	CCONJ	KON	_	4	cc	_	_
-3	ihr	ihr	PRON	PPOSAT	Case=Nom|Gender=Neut|Number=Sing|Poss=Yes	4	det:poss	_	_
-4	Forschungsteam	Forschungsteam	NOUN	NN	Case=Nom|Gender=Neut|Number=Sing	1	conj	_	_
-5-6	vom	_	_	_	_	_	_	_	_
-5	von	von	ADP	APPR	_	10	case	_	_
-6	dem	der	DET	ART	Case=Dat|Definite=Def|Gender=Masc|Number=Sing|PronType=Art	10	det	_	_
-7	Nationalen	national	ADJ	ADJA	Case=Dat|Gender=Neut|Number=Sing	10	compound	_	_
-8	Krebs	Krebs	NOUN	NN	Case=Dat|Gender=Neut|Number=Sing	10	compound	_	SpaceAfter=No
-9	-	-	PUNCT	$(	_	8	punct	_	SpaceAfter=No
-10	Institut	Institut	NOUN	NN	Case=Dat|Gender=Neut|Number=Sing	4	nmod	_	_
-11	der	der	DET	ART	Case=Gen|Definite=Def|Number=Sing|PronType=Art	12	det	_	_
-12	USA	USA	PROPN	NE	Case=Gen|Number=Sing	10	nmod	_	_
-13	in	in	ADP	APPR	_	14	case	_	_
-14	Bethesda	Bethesda	PROPN	NE	Case=Dat|Gender=Neut|Number=Sing	12	nmod	_	_
-15	zählt	zählen	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	0	root	_	_
-16	dazu	dazu	ADV	PAV	_	15	advmod	_	_
-17	Kinderlosigkeit	Kinderlosigkeit	NOUN	NN	Case=Acc|Gender=Fem|Number=Sing	15	obj	_	SpaceAfter=No
-18	,	,	PUNCT	$,	_	20	punct	_	_
-19	die	der	DET	ART	Case=Acc|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	20	det	_	_
-20	Geburt	Geburt	NOUN	NN	Case=Acc|Gender=Fem|Number=Sing	17	conj	_	_
-21	des	der	DET	ART	Case=Gen|Definite=Def|Gender=Neut|Number=Sing|PronType=Art	23	det	_	_
-22	ersten	erster	ADJ	ADJA	Case=Gen|Gender=Neut|Number=Sing	23	amod	_	_
-23	Kindes	Kind	NOUN	NN	Case=Gen|Gender=Neut|Number=Sing	20	nmod	_	_
-24	nach	nach	ADP	APPR	_	27	case	_	_
-25	dem	der	DET	ART	Case=Dat|Definite=Def|Gender=Neut|Number=Sing|PronType=Art	27	det	_	_
-26	19.	19	ADJ	ADJA	Case=Dat|Gender=Neut|Number=Sing	27	nummod	_	_
-27	Lebensjahr	Lebensjahr	NOUN	NN	Case=Dat|Gender=Neut|Number=Sing	23	nmod	_	SpaceAfter=No
-28	,	,	PUNCT	$,	_	31	punct	_	_
-29	ein	ein	DET	ART	Case=Acc|Definite=Ind|Gender=Neut|Number=Sing|PronType=Art	31	det	_	_
-30	hohes	hoch	ADJ	ADJA	Case=Acc|Gender=Neut|Number=Sing	31	amod	_	_
-31	Einkommen	Einkommen	NOUN	NN	Case=Acc|Gender=Neut|Number=Sing	17	conj	_	_
-32	und	und	CCONJ	KON	_	37	cc	_	_
-33	ein	ein	DET	ART	Case=Acc|Definite=Ind|Number=Sing|PronType=Art	37	det	_	_
-34	an	an	ADP	APPR	_	35	case	_	_
-35	Krebs	Krebs	NOUN	NN	Case=Dat|Gender=Masc|Number=Sing	36	nmod	_	_
-36	erkrankter	erkrankt	ADJ	ADJA	Case=Acc|Number=Sing	37	amod	_	_
-37	Verwandter	Verwandte	NOUN	NN	Case=Acc|Number=Sing	17	conj	_	_
-38	ersten	erster	ADJ	ADJA	Case=Gen|Gender=Masc|Number=Sing	39	amod	_	_
-39	Grades	Grad	NOUN	NN	Case=Gen|Gender=Masc|Number=Sing	37	nmod	_	SpaceAfter=No
-40	.	.	PUNCT	$.	_	15	punct	_	_
+# text = Patricia Madigan und ihr Forschungsteam vom Nationalen Krebs-Institut der USA in Bethesda zählt dazu Kinderlosigkeit, die Geburt des ersten Kindes nach dem 19. Lebensjahr, ein hohes Einkommen und ein an Krebs erkrankter Verwandter ersten Grades.
+1	Patricia	Patricia	PROPN	NE	Case=Nom|Gender=Fem|Number=Sing	2	dep	_	FixTigerDep=Yes
+2	Madigan	Madigan	PROPN	NE	Case=Nom|Gender=Fem|Number=Sing	16	nsubj	_	_
+3	und	und	CCONJ	KON	_	5	cc	_	_
+4	ihr	ihr	PRON	PPOSAT	Case=Nom|Gender=Neut|Number=Sing|Poss=Yes	5	det:poss	_	_
+5	Forschungsteam	Forschungsteam	NOUN	NN	Case=Nom|Gender=Neut|Number=Sing	2	conj	_	_
+6-7	vom	_	_	_	_	_	_	_	_
+6	von	von	ADP	APPR	_	11	case	_	_
+7	dem	der	DET	ART	Case=Dat|Definite=Def|Gender=Masc|Number=Sing|PronType=Art	11	det	_	_
+8	Nationalen	national	ADJ	ADJA	Case=Dat|Gender=Neut|Number=Sing	11	compound	_	_
+9	Krebs	Krebs	NOUN	NN	Case=Dat|Gender=Neut|Number=Sing	11	compound	_	SpaceAfter=No
+10	-	-	PUNCT	$(	_	9	punct	_	SpaceAfter=No
+11	Institut	Institut	NOUN	NN	Case=Dat|Gender=Neut|Number=Sing	5	nmod	_	_
+12	der	der	DET	ART	Case=Gen|Definite=Def|Number=Sing|PronType=Art	13	det	_	_
+13	USA	USA	PROPN	NE	Case=Gen|Number=Sing	11	nmod	_	_
+14	in	in	ADP	APPR	_	15	case	_	_
+15	Bethesda	Bethesda	PROPN	NE	Case=Dat|Gender=Neut|Number=Sing	13	nmod	_	_
+16	zählt	zählen	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	0	root	_	_
+17	dazu	dazu	ADV	PAV	_	16	advmod	_	_
+18	Kinderlosigkeit	Kinderlosigkeit	NOUN	NN	Case=Acc|Gender=Fem|Number=Sing	16	obj	_	SpaceAfter=No
+19	,	,	PUNCT	$,	_	21	punct	_	_
+20	die	der	DET	ART	Case=Acc|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	21	det	_	_
+21	Geburt	Geburt	NOUN	NN	Case=Acc|Gender=Fem|Number=Sing	18	conj	_	_
+22	des	der	DET	ART	Case=Gen|Definite=Def|Gender=Neut|Number=Sing|PronType=Art	24	det	_	_
+23	ersten	erster	ADJ	ADJA	Case=Gen|Gender=Neut|Number=Sing	24	amod	_	_
+24	Kindes	Kind	NOUN	NN	Case=Gen|Gender=Neut|Number=Sing	21	nmod	_	_
+25	nach	nach	ADP	APPR	_	28	case	_	_
+26	dem	der	DET	ART	Case=Dat|Definite=Def|Gender=Neut|Number=Sing|PronType=Art	28	det	_	_
+27	19.	19	ADJ	ADJA	Case=Dat|Gender=Neut|Number=Sing	28	nummod	_	_
+28	Lebensjahr	Lebensjahr	NOUN	NN	Case=Dat|Gender=Neut|Number=Sing	24	nmod	_	SpaceAfter=No
+29	,	,	PUNCT	$,	_	32	punct	_	_
+30	ein	ein	DET	ART	Case=Acc|Definite=Ind|Gender=Neut|Number=Sing|PronType=Art	32	det	_	_
+31	hohes	hoch	ADJ	ADJA	Case=Acc|Gender=Neut|Number=Sing	32	amod	_	_
+32	Einkommen	Einkommen	NOUN	NN	Case=Acc|Gender=Neut|Number=Sing	18	conj	_	_
+33	und	und	CCONJ	KON	_	38	cc	_	_
+34	ein	ein	DET	ART	Case=Acc|Definite=Ind|Number=Sing|PronType=Art	38	det	_	_
+35	an	an	ADP	APPR	_	36	case	_	_
+36	Krebs	Krebs	NOUN	NN	Case=Dat|Gender=Masc|Number=Sing	37	nmod	_	_
+37	erkrankter	erkrankt	ADJ	ADJA	Case=Acc|Number=Sing	38	amod	_	_
+38	Verwandter	Verwandte	NOUN	NN	Case=Acc|Number=Sing	18	conj	_	_
+39	ersten	erster	ADJ	ADJA	Case=Gen|Gender=Masc|Number=Sing	40	amod	_	_
+40	Grades	Grad	NOUN	NN	Case=Gen|Gender=Masc|Number=Sing	38	nmod	_	SpaceAfter=No
+41	.	.	PUNCT	$.	_	16	punct	_	_
 
 # sent_id = test-s467
-# text = Make-ups changieren zwischen dezent und betont.
-1	Make	make	NOUN	NN	Case=Nom|Gender=Neut|Number=Plur	3	compound	_	SpaceAfter=No
-2	-	-	PUNCT	$(	_	1	punct	_	SpaceAfter=No
-3	ups	ups	X	NN	Case=Nom|Gender=Neut|Number=Plur	4	nsubj	_	_
-4	changieren	changieren	VERB	VVFIN	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	0	root	_	_
-5	zwischen	zwischen	ADP	APPR	_	6	case	_	_
-6	dezent	dezent	ADJ	ADJD	_	4	amod	_	_
-7	und	und	CCONJ	KON	_	8	cc	_	_
-8	betont	betont	ADJ	ADJD	_	6	conj	_	SpaceAfter=No
-9	.	.	PUNCT	$.	_	4	punct	_	_
+# text = Die Make-ups changieren zwischen dezent und betont.
+1	Die	der	DET	ART	Case=Nom|Definite=Def|Gender=Neut|Number=Plur|PronType=Art	2	dep	_	FixTigerDep=Yes
+2	Make	make	NOUN	NN	Case=Nom|Gender=Neut|Number=Plur	4	compound	_	SpaceAfter=No
+3	-	-	PUNCT	$(	_	2	punct	_	SpaceAfter=No
+4	ups	ups	X	NN	Case=Nom|Gender=Neut|Number=Plur	5	nsubj	_	_
+5	changieren	changieren	VERB	VVFIN	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	0	root	_	_
+6	zwischen	zwischen	ADP	APPR	_	7	case	_	_
+7	dezent	dezent	ADJ	ADJD	_	5	amod	_	_
+8	und	und	CCONJ	KON	_	9	cc	_	_
+9	betont	betont	ADJ	ADJD	_	7	conj	_	SpaceAfter=No
+10	.	.	PUNCT	$.	_	5	punct	_	_
 
 # sent_id = test-s468
-# text = mehr Menschen in Deutschland werden obdachlos.
-1	mehr	mehr	PRON	PIAT	Definite=Ind|PronType=Ind	2	amod	_	_
-2	Menschen	Mensch	NOUN	NN	Case=Nom|Gender=Masc|Number=Plur	6	nsubj	_	_
-3	in	in	ADP	APPR	_	4	case	_	_
-4	Deutschland	Deutschland	PROPN	NE	Case=Dat|Gender=Neut|Number=Sing	2	nmod	_	_
-5	werden	werden	AUX	VAFIN	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	6	cop	_	_
-6	obdachlos	obdachlos	ADJ	ADJD	_	0	root	_	SpaceAfter=No
-7	.	.	PUNCT	$.	_	6	punct	_	_
+# text = Immer mehr Menschen in Deutschland werden obdachlos.
+1	Immer	immer	ADV	ADV	_	2	dep	_	FixTigerDep=Yes
+2	mehr	mehr	PRON	PIAT	Definite=Ind|PronType=Ind	3	amod	_	_
+3	Menschen	Mensch	NOUN	NN	Case=Nom|Gender=Masc|Number=Plur	7	nsubj	_	_
+4	in	in	ADP	APPR	_	5	case	_	_
+5	Deutschland	Deutschland	PROPN	NE	Case=Dat|Gender=Neut|Number=Sing	3	nmod	_	_
+6	werden	werden	AUX	VAFIN	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	7	cop	_	_
+7	obdachlos	obdachlos	ADJ	ADJD	_	0	root	_	SpaceAfter=No
+8	.	.	PUNCT	$.	_	7	punct	_	_
 
 # sent_id = test-s469
-# text = Mehrheit der Abgeordneten sah darin einen wichtigen Schritt auf dem Weg zur Vollmitgliedschaft in der EG.
-1	Mehrheit	Mehrheit	NOUN	NN	Case=Nom|Gender=Fem|Number=Sing	4	nsubj	_	_
-2	der	der	DET	ART	Case=Gen|Definite=Def|Number=Plur|PronType=Art	3	det	_	_
-3	Abgeordneten	Abgeordneter	NOUN	NN	Case=Gen|Number=Plur	1	nmod	_	_
-4	sah	sehen	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	0	root	_	_
-5	darin	darin	ADV	PAV	_	4	advmod	_	_
-6	einen	ein	DET	ART	Case=Acc|Definite=Ind|Gender=Masc|Number=Sing|PronType=Art	8	det	_	_
-7	wichtigen	wichtig	ADJ	ADJA	Case=Acc|Gender=Masc|Number=Sing	8	amod	_	_
-8	Schritt	Schritt	NOUN	NN	Case=Acc|Gender=Masc|Number=Sing	4	obj	_	_
-9	auf	auf	ADP	APPR	_	11	case	_	_
-10	dem	der	DET	ART	Case=Dat|Definite=Def|Gender=Masc|Number=Sing|PronType=Art	11	det	_	_
-11	Weg	Weg	NOUN	NN	Case=Dat|Gender=Masc|Number=Sing	8	nmod	_	_
-12-13	zur	_	_	_	_	_	_	_	_
-12	zu	zu	ADP	APPR	_	14	case	_	_
-13	der	der	DET	ART	Case=Dat|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	14	det	_	_
-14	Vollmitgliedschaft	Vollmitgliedschaft	NOUN	NN	Case=Dat|Gender=Fem|Number=Sing	11	nmod	_	_
-15	in	in	ADP	APPR	_	17	case	_	_
-16	der	der	DET	ART	Case=Dat|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	17	det	_	_
-17	EG	EG	PROPN	NE	Case=Dat|Gender=Fem|Number=Sing	14	nmod	_	SpaceAfter=No
-18	.	.	PUNCT	$.	_	4	punct	_	_
+# text = Die Mehrheit der Abgeordneten sah darin einen wichtigen Schritt auf dem Weg zur Vollmitgliedschaft in der EG.
+1	Die	der	DET	ART	Case=Nom|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	2	dep	_	FixTigerDep=Yes
+2	Mehrheit	Mehrheit	NOUN	NN	Case=Nom|Gender=Fem|Number=Sing	5	nsubj	_	_
+3	der	der	DET	ART	Case=Gen|Definite=Def|Number=Plur|PronType=Art	4	det	_	_
+4	Abgeordneten	Abgeordneter	NOUN	NN	Case=Gen|Number=Plur	2	nmod	_	_
+5	sah	sehen	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	0	root	_	_
+6	darin	darin	ADV	PAV	_	5	advmod	_	_
+7	einen	ein	DET	ART	Case=Acc|Definite=Ind|Gender=Masc|Number=Sing|PronType=Art	9	det	_	_
+8	wichtigen	wichtig	ADJ	ADJA	Case=Acc|Gender=Masc|Number=Sing	9	amod	_	_
+9	Schritt	Schritt	NOUN	NN	Case=Acc|Gender=Masc|Number=Sing	5	obj	_	_
+10	auf	auf	ADP	APPR	_	12	case	_	_
+11	dem	der	DET	ART	Case=Dat|Definite=Def|Gender=Masc|Number=Sing|PronType=Art	12	det	_	_
+12	Weg	Weg	NOUN	NN	Case=Dat|Gender=Masc|Number=Sing	9	nmod	_	_
+13-14	zur	_	_	_	_	_	_	_	_
+13	zu	zu	ADP	APPR	_	15	case	_	_
+14	der	der	DET	ART	Case=Dat|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	15	det	_	_
+15	Vollmitgliedschaft	Vollmitgliedschaft	NOUN	NN	Case=Dat|Gender=Fem|Number=Sing	12	nmod	_	_
+16	in	in	ADP	APPR	_	18	case	_	_
+17	der	der	DET	ART	Case=Dat|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	18	det	_	_
+18	EG	EG	PROPN	NE	Case=Dat|Gender=Fem|Number=Sing	15	nmod	_	SpaceAfter=No
+19	.	.	PUNCT	$.	_	5	punct	_	_
 
 # sent_id = test-s470
-# text = Menschen hier glauben noch nicht, daß man seine Rechte einklagen kann.''
-1	Menschen	Mensch	NOUN	NN	Case=Nom|Gender=Masc|Number=Plur	3	nsubj	_	_
-2	hier	hier	ADV	ADV	_	3	advmod	_	_
-3	glauben	glauben	VERB	VVFIN	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	0	root	_	_
-4	noch	noch	ADV	ADV	_	5	advmod	_	_
-5	nicht	nicht	PART	PTKNEG	Polarity=Neg	3	advmod	_	SpaceAfter=No
-6	,	,	PUNCT	$,	_	3	punct	_	_
-7	daß	daß	SCONJ	KOUS	_	11	mark	_	_
-8	man	man	PRON	PIS	Case=Nom|Definite=Ind|Number=Sing|PronType=Ind	11	nsubj	_	_
-9	seine	sein	PRON	PPOSAT	Case=Acc|Gender=Neut|Number=Plur|Poss=Yes	10	det:poss	_	_
-10	Rechte	Recht	NOUN	NN	Case=Acc|Gender=Neut|Number=Plur	11	obj	_	_
-11	einklagen	einklagen	VERB	VVINF	VerbForm=Inf	3	ccomp	_	_
-12	kann	können	AUX	VMFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	11	aux	_	SpaceAfter=No
-13	.	.	PUNCT	$.	_	3	punct	_	SpaceAfter=No
-14	''	''	PUNCT	$(	_	3	punct	_	_
+# text = Die Menschen hier glauben noch nicht, daß man seine Rechte einklagen kann.''
+1	Die	der	DET	ART	Case=Nom|Definite=Def|Gender=Masc|Number=Plur|PronType=Art	2	dep	_	FixTigerDep=Yes
+2	Menschen	Mensch	NOUN	NN	Case=Nom|Gender=Masc|Number=Plur	4	nsubj	_	_
+3	hier	hier	ADV	ADV	_	4	advmod	_	_
+4	glauben	glauben	VERB	VVFIN	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	0	root	_	_
+5	noch	noch	ADV	ADV	_	6	advmod	_	_
+6	nicht	nicht	PART	PTKNEG	Polarity=Neg	4	advmod	_	SpaceAfter=No
+7	,	,	PUNCT	$,	_	4	punct	_	_
+8	daß	daß	SCONJ	KOUS	_	12	mark	_	_
+9	man	man	PRON	PIS	Case=Nom|Definite=Ind|Number=Sing|PronType=Ind	12	nsubj	_	_
+10	seine	sein	PRON	PPOSAT	Case=Acc|Gender=Neut|Number=Plur|Poss=Yes	11	det:poss	_	_
+11	Rechte	Recht	NOUN	NN	Case=Acc|Gender=Neut|Number=Plur	12	obj	_	_
+12	einklagen	einklagen	VERB	VVINF	VerbForm=Inf	4	ccomp	_	_
+13	kann	können	AUX	VMFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	12	aux	_	SpaceAfter=No
+14	.	.	PUNCT	$.	_	4	punct	_	SpaceAfter=No
+15	''	''	PUNCT	$(	_	4	punct	_	_
 
 # sent_id = test-s471
-# text = Menschen sind seit 10 Uhr vor Tor 2 der Märkischen Faserwerke versammelt.
-1	Menschen	Mensch	NOUN	NN	Case=Nom|Gender=Masc|Number=Plur	12	nsubj	_	_
-2	sind	sein	AUX	VAFIN	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	12	aux	_	_
-3	seit	seit	ADP	APPR	_	5	case	_	_
-4	10	10	NUM	CARD	NumType=Card	5	nummod	_	_
-5	Uhr	Uhr	NOUN	NN	Case=Dat|Gender=Fem|Number=Sing	12	obl	_	_
-6	vor	vor	ADP	APPR	_	7	case	_	_
-7	Tor	Tor	NOUN	NN	Case=Dat|Gender=Neut|Number=Sing	12	obl	_	_
-8	2	2	NUM	CARD	NumType=Card	7	compound	_	_
-9	der	der	DET	ART	Case=Gen|Definite=Def|Gender=Neut|Number=Plur|PronType=Art	11	det	_	_
-10	Märkischen	märkisch	ADJ	ADJA	Case=Gen|Gender=Neut|Number=Plur	11	amod	_	_
-11	Faserwerke	Faserwerk	PROPN	NN	Case=Gen|Gender=Neut|Number=Plur	7	nmod	_	_
-12	versammelt	versammeln	VERB	VVPP	VerbForm=Part	0	root	_	SpaceAfter=No
-13	.	.	PUNCT	$.	_	12	punct	_	_
+# text = 300 Menschen sind seit 10 Uhr vor Tor 2 der Märkischen Faserwerke versammelt.
+1	300	300	NUM	CARD	NumType=Card	2	dep	_	FixTigerDep=Yes
+2	Menschen	Mensch	NOUN	NN	Case=Nom|Gender=Masc|Number=Plur	13	nsubj	_	_
+3	sind	sein	AUX	VAFIN	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	13	aux	_	_
+4	seit	seit	ADP	APPR	_	6	case	_	_
+5	10	10	NUM	CARD	NumType=Card	6	nummod	_	_
+6	Uhr	Uhr	NOUN	NN	Case=Dat|Gender=Fem|Number=Sing	13	obl	_	_
+7	vor	vor	ADP	APPR	_	8	case	_	_
+8	Tor	Tor	NOUN	NN	Case=Dat|Gender=Neut|Number=Sing	13	obl	_	_
+9	2	2	NUM	CARD	NumType=Card	8	compound	_	_
+10	der	der	DET	ART	Case=Gen|Definite=Def|Gender=Neut|Number=Plur|PronType=Art	12	det	_	_
+11	Märkischen	märkisch	ADJ	ADJA	Case=Gen|Gender=Neut|Number=Plur	12	amod	_	_
+12	Faserwerke	Faserwerk	PROPN	NN	Case=Gen|Gender=Neut|Number=Plur	8	nmod	_	_
+13	versammelt	versammeln	VERB	VVPP	VerbForm=Part	0	root	_	SpaceAfter=No
+14	.	.	PUNCT	$.	_	13	punct	_	_
 
 # sent_id = test-s472
-# text = Mischung aus schlechten und etwas besseren Motiven zu einer ``europäischen'' Position -- abzüglich der offenkundig nachbarschaftlich befangenen Skandinavier -- zu adeln, hieß nun freilich, die Rechnung auf stoffelige Weise ohne den Wirt zu machen.
-1	Mischung	Mischung	NOUN	NN	Case=Acc|Gender=Fem|Number=Sing	23	obj	_	_
-2	aus	aus	ADP	APPR	_	7	case	_	_
-3	schlechten	schlecht	ADJ	ADJA	Case=Dat|Gender=Neut|Number=Plur	7	amod	_	_
-4	und	und	CCONJ	KON	_	3	cc	_	_
-5	etwas	etwas	PRON	ADV	_	6	advmod	_	_
-6	besseren	gut	ADJ	ADJA	Case=Dat|Gender=Neut|Number=Plur	3	amod	_	_
-7	Motiven	Motiv	NOUN	NN	Case=Dat|Gender=Neut|Number=Plur	1	nmod	_	_
-8	zu	zu	ADP	APPR	_	13	case	_	_
-9	einer	ein	DET	ART	Case=Dat|Definite=Ind|Gender=Fem|Number=Sing|PronType=Art	13	det	_	_
-10	``	``	PUNCT	$(	_	13	punct	_	SpaceAfter=No
-11	europäischen	europäisch	ADJ	ADJA	Case=Dat|Gender=Fem|Number=Sing	13	amod	_	SpaceAfter=No
-12	''	''	PUNCT	$(	_	13	punct	_	_
-13	Position	Position	NOUN	NN	Case=Dat|Gender=Fem|Number=Sing	23	obl	_	_
-14	--	--	PUNCT	$(	_	20	punct	_	_
-15	abzüglich	abzüglich	ADP	APPR	_	20	case	_	_
-16	der	der	DET	ART	Case=Gen|Definite=Def|Gender=Masc|Number=Plur|PronType=Art	20	det	_	_
-17	offenkundig	offenkundig	ADV	ADJD	_	19	advmod	_	_
-18	nachbarschaftlich	nachbarschaftlich	ADV	ADJD	_	19	advmod	_	_
-19	befangenen	befangen	ADJ	ADJA	Case=Gen|Gender=Masc|Number=Plur	20	amod	_	_
-20	Skandinavier	Skandinavier	NOUN	NN	Case=Gen|Gender=Masc|Number=Plur	13	nmod	_	_
-21	--	--	PUNCT	$(	_	20	punct	_	_
-22	zu	zu	PART	PTKZU	_	23	mark	_	_
-23	adeln	adeln	VERB	VVINF	VerbForm=Inf	25	csubj	_	SpaceAfter=No
-24	,	,	PUNCT	$,	_	25	punct	_	_
-25	hieß	heißen	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	0	root	_	_
-26	nun	nun	ADV	ADV	_	25	advmod	_	_
-27	freilich	freilich	ADV	ADV	_	25	advmod	_	SpaceAfter=No
-28	,	,	PUNCT	$,	_	25	punct	_	_
-29	die	der	DET	ART	Case=Acc|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	30	det	_	_
-30	Rechnung	Rechnung	NOUN	NN	Case=Acc|Gender=Fem|Number=Sing	38	obj	_	_
-31	auf	auf	ADP	APPR	_	33	case	_	_
-32	stoffelige	stoffelig	ADJ	ADJA	Case=Acc|Gender=Fem|Number=Sing	33	amod	_	_
-33	Weise	Weise	NOUN	NN	Case=Acc|Gender=Fem|Number=Sing	30	nmod	_	_
-34	ohne	ohne	ADP	APPR	_	36	case	_	_
-35	den	der	DET	ART	Case=Acc|Definite=Def|Gender=Masc|Number=Sing|PronType=Art	36	det	_	_
-36	Wirt	Wirt	NOUN	NN	Case=Acc|Gender=Masc|Number=Sing	30	nmod	_	_
-37	zu	zu	PART	PTKZU	_	38	mark	_	_
-38	machen	machen	VERB	VVINF	VerbForm=Inf	25	xcomp	_	SpaceAfter=No
-39	.	.	PUNCT	$.	_	25	punct	_	_
+# text = Diese Mischung aus schlechten und etwas besseren Motiven zu einer ``europäischen'' Position -- abzüglich der offenkundig nachbarschaftlich befangenen Skandinavier -- zu adeln, hieß nun freilich, die Rechnung auf stoffelige Weise ohne den Wirt zu machen.
+1	Diese	dies	DET	PDAT	Case=Acc|Gender=Fem|Number=Sing|PronType=Dem	2	dep	_	FixTigerDep=Yes
+2	Mischung	Mischung	NOUN	NN	Case=Acc|Gender=Fem|Number=Sing	24	obj	_	_
+3	aus	aus	ADP	APPR	_	8	case	_	_
+4	schlechten	schlecht	ADJ	ADJA	Case=Dat|Gender=Neut|Number=Plur	8	amod	_	_
+5	und	und	CCONJ	KON	_	4	cc	_	_
+6	etwas	etwas	PRON	ADV	_	7	advmod	_	_
+7	besseren	gut	ADJ	ADJA	Case=Dat|Gender=Neut|Number=Plur	4	amod	_	_
+8	Motiven	Motiv	NOUN	NN	Case=Dat|Gender=Neut|Number=Plur	2	nmod	_	_
+9	zu	zu	ADP	APPR	_	14	case	_	_
+10	einer	ein	DET	ART	Case=Dat|Definite=Ind|Gender=Fem|Number=Sing|PronType=Art	14	det	_	_
+11	``	``	PUNCT	$(	_	14	punct	_	SpaceAfter=No
+12	europäischen	europäisch	ADJ	ADJA	Case=Dat|Gender=Fem|Number=Sing	14	amod	_	SpaceAfter=No
+13	''	''	PUNCT	$(	_	14	punct	_	_
+14	Position	Position	NOUN	NN	Case=Dat|Gender=Fem|Number=Sing	24	obl	_	_
+15	--	--	PUNCT	$(	_	21	punct	_	_
+16	abzüglich	abzüglich	ADP	APPR	_	21	case	_	_
+17	der	der	DET	ART	Case=Gen|Definite=Def|Gender=Masc|Number=Plur|PronType=Art	21	det	_	_
+18	offenkundig	offenkundig	ADV	ADJD	_	20	advmod	_	_
+19	nachbarschaftlich	nachbarschaftlich	ADV	ADJD	_	20	advmod	_	_
+20	befangenen	befangen	ADJ	ADJA	Case=Gen|Gender=Masc|Number=Plur	21	amod	_	_
+21	Skandinavier	Skandinavier	NOUN	NN	Case=Gen|Gender=Masc|Number=Plur	14	nmod	_	_
+22	--	--	PUNCT	$(	_	21	punct	_	_
+23	zu	zu	PART	PTKZU	_	24	mark	_	_
+24	adeln	adeln	VERB	VVINF	VerbForm=Inf	26	csubj	_	SpaceAfter=No
+25	,	,	PUNCT	$,	_	26	punct	_	_
+26	hieß	heißen	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	0	root	_	_
+27	nun	nun	ADV	ADV	_	26	advmod	_	_
+28	freilich	freilich	ADV	ADV	_	26	advmod	_	SpaceAfter=No
+29	,	,	PUNCT	$,	_	26	punct	_	_
+30	die	der	DET	ART	Case=Acc|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	31	det	_	_
+31	Rechnung	Rechnung	NOUN	NN	Case=Acc|Gender=Fem|Number=Sing	39	obj	_	_
+32	auf	auf	ADP	APPR	_	34	case	_	_
+33	stoffelige	stoffelig	ADJ	ADJA	Case=Acc|Gender=Fem|Number=Sing	34	amod	_	_
+34	Weise	Weise	NOUN	NN	Case=Acc|Gender=Fem|Number=Sing	31	nmod	_	_
+35	ohne	ohne	ADP	APPR	_	37	case	_	_
+36	den	der	DET	ART	Case=Acc|Definite=Def|Gender=Masc|Number=Sing|PronType=Art	37	det	_	_
+37	Wirt	Wirt	NOUN	NN	Case=Acc|Gender=Masc|Number=Sing	31	nmod	_	_
+38	zu	zu	PART	PTKZU	_	39	mark	_	_
+39	machen	machen	VERB	VVINF	VerbForm=Inf	26	xcomp	_	SpaceAfter=No
+40	.	.	PUNCT	$.	_	26	punct	_	_
 
 # sent_id = test-s473
-# text = Misere wird nach Ansicht von Branchenvertretern von den zunehmenden Freizeitaktivitäten wie Sport, Reisen und Kultur mitverursacht, die zu Lasten des Konsums gingen.
-1	Misere	Misere	NOUN	NN	Case=Nom|Gender=Fem|Number=Sing	17	nsubj:pass	_	_
-2	wird	werden	AUX	VAFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	17	aux:pass	_	_
-3	nach	nach	ADP	APPR	_	4	case	_	_
-4	Ansicht	Ansicht	NOUN	NN	Case=Dat|Gender=Fem|Number=Sing	17	obl	_	_
-5	von	von	ADP	APPR	_	6	case	_	_
-6	Branchenvertretern	Branchenvertreter	NOUN	NN	Case=Dat|Gender=Masc|Number=Plur	4	nmod	_	_
-7	von	von	ADP	APPR	_	10	case	_	_
-8	den	der	DET	ART	Case=Dat|Definite=Def|Gender=Fem|Number=Plur|PronType=Art	10	det	_	_
-9	zunehmenden	zunehmend	ADJ	ADJA	Case=Dat|Gender=Fem|Number=Plur	10	amod	_	_
-10	Freizeitaktivitäten	Freizeitaktivität	NOUN	NN	Case=Dat|Gender=Fem|Number=Plur	17	obl	_	_
-11	wie	wie	CCONJ	KOKOM	_	12	case	_	_
-12	Sport	Sport	NOUN	NN	Case=Dat|Gender=Masc|Number=Sing	10	nmod	_	SpaceAfter=No
-13	,	,	PUNCT	$,	_	14	punct	_	_
-14	Reisen	Reise	NOUN	NN	Case=Dat|Gender=Fem|Number=Plur	12	conj	_	_
-15	und	und	CCONJ	KON	_	16	cc	_	_
-16	Kultur	Kultur	NOUN	NN	Case=Dat|Gender=Fem|Number=Sing	12	conj	_	_
-17	mitverursacht	mitverursachen	VERB	VVPP	VerbForm=Part	0	root	_	SpaceAfter=No
-18	,	,	PUNCT	$,	_	17	punct	_	_
-19	die	der	PRON	PRELS	Case=Nom|Gender=Fem|Number=Plur|PronType=Rel	24	nsubj	_	_
-20	zu	zu	ADP	APPR	_	21	case	_	_
-21	Lasten	Last	NOUN	NN	Case=Dat|Gender=Fem|Number=Plur	24	obl	_	_
-22	des	der	DET	ART	Case=Gen|Definite=Def|Gender=Masc|Number=Sing|PronType=Art	23	det	_	_
-23	Konsums	Konsum	NOUN	NN	Case=Gen|Gender=Masc|Number=Sing	21	nmod	_	_
-24	gingen	gehen	VERB	VVFIN	Mood=Sub|Number=Plur|Person=3|Tense=Past|VerbForm=Fin	10	acl	_	SpaceAfter=No
-25	.	.	PUNCT	$.	_	17	punct	_	_
+# text = Die Misere wird nach Ansicht von Branchenvertretern von den zunehmenden Freizeitaktivitäten wie Sport, Reisen und Kultur mitverursacht, die zu Lasten des Konsums gingen.
+1	Die	der	DET	ART	Case=Nom|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	2	dep	_	FixTigerDep=Yes
+2	Misere	Misere	NOUN	NN	Case=Nom|Gender=Fem|Number=Sing	18	nsubj:pass	_	_
+3	wird	werden	AUX	VAFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	18	aux:pass	_	_
+4	nach	nach	ADP	APPR	_	5	case	_	_
+5	Ansicht	Ansicht	NOUN	NN	Case=Dat|Gender=Fem|Number=Sing	18	obl	_	_
+6	von	von	ADP	APPR	_	7	case	_	_
+7	Branchenvertretern	Branchenvertreter	NOUN	NN	Case=Dat|Gender=Masc|Number=Plur	5	nmod	_	_
+8	von	von	ADP	APPR	_	11	case	_	_
+9	den	der	DET	ART	Case=Dat|Definite=Def|Gender=Fem|Number=Plur|PronType=Art	11	det	_	_
+10	zunehmenden	zunehmend	ADJ	ADJA	Case=Dat|Gender=Fem|Number=Plur	11	amod	_	_
+11	Freizeitaktivitäten	Freizeitaktivität	NOUN	NN	Case=Dat|Gender=Fem|Number=Plur	18	obl	_	_
+12	wie	wie	CCONJ	KOKOM	_	13	case	_	_
+13	Sport	Sport	NOUN	NN	Case=Dat|Gender=Masc|Number=Sing	11	nmod	_	SpaceAfter=No
+14	,	,	PUNCT	$,	_	15	punct	_	_
+15	Reisen	Reise	NOUN	NN	Case=Dat|Gender=Fem|Number=Plur	13	conj	_	_
+16	und	und	CCONJ	KON	_	17	cc	_	_
+17	Kultur	Kultur	NOUN	NN	Case=Dat|Gender=Fem|Number=Sing	13	conj	_	_
+18	mitverursacht	mitverursachen	VERB	VVPP	VerbForm=Part	0	root	_	SpaceAfter=No
+19	,	,	PUNCT	$,	_	18	punct	_	_
+20	die	der	PRON	PRELS	Case=Nom|Gender=Fem|Number=Plur|PronType=Rel	25	nsubj	_	_
+21	zu	zu	ADP	APPR	_	22	case	_	_
+22	Lasten	Last	NOUN	NN	Case=Dat|Gender=Fem|Number=Plur	25	obl	_	_
+23	des	der	DET	ART	Case=Gen|Definite=Def|Gender=Masc|Number=Sing|PronType=Art	24	det	_	_
+24	Konsums	Konsum	NOUN	NN	Case=Gen|Gender=Masc|Number=Sing	22	nmod	_	_
+25	gingen	gehen	VERB	VVFIN	Mood=Sub|Number=Plur|Person=3|Tense=Past|VerbForm=Fin	11	acl	_	SpaceAfter=No
+26	.	.	PUNCT	$.	_	18	punct	_	_
 
 # sent_id = test-s474
-# text = "Mittelstand solle sich entscheiden, ob er günstige Teilzeitkräfte oder längere Öffnungszeiten wolle.
-1	"	"	PUNCT	$(	_	5	punct	_	SpaceAfter=No
+# text = Der Mittelstand solle sich entscheiden, ob er günstige Teilzeitkräfte oder längere Öffnungszeiten wolle.
+1	Der	der	DET	ART	Case=Nom|Definite=Def|Gender=Masc|Number=Sing|PronType=Art	2	dep	_	FixTigerDep=Yes
 2	Mittelstand	Mittelstand	NOUN	NN	Case=Nom|Gender=Masc|Number=Sing	5	nsubj	_	_
 3	solle	sollen	AUX	VMFIN	Mood=Sub|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	5	aux	_	_
 4	sich	er|es|sie	PRON	PRF	Case=Acc|Number=Sing|Person=3|PronType=Prs|Reflex=Yes	5	obj	_	_
@@ -9113,69 +9252,76 @@
 15	.	.	PUNCT	$.	_	5	punct	_	_
 
 # sent_id = test-s475
-# text = "Mittwoch im Parlament ist (fast) alles anders.
-1	"	"	PUNCT	$(	_	11	punct	_	SpaceAfter=No
-2	Mittwoch	Mittwoch	PROPN	NN	Case=Dat|Gender=Masc|Number=Sing	11	nmod	_	_
-3-4	im	_	_	_	_	_	_	_	_
-3	in	in	ADP	APPR	_	5	case	_	_
-4	dem	der	DET	ART	Case=Dat|Definite=Def|Gender=Neut|Number=Sing|PronType=Art	5	det	_	_
-5	Parlament	Parlament	NOUN	NN	Case=Dat|Gender=Neut|Number=Sing	2	nmod	_	_
-6	ist	sein	AUX	VAFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	11	cop	_	_
-7	(	(	PUNCT	$(	_	8	punct	_	SpaceAfter=No
-8	fast	fast	ADV	ADV	_	10	appos	_	SpaceAfter=No
-9	)	)	PUNCT	$(	_	8	punct	_	_
-10	alles	alle	PRON	PIS	Case=Nom|Definite=Ind|Gender=Neut|Number=Sing|PronType=Ind	11	nsubj	_	_
-11	anders	anders	ADJ	ADV	_	0	root	_	SpaceAfter=No
-12	.	.	PUNCT	$.	_	11	punct	_	_
+# text = Am Mittwoch im Parlament ist (fast) alles anders.
+1-2	Am	_	_	_	_	_	_	_	_
+1	An	an	ADP	APPR	_	3	case	_	_
+2	dem	der	DET	ART	Case=Dat|Gender=Masc|Number=Sing	3	det	_	_
+3	Mittwoch	Mittwoch	PROPN	NN	Case=Dat|Gender=Masc|Number=Sing	12	nmod	_	_
+4-5	im	_	_	_	_	_	_	_	_
+4	in	in	ADP	APPR	_	6	case	_	_
+5	dem	der	DET	ART	Case=Dat|Definite=Def|Gender=Neut|Number=Sing|PronType=Art	6	det	_	_
+6	Parlament	Parlament	NOUN	NN	Case=Dat|Gender=Neut|Number=Sing	3	nmod	_	_
+7	ist	sein	AUX	VAFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	12	cop	_	_
+8	(	(	PUNCT	$(	_	9	punct	_	SpaceAfter=No
+9	fast	fast	ADV	ADV	_	11	appos	_	SpaceAfter=No
+10	)	)	PUNCT	$(	_	9	punct	_	_
+11	alles	alle	PRON	PIS	Case=Nom|Definite=Ind|Gender=Neut|Number=Sing|PronType=Ind	12	nsubj	_	_
+12	anders	anders	ADJ	ADV	_	0	root	_	SpaceAfter=No
+13	.	.	PUNCT	$.	_	12	punct	_	_
 
 # sent_id = test-s476
-# text = Modell ``Soziale Marktwirtschaft'' steht für die Gewerkschaften nicht zur Debatte.
-1	Modell	Modell	NOUN	NN	Case=Nom|Gender=Neut|Number=Sing	6	nsubj	_	_
-2	``	``	PUNCT	$(	_	4	punct	_	SpaceAfter=No
-3	Soziale	sozial	ADJ	ADJA	Case=Nom|Gender=Fem|Number=Sing	4	compound	_	_
-4	Marktwirtschaft	Marktwirtschaft	NOUN	NN	Case=Nom|Gender=Fem|Number=Sing	1	appos	_	SpaceAfter=No
-5	''	''	PUNCT	$(	_	4	punct	_	_
-6	steht	stehen	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	0	root	_	_
-7	für	für	ADP	APPR	_	9	case	_	_
-8	die	der	DET	ART	Case=Acc|Definite=Def|Gender=Fem|Number=Plur|PronType=Art	9	det	_	_
-9	Gewerkschaften	Gewerkschaft	NOUN	NN	Case=Acc|Gender=Fem|Number=Plur	6	obl	_	_
-10	nicht	nicht	PART	PTKNEG	Polarity=Neg	6	advmod	_	_
-11-12	zur	_	_	_	_	_	_	_	_
-11	zu	zu	ADP	APPR	_	13	case	_	_
-12	der	der	DET	ART	Case=Dat|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	13	det	_	_
-13	Debatte	Debatte	NOUN	NN	Case=Dat|Gender=Fem|Number=Sing	6	obl	_	SpaceAfter=No
-14	.	.	PUNCT	$.	_	6	punct	_	_
+# text = Das Modell ``Soziale Marktwirtschaft'' steht für die Gewerkschaften nicht zur Debatte.
+1	Das	der	DET	ART	Case=Nom|Definite=Def|Gender=Neut|Number=Sing|PronType=Art	2	dep	_	FixTigerDep=Yes
+2	Modell	Modell	NOUN	NN	Case=Nom|Gender=Neut|Number=Sing	7	nsubj	_	_
+3	``	``	PUNCT	$(	_	5	punct	_	SpaceAfter=No
+4	Soziale	sozial	ADJ	ADJA	Case=Nom|Gender=Fem|Number=Sing	5	compound	_	_
+5	Marktwirtschaft	Marktwirtschaft	NOUN	NN	Case=Nom|Gender=Fem|Number=Sing	2	appos	_	SpaceAfter=No
+6	''	''	PUNCT	$(	_	5	punct	_	_
+7	steht	stehen	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	0	root	_	_
+8	für	für	ADP	APPR	_	10	case	_	_
+9	die	der	DET	ART	Case=Acc|Definite=Def|Gender=Fem|Number=Plur|PronType=Art	10	det	_	_
+10	Gewerkschaften	Gewerkschaft	NOUN	NN	Case=Acc|Gender=Fem|Number=Plur	7	obl	_	_
+11	nicht	nicht	PART	PTKNEG	Polarity=Neg	7	advmod	_	_
+12-13	zur	_	_	_	_	_	_	_	_
+12	zu	zu	ADP	APPR	_	14	case	_	_
+13	der	der	DET	ART	Case=Dat|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	14	det	_	_
+14	Debatte	Debatte	NOUN	NN	Case=Dat|Gender=Fem|Number=Sing	7	obl	_	SpaceAfter=No
+15	.	.	PUNCT	$.	_	7	punct	_	_
 
 # sent_id = test-s477
-# text = Montag werde der Aufsichtsrat über mögliche personelle Konsequenzen entscheiden.
-1	Montag	Montag	PROPN	NN	Case=Dat|Gender=Masc|Number=Sing	9	obl	_	_
-2	werde	werden	AUX	VAFIN	Mood=Sub|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	9	aux	_	_
-3	der	der	DET	ART	Case=Nom|Definite=Def|Gender=Masc|Number=Sing|PronType=Art	4	det	_	_
-4	Aufsichtsrat	Aufsichtsrat	NOUN	NN	Case=Nom|Gender=Masc|Number=Sing	9	nsubj	_	_
-5	über	über	ADP	APPR	_	8	case	_	_
-6	mögliche	möglich	ADJ	ADJA	Case=Acc|Gender=Fem|Number=Plur	8	amod	_	_
-7	personelle	personell	ADJ	ADJA	Case=Acc|Gender=Fem|Number=Plur	8	amod	_	_
-8	Konsequenzen	Konsequenz	NOUN	NN	Case=Acc|Gender=Fem|Number=Plur	9	obl	_	_
-9	entscheiden	entscheiden	VERB	VVINF	VerbForm=Inf	0	root	_	SpaceAfter=No
-10	.	.	PUNCT	$.	_	9	punct	_	_
+# text = Am Montag werde der Aufsichtsrat über mögliche personelle Konsequenzen entscheiden.
+1-2	Am	_	_	_	_	_	_	_	_
+1	An	an	ADP	APPR	_	3	case	_	FixTigerDep=Yes
+2	dem	der	DET	ART	Case=Dat|Gender=Masc|Number=Sing	3	det	_	_
+3	Montag	Montag	PROPN	NN	Case=Dat|Gender=Masc|Number=Sing	11	obl	_	_
+4	werde	werden	AUX	VAFIN	Mood=Sub|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	11	aux	_	_
+5	der	der	DET	ART	Case=Nom|Definite=Def|Gender=Masc|Number=Sing|PronType=Art	6	det	_	_
+6	Aufsichtsrat	Aufsichtsrat	NOUN	NN	Case=Nom|Gender=Masc|Number=Sing	11	nsubj	_	_
+7	über	über	ADP	APPR	_	10	case	_	_
+8	mögliche	möglich	ADJ	ADJA	Case=Acc|Gender=Fem|Number=Plur	10	amod	_	_
+9	personelle	personell	ADJ	ADJA	Case=Acc|Gender=Fem|Number=Plur	10	amod	_	_
+10	Konsequenzen	Konsequenz	NOUN	NN	Case=Acc|Gender=Fem|Number=Plur	11	obl	_	_
+11	entscheiden	entscheiden	VERB	VVINF	VerbForm=Inf	0	root	_	SpaceAfter=No
+12	.	.	PUNCT	$.	_	11	punct	_	_
 
 # sent_id = test-s478
-# text = Nationalbühne wie das Burgtheater kann ein solches lokalbezogenes literarisches Segment herausstellen, auch darstellen.
-1	Nationalbühne	Nationalbühne	NOUN	NN	Case=Nom|Gender=Fem|Number=Sing	11	nsubj	_	_
-2	wie	wie	ADV	KOKOM	_	4	advmod	_	_
-3	das	der	DET	ART	Case=Nom|Definite=Def|Gender=Neut|Number=Sing|PronType=Art	4	det	_	_
-4	Burgtheater	Burgtheater	PROPN	NE	Case=Nom|Gender=Neut|Number=Sing	1	nmod	_	_
-5	kann	können	AUX	VMFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	11	aux	_	_
-6	ein	ein	DET	ART	Case=Acc|Definite=Ind|Gender=Neut|Number=Sing|PronType=Art	10	det	_	_
-7	solches	solch	PRON	PIAT	Case=Acc|Definite=Ind|Gender=Neut|Number=Sing|PronType=Ind	10	det	_	_
-8	lokalbezogenes	lokalbezogen	ADJ	ADJA	Case=Acc|Gender=Neut|Number=Sing	10	amod	_	_
-9	literarisches	literarisch	ADJ	ADJA	Case=Acc|Gender=Neut|Number=Sing	10	amod	_	_
-10	Segment	Segment	NOUN	NN	Case=Acc|Gender=Neut|Number=Sing	11	obj	_	_
-11	herausstellen	herausstellen	VERB	VVINF	VerbForm=Inf	0	root	_	SpaceAfter=No
-12	,	,	PUNCT	$,	_	14	punct	_	_
-13	auch	auch	ADV	ADV	_	14	advmod	_	_
-14	darstellen	darstellen	VERB	VVINF	VerbForm=Inf	11	conj	_	SpaceAfter=No
-15	.	.	PUNCT	$.	_	11	punct	_	_
+# text = Eine Nationalbühne wie das Burgtheater kann ein solches lokalbezogenes literarisches Segment herausstellen, auch darstellen.
+1	Eine	ein	DET	ART	Case=Nom|Definite=Ind|Gender=Fem|Number=Sing|PronType=Art	2	dep	_	FixTigerDep=Yes
+2	Nationalbühne	Nationalbühne	NOUN	NN	Case=Nom|Gender=Fem|Number=Sing	12	nsubj	_	_
+3	wie	wie	ADV	KOKOM	_	5	advmod	_	_
+4	das	der	DET	ART	Case=Nom|Definite=Def|Gender=Neut|Number=Sing|PronType=Art	5	det	_	_
+5	Burgtheater	Burgtheater	PROPN	NE	Case=Nom|Gender=Neut|Number=Sing	2	nmod	_	_
+6	kann	können	AUX	VMFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	12	aux	_	_
+7	ein	ein	DET	ART	Case=Acc|Definite=Ind|Gender=Neut|Number=Sing|PronType=Art	11	det	_	_
+8	solches	solch	PRON	PIAT	Case=Acc|Definite=Ind|Gender=Neut|Number=Sing|PronType=Ind	11	det	_	_
+9	lokalbezogenes	lokalbezogen	ADJ	ADJA	Case=Acc|Gender=Neut|Number=Sing	11	amod	_	_
+10	literarisches	literarisch	ADJ	ADJA	Case=Acc|Gender=Neut|Number=Sing	11	amod	_	_
+11	Segment	Segment	NOUN	NN	Case=Acc|Gender=Neut|Number=Sing	12	obj	_	_
+12	herausstellen	herausstellen	VERB	VVINF	VerbForm=Inf	0	root	_	SpaceAfter=No
+13	,	,	PUNCT	$,	_	15	punct	_	_
+14	auch	auch	ADV	ADV	_	15	advmod	_	_
+15	darstellen	darstellen	VERB	VVINF	VerbForm=Inf	12	conj	_	SpaceAfter=No
+16	.	.	PUNCT	$.	_	12	punct	_	_
 
 # sent_id = test-s479
 # text = Naturalien, meint die HBV -- Frau, ``lassen wir auf Dauer nicht uns abspeisen''.
@@ -9209,21 +9355,22 @@
 6	Sichtweite	Sichtweite	NOUN	NN	Case=Dat|Gender=Fem|Number=Sing	1	nmod	_	_
 
 # sent_id = test-s481
-# text = Nitschmann wird mit dieser CDU-Schelte leben können.
-1	Nitschmann	Nitschmann	PROPN	NE	Case=Nom|Gender=Masc|Number=Sing	8	nsubj	_	_
-2	wird	werden	AUX	VAFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	8	aux	_	_
-3	mit	mit	ADP	APPR	_	5	case	_	_
-4	dieser	dies	PRON	PDAT	Case=Dat|Gender=Fem|Number=Sing|PronType=Dem	5	det	_	_
-5	CDU	CDU	PROPN	NN	Case=Dat|Gender=Fem|Number=Sing	7	compound	_	SpaceAfter=No
-6	-	-	PUNCT	$(	_	5	punct	_	SpaceAfter=No
-7	Schelte	Schelte	NOUN	NN	Case=Dat|Gender=Fem|Number=Sing	8	obl	_	_
-8	leben	leben	VERB	VVINF	VerbForm=Inf	0	root	_	_
-9	können	können	AUX	VMINF	VerbForm=Inf	8	aux	_	SpaceAfter=No
-10	.	.	PUNCT	$.	_	8	punct	_	_
+# text = Johannes Nitschmann wird mit dieser CDU-Schelte leben können.
+1	Johannes	Johannes	PROPN	NE	Case=Nom|Gender=Masc|Number=Sing	2	dep	_	FixTigerDep=Yes
+2	Nitschmann	Nitschmann	PROPN	NE	Case=Nom|Gender=Masc|Number=Sing	9	nsubj	_	_
+3	wird	werden	AUX	VAFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	9	aux	_	_
+4	mit	mit	ADP	APPR	_	6	case	_	_
+5	dieser	dies	PRON	PDAT	Case=Dat|Gender=Fem|Number=Sing|PronType=Dem	6	det	_	_
+6	CDU	CDU	PROPN	NN	Case=Dat|Gender=Fem|Number=Sing	8	compound	_	SpaceAfter=No
+7	-	-	PUNCT	$(	_	6	punct	_	SpaceAfter=No
+8	Schelte	Schelte	NOUN	NN	Case=Dat|Gender=Fem|Number=Sing	9	obl	_	_
+9	leben	leben	VERB	VVINF	VerbForm=Inf	0	root	_	_
+10	können	können	AUX	VMINF	VerbForm=Inf	9	aux	_	SpaceAfter=No
+11	.	.	PUNCT	$.	_	9	punct	_	_
 
 # sent_id = test-s482
-# text = "nur die Schichtarbeiter beschränkten ihre Freizeitaktivität auf Fernsehen, Video oder Musikhören -- auch die Kinder seien dazu gezwungen.
-1	"	"	PUNCT	$(	_	5	punct	_	SpaceAfter=No
+# text = Nicht nur die Schichtarbeiter beschränkten ihre Freizeitaktivität auf Fernsehen, Video oder Musikhören -- auch die Kinder seien dazu gezwungen.
+1	Nicht	nicht	PART	PTKNEG	Polarity=Neg	2	dep	_	FixTigerDep=Yes
 2	nur	nur	ADV	ADV	_	5	advmod	_	_
 3	die	der	DET	ART	Case=Nom|Definite=Def|Gender=Masc|Number=Plur|PronType=Art	4	det	_	_
 4	Schichtarbeiter	Schichtarbeiter	NOUN	NN	Case=Nom|Gender=Masc|Number=Plur	5	nsubj	_	_
@@ -9246,8 +9393,8 @@
 21	.	.	PUNCT	$.	_	5	punct	_	_
 
 # sent_id = test-s483
-# text = "Oberste Gerichtshof Argentiniens hat am Dienstag den Einspruch des früheren SS-Offiziers Erich Priebke abgelehnt und so den Weg für seine Auslieferung nach Italien frei gemacht.
-1	"	"	PUNCT	$(	_	18	punct	_	SpaceAfter=No
+# text = Der Oberste Gerichtshof Argentiniens hat am Dienstag den Einspruch des früheren SS-Offiziers Erich Priebke abgelehnt und so den Weg für seine Auslieferung nach Italien frei gemacht.
+1	Der	der	DET	ART	Case=Nom|Definite=Def|Gender=Masc|Number=Sing|PronType=Art	2	dep	_	FixTigerDep=Yes
 2	Oberste	oberer	ADJ	ADJA	Case=Nom|Gender=Masc|Number=Sing	3	compound	_	_
 3	Gerichtshof	Gerichtshof	NOUN	NN	Case=Nom|Gender=Masc|Number=Sing	18	nsubj	_	_
 4	Argentiniens	Argentinien	PROPN	NE	Case=Gen|Gender=Neut|Number=Sing	3	nmod	_	_
@@ -9280,100 +9427,104 @@
 30	.	.	PUNCT	$.	_	18	punct	_	_
 
 # sent_id = test-s484
-# text = Opposition fordert Dialog
-1	Opposition	Opposition	NOUN	NN	Case=Nom|Gender=Fem|Number=Sing	2	nsubj	_	_
-2	fordert	fordern	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	0	root	_	_
-3	Dialog	Dialog	NOUN	NN	Case=Acc|Gender=Masc|Number=Sing	2	obj	_	_
+# text = Islamische Opposition fordert Dialog
+1	Islamische	islamisch	ADJ	ADJA	Case=Nom|Gender=Fem|Number=Sing	2	dep	_	FixTigerDep=Yes
+2	Opposition	Opposition	NOUN	NN	Case=Nom|Gender=Fem|Number=Sing	3	nsubj	_	_
+3	fordert	fordern	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	0	root	_	_
+4	Dialog	Dialog	NOUN	NN	Case=Acc|Gender=Masc|Number=Sing	3	obj	_	_
 
 # sent_id = test-s485
-# text = Osten zieht nun nach.
-1	Osten	Osten	NOUN	NN	Case=Nom|Gender=Masc|Number=Sing	2	nsubj	_	_
-2	zieht	ziehen	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	0	root	_	_
-3	nun	nun	ADV	ADV	_	2	advmod	_	_
-4	nach	nach	ADP	PTKVZ	_	2	compound:prt	_	SpaceAfter=No
-5	.	.	PUNCT	$.	_	2	punct	_	_
+# text = Der Osten zieht nun nach.
+1	Der	der	DET	ART	Case=Nom|Definite=Def|Gender=Masc|Number=Sing|PronType=Art	2	dep	_	FixTigerDep=Yes
+2	Osten	Osten	NOUN	NN	Case=Nom|Gender=Masc|Number=Sing	3	nsubj	_	_
+3	zieht	ziehen	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	0	root	_	_
+4	nun	nun	ADV	ADV	_	3	advmod	_	_
+5	nach	nach	ADP	PTKVZ	_	3	compound:prt	_	SpaceAfter=No
+6	.	.	PUNCT	$.	_	3	punct	_	_
 
 # sent_id = test-s486
-# text = Otto Wolf von der Osteuropa-Initiative Eurocom prangerte die ``intellektuelle Unredlichkeit'' der ``falschen Versprechungen'' durch die westlichen Politiker an, die Sozialabbau und Schließung ganzer Industrien in Osteuropa als ``unvermeidlich'' erklärten.
-1	Otto	Otto	PROPN	NE	Case=Nom|Gender=Masc|Number=Sing	9	nsubj	_	_
-2	Wolf	Wolf	PROPN	NE	Case=Nom|Gender=Masc|Number=Sing	1	flat	_	_
-3	von	von	ADP	APPR	_	7	case	_	_
-4	der	der	DET	ART	Case=Dat|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	7	det	_	_
-5	Osteuropa	Osteuropa	NOUN	NN	Case=Dat|Gender=Fem|Number=Sing	7	compound	_	SpaceAfter=No
-6	-	-	PUNCT	$(	_	5	punct	_	SpaceAfter=No
-7	Initiative	initiativ	NOUN	NN	Case=Dat|Gender=Fem|Number=Sing	1	nmod	_	_
-8	Eurocom	Eurocom	PROPN	NE	Case=Nom|Gender=Fem|Number=Sing	7	appos	_	_
-9	prangerte	prangern	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	0	root	_	_
-10	die	der	DET	ART	Case=Acc|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	13	det	_	_
-11	``	``	PUNCT	$(	_	13	punct	_	SpaceAfter=No
-12	intellektuelle	intellektuell	ADJ	ADJA	Case=Acc|Gender=Fem|Number=Sing	13	amod	_	_
-13	Unredlichkeit	Unredlichkeit	NOUN	NN	Case=Acc|Gender=Fem|Number=Sing	9	obj	_	SpaceAfter=No
-14	''	''	PUNCT	$(	_	13	punct	_	_
-15	der	der	DET	ART	Case=Gen|Definite=Def|Gender=Fem|Number=Plur|PronType=Art	18	det	_	_
-16	``	``	PUNCT	$(	_	18	punct	_	SpaceAfter=No
-17	falschen	falsch	ADJ	ADJA	Case=Gen|Gender=Fem|Number=Plur	18	amod	_	_
-18	Versprechungen	Versprechung	NOUN	NN	Case=Gen|Gender=Fem|Number=Plur	13	nmod	_	SpaceAfter=No
-19	''	''	PUNCT	$(	_	18	punct	_	_
-20	durch	durch	ADP	APPR	_	23	case	_	_
-21	die	der	DET	ART	Case=Acc|Definite=Def|Gender=Masc|Number=Plur|PronType=Art	23	det	_	_
-22	westlichen	westlich	ADJ	ADJA	Case=Acc|Gender=Masc|Number=Plur	23	amod	_	_
-23	Politiker	Politiker	NOUN	NN	Case=Acc|Gender=Masc|Number=Plur	13	nmod	_	_
-24	an	an	ADP	PTKVZ	_	9	compound:prt	_	SpaceAfter=No
-25	,	,	PUNCT	$,	_	23	punct	_	_
-26	die	der	DET	PRELS	Case=Nom|Gender=Masc|Number=Plur|PronType=Rel	38	nsubj	_	_
-27	Sozialabbau	Sozialabbau	NOUN	NN	Case=Acc|Gender=Masc|Number=Sing	38	obj	_	_
-28	und	und	CCONJ	KON	_	29	cc	_	_
-29	Schließung	Schließung	NOUN	NN	Case=Acc|Gender=Fem|Number=Sing	27	conj	_	_
-30	ganzer	ganz	ADJ	ADJA	Case=Gen|Gender=Fem|Number=Plur	31	amod	_	_
-31	Industrien	Industrie	NOUN	NN	Case=Gen|Gender=Fem|Number=Plur	29	nmod	_	_
-32	in	in	ADP	APPR	_	33	case	_	_
-33	Osteuropa	Osteuropa	NOUN	NE	Case=Dat|Gender=Neut|Number=Sing	31	nmod	_	_
-34	als	als	ADV	APPR	_	36	advmod	_	_
-35	``	``	PUNCT	$(	_	36	punct	_	SpaceAfter=No
-36	unvermeidlich	unvermeidlich	ADJ	ADJD	_	38	xcomp	_	SpaceAfter=No
-37	''	''	PUNCT	$(	_	36	punct	_	_
-38	erklärten	erklären	VERB	VVFIN	Mood=Sub|Number=Plur|Person=3|Tense=Past|VerbForm=Fin	23	acl	_	SpaceAfter=No
-39	.	.	PUNCT	$.	_	9	punct	_	_
+# text = Frieder Otto Wolf von der Osteuropa-Initiative Eurocom prangerte die ``intellektuelle Unredlichkeit'' der ``falschen Versprechungen'' durch die westlichen Politiker an, die Sozialabbau und Schließung ganzer Industrien in Osteuropa als ``unvermeidlich'' erklärten.
+1	Frieder	Frieder	PROPN	NE	Case=Nom|Gender=Masc|Number=Sing	2	dep	_	FixTigerDep=Yes
+2	Otto	Otto	PROPN	NE	Case=Nom|Gender=Masc|Number=Sing	10	nsubj	_	_
+3	Wolf	Wolf	PROPN	NE	Case=Nom|Gender=Masc|Number=Sing	2	flat	_	_
+4	von	von	ADP	APPR	_	8	case	_	_
+5	der	der	DET	ART	Case=Dat|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	8	det	_	_
+6	Osteuropa	Osteuropa	NOUN	NN	Case=Dat|Gender=Fem|Number=Sing	8	compound	_	SpaceAfter=No
+7	-	-	PUNCT	$(	_	6	punct	_	SpaceAfter=No
+8	Initiative	initiativ	NOUN	NN	Case=Dat|Gender=Fem|Number=Sing	2	nmod	_	_
+9	Eurocom	Eurocom	PROPN	NE	Case=Nom|Gender=Fem|Number=Sing	8	appos	_	_
+10	prangerte	prangern	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	0	root	_	_
+11	die	der	DET	ART	Case=Acc|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	14	det	_	_
+12	``	``	PUNCT	$(	_	14	punct	_	SpaceAfter=No
+13	intellektuelle	intellektuell	ADJ	ADJA	Case=Acc|Gender=Fem|Number=Sing	14	amod	_	_
+14	Unredlichkeit	Unredlichkeit	NOUN	NN	Case=Acc|Gender=Fem|Number=Sing	10	obj	_	SpaceAfter=No
+15	''	''	PUNCT	$(	_	14	punct	_	_
+16	der	der	DET	ART	Case=Gen|Definite=Def|Gender=Fem|Number=Plur|PronType=Art	19	det	_	_
+17	``	``	PUNCT	$(	_	19	punct	_	SpaceAfter=No
+18	falschen	falsch	ADJ	ADJA	Case=Gen|Gender=Fem|Number=Plur	19	amod	_	_
+19	Versprechungen	Versprechung	NOUN	NN	Case=Gen|Gender=Fem|Number=Plur	14	nmod	_	SpaceAfter=No
+20	''	''	PUNCT	$(	_	19	punct	_	_
+21	durch	durch	ADP	APPR	_	24	case	_	_
+22	die	der	DET	ART	Case=Acc|Definite=Def|Gender=Masc|Number=Plur|PronType=Art	24	det	_	_
+23	westlichen	westlich	ADJ	ADJA	Case=Acc|Gender=Masc|Number=Plur	24	amod	_	_
+24	Politiker	Politiker	NOUN	NN	Case=Acc|Gender=Masc|Number=Plur	14	nmod	_	_
+25	an	an	ADP	PTKVZ	_	10	compound:prt	_	SpaceAfter=No
+26	,	,	PUNCT	$,	_	24	punct	_	_
+27	die	der	DET	PRELS	Case=Nom|Gender=Masc|Number=Plur|PronType=Rel	39	nsubj	_	_
+28	Sozialabbau	Sozialabbau	NOUN	NN	Case=Acc|Gender=Masc|Number=Sing	39	obj	_	_
+29	und	und	CCONJ	KON	_	30	cc	_	_
+30	Schließung	Schließung	NOUN	NN	Case=Acc|Gender=Fem|Number=Sing	28	conj	_	_
+31	ganzer	ganz	ADJ	ADJA	Case=Gen|Gender=Fem|Number=Plur	32	amod	_	_
+32	Industrien	Industrie	NOUN	NN	Case=Gen|Gender=Fem|Number=Plur	30	nmod	_	_
+33	in	in	ADP	APPR	_	34	case	_	_
+34	Osteuropa	Osteuropa	NOUN	NE	Case=Dat|Gender=Neut|Number=Sing	32	nmod	_	_
+35	als	als	ADV	APPR	_	37	advmod	_	_
+36	``	``	PUNCT	$(	_	37	punct	_	SpaceAfter=No
+37	unvermeidlich	unvermeidlich	ADJ	ADJD	_	39	xcomp	_	SpaceAfter=No
+38	''	''	PUNCT	$(	_	37	punct	_	_
+39	erklärten	erklären	VERB	VVFIN	Mood=Sub|Number=Plur|Person=3|Tense=Past|VerbForm=Fin	24	acl	_	SpaceAfter=No
+40	.	.	PUNCT	$.	_	10	punct	_	_
 
 # sent_id = test-s487
-# text = Papiere der Fleischfirma Moksel zogen sofort um rund 4,5 Prozent oder 17,70 Mark an, nachdem ein Sprecher der März-Gruppe eine anstehende Paketbeteiligung von einem Drittel bestätigt und Zukäufe über die Börse angekündigt hatte.
-1	Papiere	Papier	NOUN	NN	Case=Nom|Gender=Neut|Number=Plur	5	nsubj	_	_
-2	der	der	DET	ART	Case=Gen|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	3	det	_	_
-3	Fleischfirma	Fleischfirma	NOUN	NN	Case=Gen|Gender=Fem|Number=Sing	1	nmod	_	_
-4	Moksel	Moksel	PROPN	NE	Case=Nom|Number=Sing	3	appos	_	_
-5	zogen	ziehen	VERB	VVFIN	Mood=Ind|Number=Plur|Person=3|Tense=Past|VerbForm=Fin	0	root	_	_
-6	sofort	sofort	ADV	ADV	_	5	advmod	_	_
-7	um	um	ADP	APPR	_	10	case	_	_
-8	rund	rund	ADV	ADJD	_	9	advmod	_	_
-9	4,5	4,5	NUM	CARD	NumType=Card	10	nummod	_	_
-10	Prozent	Prozent	NOUN	NN	Gender=Neut	5	obl	_	_
-11	oder	oder	CCONJ	KON	_	13	cc	_	_
-12	17,70	17,70	NUM	CARD	NumType=Card	13	nummod	_	_
-13	Mark	Mark	NOUN	NN	Gender=Fem	10	conj	_	_
-14	an	an	ADP	PTKVZ	_	5	compound:prt	_	SpaceAfter=No
-15	,	,	PUNCT	$,	_	5	punct	_	_
-16	nachdem	nachdem	SCONJ	KOUS	_	29	mark	_	_
-17	ein	ein	DET	ART	Case=Nom|Definite=Ind|Gender=Masc|Number=Sing|PronType=Art	18	det	_	_
-18	Sprecher	Sprecher	NOUN	NN	Case=Nom|Gender=Masc|Number=Sing	29	nsubj	_	_
-19	der	der	DET	ART	Case=Gen|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	20	det	_	_
-20	März	März	PROPN	NN	Case=Gen|Gender=Fem|Number=Sing	22	compound	_	SpaceAfter=No
-21	-	-	PUNCT	$(	_	20	punct	_	SpaceAfter=No
-22	Gruppe	Gruppe	NOUN	NN	Case=Gen|Gender=Fem|Number=Sing	18	nmod	_	_
-23	eine	ein	DET	ART	Case=Acc|Definite=Ind|Gender=Fem|Number=Sing|PronType=Art	25	det	_	_
-24	anstehende	anstehend	ADJ	ADJA	Case=Acc|Gender=Fem|Number=Sing	25	amod	_	_
-25	Paketbeteiligung	Paketbeteiligung	NOUN	NN	Case=Acc|Gender=Fem|Number=Sing	29	obj	_	_
-26	von	von	ADP	APPR	_	28	case	_	_
-27	einem	ein	NUM	ART	Case=Dat|Definite=Ind|Gender=Neut|Number=Sing|PronType=Art	28	nummod	_	_
-28	Drittel	Drittel	NOUN	NN	Case=Dat|Gender=Neut|Number=Sing	25	nmod	_	_
-29	bestätigt	bestätigen	VERB	VVPP	VerbForm=Part	5	advcl	_	_
-30	und	und	CCONJ	KON	_	35	cc	_	_
-31	Zukäufe	Zukauf	NOUN	NN	Case=Acc|Gender=Masc|Number=Plur	35	obj	_	_
-32	über	über	ADP	APPR	_	34	case	_	_
-33	die	der	DET	ART	Case=Acc|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	34	det	_	_
-34	Börse	Börse	NOUN	NN	Case=Acc|Gender=Fem|Number=Sing	31	nmod	_	_
-35	angekündigt	ankündigen	VERB	VVPP	VerbForm=Part	29	conj	_	_
-36	hatte	haben	AUX	VAFIN	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	35	aux	_	SpaceAfter=No
-37	.	.	PUNCT	$.	_	5	punct	_	_
+# text = Die Papiere der Fleischfirma Moksel zogen sofort um rund 4,5 Prozent oder 17,70 Mark an, nachdem ein Sprecher der März-Gruppe eine anstehende Paketbeteiligung von einem Drittel bestätigt und Zukäufe über die Börse angekündigt hatte.
+1	Die	der	DET	ART	Case=Nom|Definite=Def|Gender=Neut|Number=Plur|PronType=Art	2	dep	_	FixTigerDep=Yes
+2	Papiere	Papier	NOUN	NN	Case=Nom|Gender=Neut|Number=Plur	6	nsubj	_	_
+3	der	der	DET	ART	Case=Gen|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	4	det	_	_
+4	Fleischfirma	Fleischfirma	NOUN	NN	Case=Gen|Gender=Fem|Number=Sing	2	nmod	_	_
+5	Moksel	Moksel	PROPN	NE	Case=Nom|Number=Sing	4	appos	_	_
+6	zogen	ziehen	VERB	VVFIN	Mood=Ind|Number=Plur|Person=3|Tense=Past|VerbForm=Fin	0	root	_	_
+7	sofort	sofort	ADV	ADV	_	6	advmod	_	_
+8	um	um	ADP	APPR	_	11	case	_	_
+9	rund	rund	ADV	ADJD	_	10	advmod	_	_
+10	4,5	4,5	NUM	CARD	NumType=Card	11	nummod	_	_
+11	Prozent	Prozent	NOUN	NN	Gender=Neut	6	obl	_	_
+12	oder	oder	CCONJ	KON	_	14	cc	_	_
+13	17,70	17,70	NUM	CARD	NumType=Card	14	nummod	_	_
+14	Mark	Mark	NOUN	NN	Gender=Fem	11	conj	_	_
+15	an	an	ADP	PTKVZ	_	6	compound:prt	_	SpaceAfter=No
+16	,	,	PUNCT	$,	_	6	punct	_	_
+17	nachdem	nachdem	SCONJ	KOUS	_	30	mark	_	_
+18	ein	ein	DET	ART	Case=Nom|Definite=Ind|Gender=Masc|Number=Sing|PronType=Art	19	det	_	_
+19	Sprecher	Sprecher	NOUN	NN	Case=Nom|Gender=Masc|Number=Sing	30	nsubj	_	_
+20	der	der	DET	ART	Case=Gen|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	21	det	_	_
+21	März	März	PROPN	NN	Case=Gen|Gender=Fem|Number=Sing	23	compound	_	SpaceAfter=No
+22	-	-	PUNCT	$(	_	21	punct	_	SpaceAfter=No
+23	Gruppe	Gruppe	NOUN	NN	Case=Gen|Gender=Fem|Number=Sing	19	nmod	_	_
+24	eine	ein	DET	ART	Case=Acc|Definite=Ind|Gender=Fem|Number=Sing|PronType=Art	26	det	_	_
+25	anstehende	anstehend	ADJ	ADJA	Case=Acc|Gender=Fem|Number=Sing	26	amod	_	_
+26	Paketbeteiligung	Paketbeteiligung	NOUN	NN	Case=Acc|Gender=Fem|Number=Sing	30	obj	_	_
+27	von	von	ADP	APPR	_	29	case	_	_
+28	einem	ein	NUM	ART	Case=Dat|Definite=Ind|Gender=Neut|Number=Sing|PronType=Art	29	nummod	_	_
+29	Drittel	Drittel	NOUN	NN	Case=Dat|Gender=Neut|Number=Sing	26	nmod	_	_
+30	bestätigt	bestätigen	VERB	VVPP	VerbForm=Part	6	advcl	_	_
+31	und	und	CCONJ	KON	_	36	cc	_	_
+32	Zukäufe	Zukauf	NOUN	NN	Case=Acc|Gender=Masc|Number=Plur	36	obj	_	_
+33	über	über	ADP	APPR	_	35	case	_	_
+34	die	der	DET	ART	Case=Acc|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	35	det	_	_
+35	Börse	Börse	NOUN	NN	Case=Acc|Gender=Fem|Number=Sing	32	nmod	_	_
+36	angekündigt	ankündigen	VERB	VVPP	VerbForm=Part	30	conj	_	_
+37	hatte	haben	AUX	VAFIN	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	36	aux	_	SpaceAfter=No
+38	.	.	PUNCT	$.	_	6	punct	_	_
 
 # sent_id = test-s488
 # text = Parlamentarische Staatssekretär im Bundesarbeitsministerium, Horst Günther (CDU,) hat ein Urteil des Europäischen Gerichtshofs (EuGH) scharf kritisiert, das Arbeitgeber zur Lohnfortzahlung auch bei berechtigten Zweifeln an der Arbeitsunfähigkeitsbescheinigung verpflichtet.
@@ -9419,111 +9570,117 @@
 38	.	.	PUNCT	$.	_	23	punct	_	_
 
 # sent_id = test-s489
-# text = Partei an der Saar verordnete sich inzwischen eine Erfrischungskur.
-1	Partei	Partei	NOUN	NN	Case=Nom|Gender=Fem|Number=Sing	5	nsubj	_	_
-2	an	an	ADP	APPR	_	4	case	_	_
-3	der	der	DET	ART	Case=Dat|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	4	det	_	_
-4	Saar	Saar	PROPN	NE	Case=Dat|Gender=Fem|Number=Sing	1	nmod	_	_
-5	verordnete	verordnen	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	0	root	_	_
-6	sich	er|es|sie	PRON	PRF	Case=Dat|Number=Sing|Person=3|PronType=Prs|Reflex=Yes	5	iobj	_	_
-7	inzwischen	inzwischen	ADV	ADV	_	5	advmod	_	_
-8	eine	ein	DET	ART	Case=Acc|Definite=Ind|Gender=Fem|Number=Sing|PronType=Art	9	det	_	_
-9	Erfrischungskur	Erfrischungskur	NOUN	NN	Case=Acc|Gender=Fem|Number=Sing	5	obj	_	SpaceAfter=No
-10	.	.	PUNCT	$.	_	5	punct	_	_
+# text = Die Partei an der Saar verordnete sich inzwischen eine Erfrischungskur.
+1	Die	der	DET	ART	Case=Nom|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	2	dep	_	FixTigerDep=Yes
+2	Partei	Partei	NOUN	NN	Case=Nom|Gender=Fem|Number=Sing	6	nsubj	_	_
+3	an	an	ADP	APPR	_	5	case	_	_
+4	der	der	DET	ART	Case=Dat|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	5	det	_	_
+5	Saar	Saar	PROPN	NE	Case=Dat|Gender=Fem|Number=Sing	2	nmod	_	_
+6	verordnete	verordnen	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	0	root	_	_
+7	sich	er|es|sie	PRON	PRF	Case=Dat|Number=Sing|Person=3|PronType=Prs|Reflex=Yes	6	iobj	_	_
+8	inzwischen	inzwischen	ADV	ADV	_	6	advmod	_	_
+9	eine	ein	DET	ART	Case=Acc|Definite=Ind|Gender=Fem|Number=Sing|PronType=Art	10	det	_	_
+10	Erfrischungskur	Erfrischungskur	NOUN	NN	Case=Acc|Gender=Fem|Number=Sing	6	obj	_	SpaceAfter=No
+11	.	.	PUNCT	$.	_	6	punct	_	_
 
 # sent_id = test-s490
-# text = Parteichef Scharping hat in seiner Rede nicht den ganz großen Hammer geschwungen.
-1	Parteichef	Parteichef	NOUN	NN	Case=Nom|Gender=Masc|Number=Sing	12	nsubj	_	_
-2	Scharping	Scharping	PROPN	NE	Case=Nom|Gender=Masc|Number=Sing	1	appos	_	_
-3	hat	haben	AUX	VAFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	12	aux	_	_
-4	in	in	ADP	APPR	_	6	case	_	_
-5	seiner	sein	PRON	PPOSAT	Case=Dat|Gender=Fem|Number=Sing|Poss=Yes	6	det:poss	_	_
-6	Rede	Rede	NOUN	NN	Case=Dat|Gender=Fem|Number=Sing	12	obl	_	_
-7	nicht	nicht	PART	PTKNEG	Polarity=Neg	12	advmod	_	_
-8	den	der	DET	ART	Case=Acc|Definite=Def|Gender=Masc|Number=Sing|PronType=Art	11	det	_	_
-9	ganz	ganz	ADV	ADV	_	10	advmod	_	_
-10	großen	groß	ADJ	ADJA	Case=Acc|Gender=Masc|Number=Sing	11	amod	_	_
-11	Hammer	Hammer	NOUN	NN	Case=Acc|Gender=Masc|Number=Sing	12	obj	_	_
-12	geschwungen	schwingen	VERB	VVPP	VerbForm=Part	0	root	_	SpaceAfter=No
-13	.	.	PUNCT	$.	_	12	punct	_	_
+# text = Auch Parteichef Scharping hat in seiner Rede nicht den ganz großen Hammer geschwungen.
+1	Auch	auch	ADV	ADV	_	2	dep	_	FixTigerDep=Yes
+2	Parteichef	Parteichef	NOUN	NN	Case=Nom|Gender=Masc|Number=Sing	13	nsubj	_	_
+3	Scharping	Scharping	PROPN	NE	Case=Nom|Gender=Masc|Number=Sing	2	appos	_	_
+4	hat	haben	AUX	VAFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	13	aux	_	_
+5	in	in	ADP	APPR	_	7	case	_	_
+6	seiner	sein	PRON	PPOSAT	Case=Dat|Gender=Fem|Number=Sing|Poss=Yes	7	det:poss	_	_
+7	Rede	Rede	NOUN	NN	Case=Dat|Gender=Fem|Number=Sing	13	obl	_	_
+8	nicht	nicht	PART	PTKNEG	Polarity=Neg	13	advmod	_	_
+9	den	der	DET	ART	Case=Acc|Definite=Def|Gender=Masc|Number=Sing|PronType=Art	12	det	_	_
+10	ganz	ganz	ADV	ADV	_	11	advmod	_	_
+11	großen	groß	ADJ	ADJA	Case=Acc|Gender=Masc|Number=Sing	12	amod	_	_
+12	Hammer	Hammer	NOUN	NN	Case=Acc|Gender=Masc|Number=Sing	13	obj	_	_
+13	geschwungen	schwingen	VERB	VVPP	VerbForm=Part	0	root	_	SpaceAfter=No
+14	.	.	PUNCT	$.	_	13	punct	_	_
 
 # sent_id = test-s491
-# text = PDS-Bundestagsgruppenchef Gysi kündigte an, er wolle bei seinem Treffen mit Lafontaine die Frage ansprechen, in welcher politischen Konstellation Veränderungen in Deutschland möglich seien.
-1	PDS	PDS	PROPN	NN	Case=Nom|Gender=Masc|Number=Sing	3	compound	_	SpaceAfter=No
-2	-	-	PUNCT	$(	_	1	punct	_	SpaceAfter=No
-3	Bundestagsgruppenchef	Bundestagsgruppenchef	NOUN	NN	Case=Nom|Gender=Masc|Number=Sing	5	nsubj	_	_
-4	Gysi	Gysi	PROPN	NE	Case=Nom|Gender=Masc|Number=Sing	1	appos	_	_
-5	kündigte	kündigen	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	0	root	_	_
-6	an	an	ADP	PTKVZ	_	5	compound:prt	_	SpaceAfter=No
-7	,	,	PUNCT	$,	_	5	punct	_	_
-8	er	er	PRON	PPER	Case=Nom|Gender=Masc|Number=Sing|Person=3|PronType=Prs	17	nsubj	_	_
-9	wolle	wollen	AUX	VMFIN	Mood=Sub|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	17	aux	_	_
-10	bei	bei	ADP	APPR	_	12	case	_	_
-11	seinem	sein	PRON	PPOSAT	Case=Dat|Gender=Neut|Number=Sing|Poss=Yes	12	det:poss	_	_
-12	Treffen	Treffen	NOUN	NN	Case=Dat|Gender=Neut|Number=Sing	17	obl	_	_
-13	mit	mit	ADP	APPR	_	14	case	_	_
-14	Lafontaine	Lafontaine	PROPN	NE	Case=Dat|Number=Sing	12	nmod	_	_
-15	die	der	DET	ART	Case=Acc|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	16	det	_	_
-16	Frage	Frage	NOUN	NN	Case=Acc|Gender=Fem|Number=Sing	17	obj	_	_
-17	ansprechen	ansprechen	VERB	VVINF	VerbForm=Inf	5	ccomp	_	SpaceAfter=No
-18	,	,	PUNCT	$,	_	5	punct	_	_
-19	in	in	ADP	APPR	_	22	case	_	_
-20	welcher	welch	PRON	PWAT	Case=Dat|Gender=Fem|Number=Sing|PronType=Int	22	det	_	_
-21	politischen	politisch	ADJ	ADJA	Case=Dat|Gender=Fem|Number=Sing	22	amod	_	_
-22	Konstellation	Konstellation	NOUN	NN	Case=Dat|Gender=Fem|Number=Sing	26	nmod	_	_
-23	Veränderungen	Veränderung	NOUN	NN	Case=Nom|Gender=Fem|Number=Plur	26	nsubj	_	_
-24	in	in	ADP	APPR	_	25	case	_	_
-25	Deutschland	Deutschland	PROPN	NE	Case=Dat|Gender=Neut|Number=Sing	23	nmod	_	_
-26	möglich	möglich	ADJ	ADJD	_	17	ccomp	_	_
-27	seien	sein	AUX	VAFIN	Mood=Sub|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	26	cop	_	SpaceAfter=No
-28	.	.	PUNCT	$.	_	5	punct	_	_
+# text = Der PDS-Bundestagsgruppenchef Gysi kündigte an, er wolle bei seinem Treffen mit Lafontaine die Frage ansprechen, in welcher politischen Konstellation Veränderungen in Deutschland möglich seien.
+1	Der	der	DET	ART	Case=Nom|Definite=Def|Gender=Masc|Number=Sing|PronType=Art	2	dep	_	FixTigerDep=Yes
+2	PDS	PDS	PROPN	NN	Case=Nom|Gender=Masc|Number=Sing	4	compound	_	SpaceAfter=No
+3	-	-	PUNCT	$(	_	2	punct	_	SpaceAfter=No
+4	Bundestagsgruppenchef	Bundestagsgruppenchef	NOUN	NN	Case=Nom|Gender=Masc|Number=Sing	6	nsubj	_	_
+5	Gysi	Gysi	PROPN	NE	Case=Nom|Gender=Masc|Number=Sing	2	appos	_	_
+6	kündigte	kündigen	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	0	root	_	_
+7	an	an	ADP	PTKVZ	_	6	compound:prt	_	SpaceAfter=No
+8	,	,	PUNCT	$,	_	6	punct	_	_
+9	er	er	PRON	PPER	Case=Nom|Gender=Masc|Number=Sing|Person=3|PronType=Prs	18	nsubj	_	_
+10	wolle	wollen	AUX	VMFIN	Mood=Sub|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	18	aux	_	_
+11	bei	bei	ADP	APPR	_	13	case	_	_
+12	seinem	sein	PRON	PPOSAT	Case=Dat|Gender=Neut|Number=Sing|Poss=Yes	13	det:poss	_	_
+13	Treffen	Treffen	NOUN	NN	Case=Dat|Gender=Neut|Number=Sing	18	obl	_	_
+14	mit	mit	ADP	APPR	_	15	case	_	_
+15	Lafontaine	Lafontaine	PROPN	NE	Case=Dat|Number=Sing	13	nmod	_	_
+16	die	der	DET	ART	Case=Acc|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	17	det	_	_
+17	Frage	Frage	NOUN	NN	Case=Acc|Gender=Fem|Number=Sing	18	obj	_	_
+18	ansprechen	ansprechen	VERB	VVINF	VerbForm=Inf	6	ccomp	_	SpaceAfter=No
+19	,	,	PUNCT	$,	_	6	punct	_	_
+20	in	in	ADP	APPR	_	23	case	_	_
+21	welcher	welch	PRON	PWAT	Case=Dat|Gender=Fem|Number=Sing|PronType=Int	23	det	_	_
+22	politischen	politisch	ADJ	ADJA	Case=Dat|Gender=Fem|Number=Sing	23	amod	_	_
+23	Konstellation	Konstellation	NOUN	NN	Case=Dat|Gender=Fem|Number=Sing	27	nmod	_	_
+24	Veränderungen	Veränderung	NOUN	NN	Case=Nom|Gender=Fem|Number=Plur	27	nsubj	_	_
+25	in	in	ADP	APPR	_	26	case	_	_
+26	Deutschland	Deutschland	PROPN	NE	Case=Dat|Gender=Neut|Number=Sing	24	nmod	_	_
+27	möglich	möglich	ADJ	ADJD	_	18	ccomp	_	_
+28	seien	sein	AUX	VAFIN	Mood=Sub|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	27	cop	_	SpaceAfter=No
+29	.	.	PUNCT	$.	_	6	punct	_	_
 
 # sent_id = test-s492
-# text = Perspektiven sieht Analyst Rolf Schneider für Deutschland.
-1	Perspektiven	Perspektive	NOUN	NN	Case=Acc|Gender=Fem|Number=Plur	2	obj	_	_
-2	sieht	sehen	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	0	root	_	_
-3	Analyst	Analyst	NOUN	NN	Case=Nom|Gender=Masc|Number=Sing	2	nsubj	_	_
-4	Rolf	Rolf	PROPN	NE	Case=Nom|Gender=Masc|Number=Sing	3	appos	_	_
-5	Schneider	Schneider	PROPN	NE	Case=Nom|Gender=Masc|Number=Sing	4	flat	_	_
-6	für	für	ADP	APPR	_	7	case	_	_
-7	Deutschland	Deutschland	PROPN	NE	Case=Acc|Gender=Neut|Number=Sing	2	obl	_	SpaceAfter=No
-8	.	.	PUNCT	$.	_	2	punct	_	_
+# text = Überdurchschnittliche Perspektiven sieht Analyst Rolf Schneider für Deutschland.
+1	Überdurchschnittliche	überdurchschnittlich	ADJ	ADJA	Case=Acc|Gender=Fem|Number=Plur	2	dep	_	FixTigerDep=Yes
+2	Perspektiven	Perspektive	NOUN	NN	Case=Acc|Gender=Fem|Number=Plur	3	obj	_	_
+3	sieht	sehen	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	0	root	_	_
+4	Analyst	Analyst	NOUN	NN	Case=Nom|Gender=Masc|Number=Sing	3	nsubj	_	_
+5	Rolf	Rolf	PROPN	NE	Case=Nom|Gender=Masc|Number=Sing	4	appos	_	_
+6	Schneider	Schneider	PROPN	NE	Case=Nom|Gender=Masc|Number=Sing	5	flat	_	_
+7	für	für	ADP	APPR	_	8	case	_	_
+8	Deutschland	Deutschland	PROPN	NE	Case=Acc|Gender=Neut|Number=Sing	3	obl	_	SpaceAfter=No
+9	.	.	PUNCT	$.	_	3	punct	_	_
 
 # sent_id = test-s493
-# text = Platz am Herd inspirierte auch die Künstler.
-1	Platz	Platz	NOUN	NN	Case=Nom|Gender=Masc|Number=Sing	5	nsubj	_	_
-2-3	am	_	_	_	_	_	_	_	_
-2	an	an	ADP	APPR	_	4	case	_	_
-3	dem	der	DET	ART	Case=Dat|Definite=Def|Gender=Masc|Number=Sing|PronType=Art	4	det	_	_
-4	Herd	Herd	NOUN	NN	Case=Dat|Gender=Masc|Number=Sing	1	nmod	_	_
-5	inspirierte	inspirieren	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	0	root	_	_
-6	auch	auch	ADV	ADV	_	5	advmod	_	_
-7	die	der	DET	ART	Case=Acc|Definite=Def|Gender=Masc|Number=Plur|PronType=Art	8	det	_	_
-8	Künstler	Künstler	NOUN	NN	Case=Acc|Gender=Masc|Number=Plur	5	obj	_	SpaceAfter=No
-9	.	.	PUNCT	$.	_	5	punct	_	_
+# text = Der Platz am Herd inspirierte auch die Künstler.
+1	Der	der	DET	ART	Case=Nom|Definite=Def|Gender=Masc|Number=Sing|PronType=Art	2	dep	_	FixTigerDep=Yes
+2	Platz	Platz	NOUN	NN	Case=Nom|Gender=Masc|Number=Sing	6	nsubj	_	_
+3-4	am	_	_	_	_	_	_	_	_
+3	an	an	ADP	APPR	_	5	case	_	_
+4	dem	der	DET	ART	Case=Dat|Definite=Def|Gender=Masc|Number=Sing|PronType=Art	5	det	_	_
+5	Herd	Herd	NOUN	NN	Case=Dat|Gender=Masc|Number=Sing	2	nmod	_	_
+6	inspirierte	inspirieren	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	0	root	_	_
+7	auch	auch	ADV	ADV	_	6	advmod	_	_
+8	die	der	DET	ART	Case=Acc|Definite=Def|Gender=Masc|Number=Plur|PronType=Art	9	det	_	_
+9	Künstler	Künstler	NOUN	NN	Case=Acc|Gender=Masc|Number=Plur	6	obj	_	SpaceAfter=No
+10	.	.	PUNCT	$.	_	6	punct	_	_
 
 # sent_id = test-s494
-# text = politische Konsequenzen zu ziehen, täte not, bevor der bosnische Bürgerkrieg doch noch in einen internationalen Konflikt umschlägt.
-1	politische	politisch	ADJ	ADJA	Case=Acc|Gender=Fem|Number=Plur	2	amod	_	_
-2	Konsequenzen	Konsequenz	NOUN	NN	Case=Acc|Gender=Fem|Number=Plur	4	obj	_	_
-3	zu	zu	PART	PTKZU	_	4	mark	_	_
-4	ziehen	ziehen	VERB	VVINF	VerbForm=Inf	6	csubj	_	SpaceAfter=No
-5	,	,	PUNCT	$,	_	6	punct	_	_
-6	täte	tun	VERB	VVFIN	Mood=Sub|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	0	root	_	_
-7	not	not	ADV	PTKVZ	_	6	advmod	_	SpaceAfter=No
-8	,	,	PUNCT	$,	_	6	punct	_	_
-9	bevor	bevor	SCONJ	KOUS	_	19	mark	_	_
-10	der	der	DET	ART	Case=Nom|Definite=Def|Gender=Masc|Number=Sing|PronType=Art	12	det	_	_
-11	bosnische	bosnisch	ADJ	ADJA	Case=Nom|Gender=Masc|Number=Sing	12	amod	_	_
-12	Bürgerkrieg	Bürgerkrieg	NOUN	NN	Case=Nom|Gender=Masc|Number=Sing	19	nsubj	_	_
-13	doch	doch	ADV	ADV	_	19	advmod	_	_
-14	noch	noch	ADV	ADV	_	13	advmod	_	_
-15	in	in	ADP	APPR	_	18	case	_	_
-16	einen	ein	DET	ART	Case=Acc|Definite=Ind|Gender=Masc|Number=Sing|PronType=Art	18	det	_	_
-17	internationalen	international	ADJ	ADJA	Case=Acc|Gender=Masc|Number=Sing	18	amod	_	_
-18	Konflikt	Konflikt	NOUN	NN	Case=Acc|Gender=Masc|Number=Sing	19	obl	_	_
-19	umschlägt	umschlagen	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	6	advcl	_	SpaceAfter=No
-20	.	.	PUNCT	$.	_	6	punct	_	_
+# text = Daraus politische Konsequenzen zu ziehen, täte not, bevor der bosnische Bürgerkrieg doch noch in einen internationalen Konflikt umschlägt.
+1	Daraus	daraus	ADV	PAV	_	2	dep	_	FixTigerDep=Yes
+2	politische	politisch	ADJ	ADJA	Case=Acc|Gender=Fem|Number=Plur	3	amod	_	_
+3	Konsequenzen	Konsequenz	NOUN	NN	Case=Acc|Gender=Fem|Number=Plur	5	obj	_	_
+4	zu	zu	PART	PTKZU	_	5	mark	_	_
+5	ziehen	ziehen	VERB	VVINF	VerbForm=Inf	7	csubj	_	SpaceAfter=No
+6	,	,	PUNCT	$,	_	7	punct	_	_
+7	täte	tun	VERB	VVFIN	Mood=Sub|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	0	root	_	_
+8	not	not	ADV	PTKVZ	_	7	advmod	_	SpaceAfter=No
+9	,	,	PUNCT	$,	_	7	punct	_	_
+10	bevor	bevor	SCONJ	KOUS	_	20	mark	_	_
+11	der	der	DET	ART	Case=Nom|Definite=Def|Gender=Masc|Number=Sing|PronType=Art	13	det	_	_
+12	bosnische	bosnisch	ADJ	ADJA	Case=Nom|Gender=Masc|Number=Sing	13	amod	_	_
+13	Bürgerkrieg	Bürgerkrieg	NOUN	NN	Case=Nom|Gender=Masc|Number=Sing	20	nsubj	_	_
+14	doch	doch	ADV	ADV	_	20	advmod	_	_
+15	noch	noch	ADV	ADV	_	14	advmod	_	_
+16	in	in	ADP	APPR	_	19	case	_	_
+17	einen	ein	DET	ART	Case=Acc|Definite=Ind|Gender=Masc|Number=Sing|PronType=Art	19	det	_	_
+18	internationalen	international	ADJ	ADJA	Case=Acc|Gender=Masc|Number=Sing	19	amod	_	_
+19	Konflikt	Konflikt	NOUN	NN	Case=Acc|Gender=Masc|Number=Sing	20	obl	_	_
+20	umschlägt	umschlagen	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	7	advcl	_	SpaceAfter=No
+21	.	.	PUNCT	$.	_	7	punct	_	_
 
 # sent_id = test-s495
 # text = Post baut angeblich Perosnal ab
@@ -9534,205 +9691,213 @@
 5	ab	ab	ADP	PTKVZ	_	2	compound:prt	_	_
 
 # sent_id = test-s496
-# text = Präsident des US-Repräsentantenhauses, Newt Gingrich, will sich nicht als Kandidat seiner Republikanischen Partei für die Präsidentschaftswahl 1996 aufstellen lassen.
-1	Präsident	Präsident	NOUN	NN	Case=Nom|Gender=Masc|Number=Sing	23	nsubj	_	_
-2	des	der	DET	ART	Case=Gen|Definite=Def|Gender=Neut|Number=Sing|PronType=Art	3	det	_	_
-3	US	US	PROPN	NN	Case=Gen|Gender=Neut|Number=Sing	5	compound	_	SpaceAfter=No
-4	-	-	PUNCT	$(	_	3	punct	_	SpaceAfter=No
-5	Repräsentantenhauses	Repräsentantenhaus	NOUN	NN	Case=Gen|Gender=Neut|Number=Sing	1	nmod	_	SpaceAfter=No
-6	,	,	PUNCT	$,	_	23	punct	_	_
-7	Newt	Newt	PROPN	NE	Case=Nom|Gender=Masc|Number=Sing	1	appos	_	_
-8	Gingrich	Gingrich	PROPN	NE	Case=Nom|Gender=Masc|Number=Sing	7	flat	_	SpaceAfter=No
-9	,	,	PUNCT	$,	_	23	punct	_	_
-10	will	wollen	AUX	VMFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	23	aux	_	_
-11	sich	er|es|sie	PRON	PRF	Case=Acc|Number=Sing|Person=3|PronType=Prs|Reflex=Yes	23	obj	_	_
-12	nicht	nicht	PART	PTKNEG	Polarity=Neg	23	advmod	_	_
-13	als	als	ADP	APPR	_	14	case	_	_
-14	Kandidat	Kandidat	NOUN	NN	Case=Acc|Gender=Masc|Number=Sing	22	obl	_	_
-15	seiner	sein	PRON	PPOSAT	Case=Gen|Gender=Fem|Number=Sing|Poss=Yes	17	det:poss	_	_
-16	Republikanischen	republikanisch	ADJ	ADJA	Case=Gen|Gender=Fem|Number=Sing	17	amod	_	_
-17	Partei	Partei	NOUN	NN	Case=Gen|Gender=Fem|Number=Sing	14	nmod	_	_
-18	für	für	ADP	APPR	_	20	case	_	_
-19	die	der	DET	ART	Case=Acc|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	20	det	_	_
-20	Präsidentschaftswahl	Präsidentschaftswahl	NOUN	NN	Case=Acc|Gender=Fem|Number=Sing	22	obl	_	_
-21	1996	1996	NUM	CARD	NumType=Card	23	obl	_	_
-22	aufstellen	aufstellen	VERB	VVINF	VerbForm=Inf	23	xcomp	_	_
-23	lassen	lassen	VERB	VVINF	VerbForm=Inf	0	root	_	SpaceAfter=No
-24	.	.	PUNCT	$.	_	23	punct	_	_
+# text = Der Präsident des US-Repräsentantenhauses, Newt Gingrich, will sich nicht als Kandidat seiner Republikanischen Partei für die Präsidentschaftswahl 1996 aufstellen lassen.
+1	Der	der	DET	ART	Case=Nom|Definite=Def|Gender=Masc|Number=Sing|PronType=Art	2	dep	_	FixTigerDep=Yes
+2	Präsident	Präsident	NOUN	NN	Case=Nom|Gender=Masc|Number=Sing	24	nsubj	_	_
+3	des	der	DET	ART	Case=Gen|Definite=Def|Gender=Neut|Number=Sing|PronType=Art	4	det	_	_
+4	US	US	PROPN	NN	Case=Gen|Gender=Neut|Number=Sing	6	compound	_	SpaceAfter=No
+5	-	-	PUNCT	$(	_	4	punct	_	SpaceAfter=No
+6	Repräsentantenhauses	Repräsentantenhaus	NOUN	NN	Case=Gen|Gender=Neut|Number=Sing	2	nmod	_	SpaceAfter=No
+7	,	,	PUNCT	$,	_	24	punct	_	_
+8	Newt	Newt	PROPN	NE	Case=Nom|Gender=Masc|Number=Sing	2	appos	_	_
+9	Gingrich	Gingrich	PROPN	NE	Case=Nom|Gender=Masc|Number=Sing	8	flat	_	SpaceAfter=No
+10	,	,	PUNCT	$,	_	24	punct	_	_
+11	will	wollen	AUX	VMFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	24	aux	_	_
+12	sich	er|es|sie	PRON	PRF	Case=Acc|Number=Sing|Person=3|PronType=Prs|Reflex=Yes	24	obj	_	_
+13	nicht	nicht	PART	PTKNEG	Polarity=Neg	24	advmod	_	_
+14	als	als	ADP	APPR	_	15	case	_	_
+15	Kandidat	Kandidat	NOUN	NN	Case=Acc|Gender=Masc|Number=Sing	23	obl	_	_
+16	seiner	sein	PRON	PPOSAT	Case=Gen|Gender=Fem|Number=Sing|Poss=Yes	18	det:poss	_	_
+17	Republikanischen	republikanisch	ADJ	ADJA	Case=Gen|Gender=Fem|Number=Sing	18	amod	_	_
+18	Partei	Partei	NOUN	NN	Case=Gen|Gender=Fem|Number=Sing	15	nmod	_	_
+19	für	für	ADP	APPR	_	21	case	_	_
+20	die	der	DET	ART	Case=Acc|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	21	det	_	_
+21	Präsidentschaftswahl	Präsidentschaftswahl	NOUN	NN	Case=Acc|Gender=Fem|Number=Sing	23	obl	_	_
+22	1996	1996	NUM	CARD	NumType=Card	24	obl	_	_
+23	aufstellen	aufstellen	VERB	VVINF	VerbForm=Inf	24	xcomp	_	_
+24	lassen	lassen	VERB	VVINF	VerbForm=Inf	0	root	_	SpaceAfter=No
+25	.	.	PUNCT	$.	_	24	punct	_	_
 
 # sent_id = test-s497
-# text = Premier verliert Abstimmung im Unterhaus
-1	Premier	Premier	NOUN	NN	Case=Nom|Gender=Masc|Number=Sing	2	nsubj	_	_
-2	verliert	verlieren	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	0	root	_	_
-3	Abstimmung	Abstimmung	NOUN	NN	Case=Acc|Gender=Fem|Number=Sing	2	obj	_	_
-4-5	im	_	_	_	_	_	_	_	_
-4	in	in	ADP	APPR	_	6	case	_	_
-5	dem	der	DET	ART	Case=Dat|Definite=Def|Gender=Neut|Number=Sing|PronType=Art	6	det	_	_
-6	Unterhaus	Unterhaus	NOUN	NN	Case=Dat|Gender=Neut|Number=Sing	3	nmod	_	_
+# text = Britischer Premier verliert Abstimmung im Unterhaus
+1	Britischer	britisch	ADJ	ADJA	Case=Nom|Gender=Masc|Number=Sing	2	dep	_	FixTigerDep=Yes
+2	Premier	Premier	NOUN	NN	Case=Nom|Gender=Masc|Number=Sing	3	nsubj	_	_
+3	verliert	verlieren	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	0	root	_	_
+4	Abstimmung	Abstimmung	NOUN	NN	Case=Acc|Gender=Fem|Number=Sing	3	obj	_	_
+5-6	im	_	_	_	_	_	_	_	_
+5	in	in	ADP	APPR	_	7	case	_	_
+6	dem	der	DET	ART	Case=Dat|Definite=Def|Gender=Neut|Number=Sing|PronType=Art	7	det	_	_
+7	Unterhaus	Unterhaus	NOUN	NN	Case=Dat|Gender=Neut|Number=Sing	4	nmod	_	_
 
 # sent_id = test-s498
-# text = Professor für Raumplanung verwies auf die Schwierigkeiten des Eurotunnels zwischen Frankreich und England.
-1	Professor	Professor	NOUN	NN	Case=Nom|Gender=Masc|Number=Sing	4	nsubj	_	_
-2	für	für	ADP	APPR	_	3	case	_	_
-3	Raumplanung	Raumplanung	NOUN	NN	Case=Acc|Gender=Fem|Number=Sing	1	nmod	_	_
-4	verwies	verweisen	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	0	root	_	_
-5	auf	auf	ADP	APPR	_	7	case	_	_
-6	die	der	DET	ART	Case=Acc|Definite=Def|Gender=Fem|Number=Plur|PronType=Art	7	det	_	_
-7	Schwierigkeiten	Schwierigkeit	NOUN	NN	Case=Acc|Gender=Fem|Number=Plur	4	obl	_	_
-8	des	der	DET	ART	Case=Gen|Definite=Def|Gender=Masc|Number=Sing|PronType=Art	9	det	_	_
-9	Eurotunnels	Eurotunnel	PROPN	NE	Case=Gen|Gender=Masc|Number=Sing	7	nmod	_	_
-10	zwischen	zwischen	ADP	APPR	_	11	case	_	_
-11	Frankreich	Frankreich	PROPN	NE	Case=Dat|Gender=Neut|Number=Sing	9	nmod	_	_
-12	und	und	CCONJ	KON	_	13	cc	_	_
-13	England	England	PROPN	NE	Case=Dat|Gender=Neut|Number=Sing	11	conj	_	SpaceAfter=No
-14	.	.	PUNCT	$.	_	4	punct	_	_
+# text = Der Professor für Raumplanung verwies auf die Schwierigkeiten des Eurotunnels zwischen Frankreich und England.
+1	Der	der	DET	ART	Case=Nom|Definite=Def|Gender=Masc|Number=Sing|PronType=Art	2	dep	_	FixTigerDep=Yes
+2	Professor	Professor	NOUN	NN	Case=Nom|Gender=Masc|Number=Sing	5	nsubj	_	_
+3	für	für	ADP	APPR	_	4	case	_	_
+4	Raumplanung	Raumplanung	NOUN	NN	Case=Acc|Gender=Fem|Number=Sing	2	nmod	_	_
+5	verwies	verweisen	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	0	root	_	_
+6	auf	auf	ADP	APPR	_	8	case	_	_
+7	die	der	DET	ART	Case=Acc|Definite=Def|Gender=Fem|Number=Plur|PronType=Art	8	det	_	_
+8	Schwierigkeiten	Schwierigkeit	NOUN	NN	Case=Acc|Gender=Fem|Number=Plur	5	obl	_	_
+9	des	der	DET	ART	Case=Gen|Definite=Def|Gender=Masc|Number=Sing|PronType=Art	10	det	_	_
+10	Eurotunnels	Eurotunnel	PROPN	NE	Case=Gen|Gender=Masc|Number=Sing	8	nmod	_	_
+11	zwischen	zwischen	ADP	APPR	_	12	case	_	_
+12	Frankreich	Frankreich	PROPN	NE	Case=Dat|Gender=Neut|Number=Sing	10	nmod	_	_
+13	und	und	CCONJ	KON	_	14	cc	_	_
+14	England	England	PROPN	NE	Case=Dat|Gender=Neut|Number=Sing	12	conj	_	SpaceAfter=No
+15	.	.	PUNCT	$.	_	5	punct	_	_
 
 # sent_id = test-s499
-# text = Rätselraten um die in der Region Busang entdeckte Menge des Edelmetalls ging unterdessen weiter.
-1	Rätselraten	Rätselraten	NOUN	NN	Case=Nom|Gender=Neut|Number=Sing	12	nsubj	_	_
-2	um	um	ADP	APPR	_	9	case	_	_
-3	die	der	DET	ART	Case=Acc|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	9	det	_	_
-4	in	in	ADP	APPR	_	6	case	_	_
-5	der	der	DET	ART	Case=Dat|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	6	det	_	_
-6	Region	Region	NOUN	NN	Case=Dat|Gender=Fem|Number=Sing	8	nmod	_	_
-7	Busang	Busang	PROPN	NE	Case=Nom|Gender=Neut|Number=Sing	6	flat	_	_
-8	entdeckte	entdeckt	ADJ	ADJA	Case=Acc|Gender=Fem|Number=Sing	9	amod	_	_
-9	Menge	Menge	NOUN	NN	Case=Acc|Gender=Fem|Number=Sing	1	nmod	_	_
-10	des	der	DET	ART	Case=Gen|Definite=Def|Gender=Neut|Number=Sing|PronType=Art	11	det	_	_
-11	Edelmetalls	Edelmetall	NOUN	NN	Case=Gen|Gender=Neut|Number=Sing	9	nmod	_	_
-12	ging	gehen	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	0	root	_	_
-13	unterdessen	unterdessen	ADV	ADV	_	12	advmod	_	_
-14	weiter	weiter	ADV	PTKVZ	_	12	advmod	_	SpaceAfter=No
-15	.	.	PUNCT	$.	_	12	punct	_	_
+# text = Das Rätselraten um die in der Region Busang entdeckte Menge des Edelmetalls ging unterdessen weiter.
+1	Das	der	DET	ART	Case=Nom|Definite=Def|Gender=Neut|Number=Sing|PronType=Art	2	dep	_	FixTigerDep=Yes
+2	Rätselraten	Rätselraten	NOUN	NN	Case=Nom|Gender=Neut|Number=Sing	13	nsubj	_	_
+3	um	um	ADP	APPR	_	10	case	_	_
+4	die	der	DET	ART	Case=Acc|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	10	det	_	_
+5	in	in	ADP	APPR	_	7	case	_	_
+6	der	der	DET	ART	Case=Dat|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	7	det	_	_
+7	Region	Region	NOUN	NN	Case=Dat|Gender=Fem|Number=Sing	9	nmod	_	_
+8	Busang	Busang	PROPN	NE	Case=Nom|Gender=Neut|Number=Sing	7	flat	_	_
+9	entdeckte	entdeckt	ADJ	ADJA	Case=Acc|Gender=Fem|Number=Sing	10	amod	_	_
+10	Menge	Menge	NOUN	NN	Case=Acc|Gender=Fem|Number=Sing	2	nmod	_	_
+11	des	der	DET	ART	Case=Gen|Definite=Def|Gender=Neut|Number=Sing|PronType=Art	12	det	_	_
+12	Edelmetalls	Edelmetall	NOUN	NN	Case=Gen|Gender=Neut|Number=Sing	10	nmod	_	_
+13	ging	gehen	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	0	root	_	_
+14	unterdessen	unterdessen	ADV	ADV	_	13	advmod	_	_
+15	weiter	weiter	ADV	PTKVZ	_	13	advmod	_	SpaceAfter=No
+16	.	.	PUNCT	$.	_	13	punct	_	_
 
 # sent_id = test-s500
-# text = Regierung von Angola erhält von der Europäischen Gemeinschaft rund vier Millionen Mark zur Vorbereitung der für Ende 1992 geplanten freien Wahlen.
-1	Regierung	Regierung	NOUN	NN	Case=Nom|Gender=Fem|Number=Sing	4	nsubj	_	_
-2	von	von	ADP	APPR	_	3	case	_	_
-3	Angola	Angola	PROPN	NE	Case=Dat|Gender=Neut|Number=Sing	1	nmod	_	_
-4	erhält	erhalten	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	0	root	_	_
-5	von	von	ADP	APPR	_	8	case	_	_
-6	der	der	DET	ART	Case=Dat|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	8	det	_	_
-7	Europäischen	europäisch	ADJ	ADJA	Case=Dat|Gender=Fem|Number=Sing	8	amod	_	_
-8	Gemeinschaft	Gemeinschaft	PROPN	NN	Case=Dat|Gender=Fem|Number=Sing	4	obl	_	_
-9	rund	rund	ADV	ADJD	_	10	advmod	_	_
-10	vier	vier	NUM	CARD	NumType=Card	11	nummod	_	_
-11	Millionen	Million	NOUN	NN	Case=Acc|Gender=Fem|Number=Plur	12	nummod	_	_
-12	Mark	Mark	NOUN	NN	Gender=Fem	4	obj	_	_
-13-14	zur	_	_	_	_	_	_	_	_
-13	zu	zu	ADP	APPR	_	15	case	_	_
-14	der	der	DET	ART	Case=Dat|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	15	det	_	_
-15	Vorbereitung	Vorbereitung	NOUN	NN	Case=Dat|Gender=Fem|Number=Sing	4	obl	_	_
-16	der	der	DET	ART	Case=Gen|Definite=Def|Gender=Fem|Number=Plur|PronType=Art	22	det	_	_
-17	für	für	ADP	APPR	_	19	case	_	_
-18	Ende	Ende	NOUN	NN	Case=Acc|Gender=Neut|Number=Sing	19	compound	_	_
-19	1992	1992	NUM	CARD	NumType=Card	20	nmod	_	_
-20	geplanten	geplant	ADJ	ADJA	Case=Gen|Gender=Fem|Number=Plur	22	amod	_	_
-21	freien	frei	ADJ	ADJA	Case=Gen|Gender=Fem|Number=Plur	22	amod	_	_
-22	Wahlen	Wahl	NOUN	NN	Case=Gen|Gender=Fem|Number=Plur	15	nmod	_	SpaceAfter=No
-23	.	.	PUNCT	$.	_	4	punct	_	_
+# text = Die Regierung von Angola erhält von der Europäischen Gemeinschaft rund vier Millionen Mark zur Vorbereitung der für Ende 1992 geplanten freien Wahlen.
+1	Die	der	DET	ART	Case=Nom|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	2	dep	_	FixTigerDep=Yes
+2	Regierung	Regierung	NOUN	NN	Case=Nom|Gender=Fem|Number=Sing	5	nsubj	_	_
+3	von	von	ADP	APPR	_	4	case	_	_
+4	Angola	Angola	PROPN	NE	Case=Dat|Gender=Neut|Number=Sing	2	nmod	_	_
+5	erhält	erhalten	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	0	root	_	_
+6	von	von	ADP	APPR	_	9	case	_	_
+7	der	der	DET	ART	Case=Dat|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	9	det	_	_
+8	Europäischen	europäisch	ADJ	ADJA	Case=Dat|Gender=Fem|Number=Sing	9	amod	_	_
+9	Gemeinschaft	Gemeinschaft	PROPN	NN	Case=Dat|Gender=Fem|Number=Sing	5	obl	_	_
+10	rund	rund	ADV	ADJD	_	11	advmod	_	_
+11	vier	vier	NUM	CARD	NumType=Card	12	nummod	_	_
+12	Millionen	Million	NOUN	NN	Case=Acc|Gender=Fem|Number=Plur	13	nummod	_	_
+13	Mark	Mark	NOUN	NN	Gender=Fem	5	obj	_	_
+14-15	zur	_	_	_	_	_	_	_	_
+14	zu	zu	ADP	APPR	_	16	case	_	_
+15	der	der	DET	ART	Case=Dat|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	16	det	_	_
+16	Vorbereitung	Vorbereitung	NOUN	NN	Case=Dat|Gender=Fem|Number=Sing	5	obl	_	_
+17	der	der	DET	ART	Case=Gen|Definite=Def|Gender=Fem|Number=Plur|PronType=Art	23	det	_	_
+18	für	für	ADP	APPR	_	20	case	_	_
+19	Ende	Ende	NOUN	NN	Case=Acc|Gender=Neut|Number=Sing	20	compound	_	_
+20	1992	1992	NUM	CARD	NumType=Card	21	nmod	_	_
+21	geplanten	geplant	ADJ	ADJA	Case=Gen|Gender=Fem|Number=Plur	23	amod	_	_
+22	freien	frei	ADJ	ADJA	Case=Gen|Gender=Fem|Number=Plur	23	amod	_	_
+23	Wahlen	Wahl	NOUN	NN	Case=Gen|Gender=Fem|Number=Plur	16	nmod	_	SpaceAfter=No
+24	.	.	PUNCT	$.	_	5	punct	_	_
 
 # sent_id = test-s501
-# text = Regierungen unterzeichneten auch vier Abkommen zur Gründung eines ``Dialogforums für Hochtechnologie'', über bilaterale Studien der chinesischen Infrastrukturentwicklung, über Export- und Importverträge und naturwissenschaftliche Forschungen.
-1	Regierungen	Regierung	NOUN	NN	Case=Nom|Gender=Fem|Number=Plur	2	nsubj	_	_
-2	unterzeichneten	unterzeichnen	VERB	VVFIN	Mood=Ind|Number=Plur|Person=3|Tense=Past|VerbForm=Fin	0	root	_	_
-3	auch	auch	ADV	ADV	_	2	advmod	_	_
-4	vier	vier	NUM	CARD	NumType=Card	5	nummod	_	_
-5	Abkommen	Abkommen	NOUN	NN	Case=Acc|Gender=Neut|Number=Plur	2	obj	_	_
-6-7	zur	_	_	_	_	_	_	_	_
-6	zu	zu	ADP	APPR	_	8	case	_	_
-7	der	der	DET	ART	Case=Dat|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	8	det	_	_
-8	Gründung	Gründung	NOUN	NN	Case=Dat|Gender=Fem|Number=Sing	5	nmod	_	_
-9	eines	ein	DET	ART	Case=Gen|Definite=Ind|Gender=Neut|Number=Sing|PronType=Art	13	det	_	_
-10	``	``	PUNCT	$(	_	2	punct	_	SpaceAfter=No
-11	Dialogforums	Dialogforum	NOUN	NN	Case=Gen|Gender=Neut|Number=Sing	13	compound	_	_
-12	für	für	ADP	APPR	_	13	compound	_	_
-13	Hochtechnologie	Hochtechnologie	NOUN	NN	Case=Acc|Gender=Fem|Number=Sing	8	nmod	_	SpaceAfter=No
-14	''	''	PUNCT	$(	_	2	punct	_	SpaceAfter=No
-15	,	,	PUNCT	$,	_	18	punct	_	_
-16	über	über	ADP	APPR	_	18	case	_	_
-17	bilaterale	bilateral	ADJ	ADJA	Case=Acc|Gender=Fem|Number=Plur	18	amod	_	_
-18	Studien	Studie	NOUN	NN	Case=Acc|Gender=Fem|Number=Plur	8	conj	_	_
-19	der	der	DET	ART	Case=Gen|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	21	det	_	_
-20	chinesischen	chinesisch	ADJ	ADJA	Case=Gen|Gender=Fem|Number=Sing	21	amod	_	_
-21	Infrastrukturentwicklung	Infrastrukturentwicklung	NOUN	NN	Case=Gen|Gender=Fem|Number=Sing	18	nmod	_	SpaceAfter=No
-22	,	,	PUNCT	$,	_	24	punct	_	_
-23	über	über	ADP	APPR	_	24	case	_	_
-24	Export	Export	NOUN	TRUNC	Case=Acc|Gender=Masc|Number=Plur	8	compound	_	SpaceAfter=No
-25	-	-	PUNCT	$(	_	27	punct	_	_
-26	und	und	CCONJ	KON	_	27	cc	_	_
-27	Importverträge	Importvertrag	NOUN	NN	Case=Acc|Gender=Masc|Number=Plur	24	conj	_	_
-28	und	und	CCONJ	KON	_	30	cc	_	_
-29	naturwissenschaftliche	naturwissenschaftlich	ADJ	ADJA	Case=Acc|Gender=Fem|Number=Plur	30	amod	_	_
-30	Forschungen	Forschung	NOUN	NN	Case=Acc|Gender=Fem|Number=Plur	24	conj	_	SpaceAfter=No
-31	.	.	PUNCT	$.	_	2	punct	_	_
+# text = Beide Regierungen unterzeichneten auch vier Abkommen zur Gründung eines ``Dialogforums für Hochtechnologie'', über bilaterale Studien der chinesischen Infrastrukturentwicklung, über Export- und Importverträge und naturwissenschaftliche Forschungen.
+1	Beide	beide	DET	PIAT	Case=Nom|Definite=Ind|Gender=Fem|Number=Plur|PronType=Ind	2	dep	_	FixTigerDep=Yes
+2	Regierungen	Regierung	NOUN	NN	Case=Nom|Gender=Fem|Number=Plur	3	nsubj	_	_
+3	unterzeichneten	unterzeichnen	VERB	VVFIN	Mood=Ind|Number=Plur|Person=3|Tense=Past|VerbForm=Fin	0	root	_	_
+4	auch	auch	ADV	ADV	_	3	advmod	_	_
+5	vier	vier	NUM	CARD	NumType=Card	6	nummod	_	_
+6	Abkommen	Abkommen	NOUN	NN	Case=Acc|Gender=Neut|Number=Plur	3	obj	_	_
+7-8	zur	_	_	_	_	_	_	_	_
+7	zu	zu	ADP	APPR	_	9	case	_	_
+8	der	der	DET	ART	Case=Dat|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	9	det	_	_
+9	Gründung	Gründung	NOUN	NN	Case=Dat|Gender=Fem|Number=Sing	6	nmod	_	_
+10	eines	ein	DET	ART	Case=Gen|Definite=Ind|Gender=Neut|Number=Sing|PronType=Art	14	det	_	_
+11	``	``	PUNCT	$(	_	3	punct	_	SpaceAfter=No
+12	Dialogforums	Dialogforum	NOUN	NN	Case=Gen|Gender=Neut|Number=Sing	14	compound	_	_
+13	für	für	ADP	APPR	_	14	compound	_	_
+14	Hochtechnologie	Hochtechnologie	NOUN	NN	Case=Acc|Gender=Fem|Number=Sing	9	nmod	_	SpaceAfter=No
+15	''	''	PUNCT	$(	_	3	punct	_	SpaceAfter=No
+16	,	,	PUNCT	$,	_	19	punct	_	_
+17	über	über	ADP	APPR	_	19	case	_	_
+18	bilaterale	bilateral	ADJ	ADJA	Case=Acc|Gender=Fem|Number=Plur	19	amod	_	_
+19	Studien	Studie	NOUN	NN	Case=Acc|Gender=Fem|Number=Plur	9	conj	_	_
+20	der	der	DET	ART	Case=Gen|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	22	det	_	_
+21	chinesischen	chinesisch	ADJ	ADJA	Case=Gen|Gender=Fem|Number=Sing	22	amod	_	_
+22	Infrastrukturentwicklung	Infrastrukturentwicklung	NOUN	NN	Case=Gen|Gender=Fem|Number=Sing	19	nmod	_	SpaceAfter=No
+23	,	,	PUNCT	$,	_	25	punct	_	_
+24	über	über	ADP	APPR	_	25	case	_	_
+25	Export	Export	NOUN	TRUNC	Case=Acc|Gender=Masc|Number=Plur	9	compound	_	SpaceAfter=No
+26	-	-	PUNCT	$(	_	28	punct	_	_
+27	und	und	CCONJ	KON	_	28	cc	_	_
+28	Importverträge	Importvertrag	NOUN	NN	Case=Acc|Gender=Masc|Number=Plur	25	conj	_	_
+29	und	und	CCONJ	KON	_	31	cc	_	_
+30	naturwissenschaftliche	naturwissenschaftlich	ADJ	ADJA	Case=Acc|Gender=Fem|Number=Plur	31	amod	_	_
+31	Forschungen	Forschung	NOUN	NN	Case=Acc|Gender=Fem|Number=Plur	25	conj	_	SpaceAfter=No
+32	.	.	PUNCT	$.	_	3	punct	_	_
 
 # sent_id = test-s502
-# text = Religion ist die Erbin vieler Namen''.
-1	Religion	Religion	NOUN	NN	Case=Nom|Gender=Fem|Number=Sing	4	nsubj	_	_
-2	ist	sein	AUX	VAFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	4	cop	_	_
-3	die	der	DET	ART	Case=Nom|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	4	det	_	_
-4	Erbin	Erbin	NOUN	NN	Case=Nom|Gender=Fem|Number=Sing	0	root	_	_
-5	vieler	viel	PRON	PIAT	Case=Gen|Definite=Ind|Gender=Masc|Number=Plur|PronType=Ind	6	det	_	_
-6	Namen	Name	NOUN	NN	Case=Gen|Gender=Masc|Number=Plur	4	nmod	_	SpaceAfter=No
-7	''	''	PUNCT	$(	_	4	punct	_	SpaceAfter=No
-8	.	.	PUNCT	$.	_	4	punct	_	_
+# text = ``Religion ist die Erbin vieler Namen''.
+1	``	``	PUNCT	$(	_	2	punct	_	FixTigerDep=Yes|SpaceAfter=No
+2	Religion	Religion	NOUN	NN	Case=Nom|Gender=Fem|Number=Sing	5	nsubj	_	_
+3	ist	sein	AUX	VAFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	5	cop	_	_
+4	die	der	DET	ART	Case=Nom|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	5	det	_	_
+5	Erbin	Erbin	NOUN	NN	Case=Nom|Gender=Fem|Number=Sing	0	root	_	_
+6	vieler	viel	PRON	PIAT	Case=Gen|Definite=Ind|Gender=Masc|Number=Plur|PronType=Ind	7	det	_	_
+7	Namen	Name	NOUN	NN	Case=Gen|Gender=Masc|Number=Plur	5	nmod	_	SpaceAfter=No
+8	''	''	PUNCT	$(	_	5	punct	_	SpaceAfter=No
+9	.	.	PUNCT	$.	_	5	punct	_	_
 
 # sent_id = test-s503
-# text = Richter hatten beim DFB nachgelesen und herausgefunden, daß ein Anrempeln nur dann einen Regelverstoß darstelle, wenn der Gegner besonders brutal zur Sache gehe, der Spieler im Ballbesitz von hinten abgedrängt werde oder bei dem Tackling überhaupt kein Ball in der Nähe gewesen sei.
-1	Richter	Richter	NOUN	NN	Case=Nom|Gender=Masc|Number=Plur	6	nsubj	_	_
-2	hatten	haben	AUX	VAFIN	Mood=Ind|Number=Plur|Person=3|Tense=Past|VerbForm=Fin	6	aux	_	_
-3-4	beim	_	_	_	_	_	_	_	_
-3	bei	bei	ADP	APPR	_	5	case	_	_
-4	dem	der	DET	ART	Case=Dat|Definite=Def|Gender=Masc|Number=Sing|PronType=Art	5	det	_	_
-5	DFB	DFB	PROPN	NE	Case=Dat|Gender=Masc|Number=Sing	6	obl	_	_
-6	nachgelesen	nachlesen	VERB	VVPP	VerbForm=Part	0	root	_	_
-7	und	und	CCONJ	KON	_	8	cc	_	_
-8	herausgefunden	herausfinden	VERB	VVPP	VerbForm=Part	6	conj	_	SpaceAfter=No
-9	,	,	PUNCT	$,	_	6	punct	_	_
-10	daß	daß	SCONJ	KOUS	_	17	mark	_	_
-11	ein	ein	DET	ART	Case=Nom|Definite=Ind|Gender=Neut|Number=Sing|PronType=Art	12	det	_	_
-12	Anrempeln	Anrempeln	NOUN	NN	Case=Nom|Gender=Neut|Number=Sing	17	nsubj	_	_
-13	nur	nur	ADV	ADV	_	14	advmod	_	_
-14	dann	dann	ADV	ADV	_	17	advmod	_	_
-15	einen	ein	DET	ART	Case=Acc|Definite=Ind|Gender=Masc|Number=Sing|PronType=Art	16	det	_	_
-16	Regelverstoß	Regelverstoß	NOUN	NN	Case=Acc|Gender=Masc|Number=Sing	17	obj	_	_
-17	darstelle	darstellen	VERB	VVFIN	Mood=Sub|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	8	ccomp	_	SpaceAfter=No
-18	,	,	PUNCT	$,	_	6	punct	_	_
-19	wenn	wenn	SCONJ	KOUS	_	27	mark	_	_
-20	der	der	DET	ART	Case=Nom|Definite=Def|Gender=Masc|Number=Sing|PronType=Art	21	det	_	_
-21	Gegner	Gegner	NOUN	NN	Case=Nom|Gender=Masc|Number=Sing	27	nsubj	_	_
-22	besonders	besonders	ADV	ADV	_	23	advmod	_	_
-23	brutal	brutal	ADV	ADJD	_	27	advmod	_	_
-24-25	zur	_	_	_	_	_	_	_	_
-24	zu	zu	ADP	APPR	_	26	case	_	_
-25	der	der	DET	ART	Case=Dat|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	26	det	_	_
-26	Sache	Sache	NOUN	NN	Case=Dat|Gender=Fem|Number=Sing	27	obl	_	_
-27	gehe	gehen	VERB	VVFIN	Mood=Sub|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	17	advcl	_	SpaceAfter=No
-28	,	,	PUNCT	$,	_	36	punct	_	_
-29	der	der	DET	ART	Case=Nom|Definite=Def|Gender=Masc|Number=Sing|PronType=Art	30	det	_	_
-30	Spieler	Spieler	NOUN	NN	Case=Nom|Gender=Masc|Number=Sing	36	nsubj:pass	_	_
-31-32	im	_	_	_	_	_	_	_	_
-31	in	in	ADP	APPR	_	33	case	_	_
-32	dem	der	DET	ART	Case=Dat|Definite=Def|Gender=Masc|Number=Sing|PronType=Art	33	det	_	_
-33	Ballbesitz	Ballbesitz	NOUN	NN	Case=Dat|Gender=Masc|Number=Sing	30	nmod	_	_
-34	von	von	ADP	APPR	_	35	case	_	_
-35	hinten	hinten	ADV	ADV	_	36	advmod	_	_
-36	abgedrängt	abdrängen	VERB	VVPP	VerbForm=Part	27	conj	_	_
-37	werde	werden	AUX	VAFIN	Mood=Sub|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin|Voice=Pass	36	aux:pass	_	_
-38	oder	oder	CCONJ	KON	_	49	cc	_	_
-39	bei	bei	ADP	APPR	_	41	case	_	_
-40	dem	der	DET	ART	Case=Dat|Definite=Def|Gender=Neut|Number=Sing|PronType=Art	41	det	_	_
-41	Tackling	Tackling	NOUN	NN	Case=Dat|Gender=Neut|Number=Sing	49	obl	_	_
-42	überhaupt	überhaupt	ADV	ADV	_	44	advmod	_	_
-43	kein	kein	PRON	PIAT	Case=Nom|Definite=Ind|Gender=Masc|Number=Sing|Polarity=Neg|PronType=Neg	44	advmod	_	_
-44	Ball	Ball	NOUN	NN	Case=Nom|Gender=Masc|Number=Sing	49	nsubj	_	_
-45	in	in	ADP	APPR	_	47	case	_	_
-46	der	der	DET	ART	Case=Dat|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	47	det	_	_
-47	Nähe	Nähe	NOUN	NN	Case=Dat|Gender=Fem|Number=Sing	49	obl	_	_
-48	gewesen	sein	AUX	VAPP	VerbForm=Part	49	aux	_	_
-49	sei	sein	VERB	VAFIN	Mood=Sub|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	27	conj	_	SpaceAfter=No
-50	.	.	PUNCT	$.	_	6	punct	_	_
+# text = Die Richter hatten beim DFB nachgelesen und herausgefunden, daß ein Anrempeln nur dann einen Regelverstoß darstelle, wenn der Gegner besonders brutal zur Sache gehe, der Spieler im Ballbesitz von hinten abgedrängt werde oder bei dem Tackling überhaupt kein Ball in der Nähe gewesen sei.
+1	Die	der	DET	ART	Case=Nom|Definite=Def|Gender=Masc|Number=Plur|PronType=Art	2	dep	_	FixTigerDep=Yes
+2	Richter	Richter	NOUN	NN	Case=Nom|Gender=Masc|Number=Plur	7	nsubj	_	_
+3	hatten	haben	AUX	VAFIN	Mood=Ind|Number=Plur|Person=3|Tense=Past|VerbForm=Fin	7	aux	_	_
+4-5	beim	_	_	_	_	_	_	_	_
+4	bei	bei	ADP	APPR	_	6	case	_	_
+5	dem	der	DET	ART	Case=Dat|Definite=Def|Gender=Masc|Number=Sing|PronType=Art	6	det	_	_
+6	DFB	DFB	PROPN	NE	Case=Dat|Gender=Masc|Number=Sing	7	obl	_	_
+7	nachgelesen	nachlesen	VERB	VVPP	VerbForm=Part	0	root	_	_
+8	und	und	CCONJ	KON	_	9	cc	_	_
+9	herausgefunden	herausfinden	VERB	VVPP	VerbForm=Part	7	conj	_	SpaceAfter=No
+10	,	,	PUNCT	$,	_	7	punct	_	_
+11	daß	daß	SCONJ	KOUS	_	18	mark	_	_
+12	ein	ein	DET	ART	Case=Nom|Definite=Ind|Gender=Neut|Number=Sing|PronType=Art	13	det	_	_
+13	Anrempeln	Anrempeln	NOUN	NN	Case=Nom|Gender=Neut|Number=Sing	18	nsubj	_	_
+14	nur	nur	ADV	ADV	_	15	advmod	_	_
+15	dann	dann	ADV	ADV	_	18	advmod	_	_
+16	einen	ein	DET	ART	Case=Acc|Definite=Ind|Gender=Masc|Number=Sing|PronType=Art	17	det	_	_
+17	Regelverstoß	Regelverstoß	NOUN	NN	Case=Acc|Gender=Masc|Number=Sing	18	obj	_	_
+18	darstelle	darstellen	VERB	VVFIN	Mood=Sub|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	9	ccomp	_	SpaceAfter=No
+19	,	,	PUNCT	$,	_	7	punct	_	_
+20	wenn	wenn	SCONJ	KOUS	_	28	mark	_	_
+21	der	der	DET	ART	Case=Nom|Definite=Def|Gender=Masc|Number=Sing|PronType=Art	22	det	_	_
+22	Gegner	Gegner	NOUN	NN	Case=Nom|Gender=Masc|Number=Sing	28	nsubj	_	_
+23	besonders	besonders	ADV	ADV	_	24	advmod	_	_
+24	brutal	brutal	ADV	ADJD	_	28	advmod	_	_
+25-26	zur	_	_	_	_	_	_	_	_
+25	zu	zu	ADP	APPR	_	27	case	_	_
+26	der	der	DET	ART	Case=Dat|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	27	det	_	_
+27	Sache	Sache	NOUN	NN	Case=Dat|Gender=Fem|Number=Sing	28	obl	_	_
+28	gehe	gehen	VERB	VVFIN	Mood=Sub|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	18	advcl	_	SpaceAfter=No
+29	,	,	PUNCT	$,	_	37	punct	_	_
+30	der	der	DET	ART	Case=Nom|Definite=Def|Gender=Masc|Number=Sing|PronType=Art	31	det	_	_
+31	Spieler	Spieler	NOUN	NN	Case=Nom|Gender=Masc|Number=Sing	37	nsubj:pass	_	_
+32-33	im	_	_	_	_	_	_	_	_
+32	in	in	ADP	APPR	_	34	case	_	_
+33	dem	der	DET	ART	Case=Dat|Definite=Def|Gender=Masc|Number=Sing|PronType=Art	34	det	_	_
+34	Ballbesitz	Ballbesitz	NOUN	NN	Case=Dat|Gender=Masc|Number=Sing	31	nmod	_	_
+35	von	von	ADP	APPR	_	36	case	_	_
+36	hinten	hinten	ADV	ADV	_	37	advmod	_	_
+37	abgedrängt	abdrängen	VERB	VVPP	VerbForm=Part	28	conj	_	_
+38	werde	werden	AUX	VAFIN	Mood=Sub|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin|Voice=Pass	37	aux:pass	_	_
+39	oder	oder	CCONJ	KON	_	50	cc	_	_
+40	bei	bei	ADP	APPR	_	42	case	_	_
+41	dem	der	DET	ART	Case=Dat|Definite=Def|Gender=Neut|Number=Sing|PronType=Art	42	det	_	_
+42	Tackling	Tackling	NOUN	NN	Case=Dat|Gender=Neut|Number=Sing	50	obl	_	_
+43	überhaupt	überhaupt	ADV	ADV	_	45	advmod	_	_
+44	kein	kein	PRON	PIAT	Case=Nom|Definite=Ind|Gender=Masc|Number=Sing|Polarity=Neg|PronType=Neg	45	advmod	_	_
+45	Ball	Ball	NOUN	NN	Case=Nom|Gender=Masc|Number=Sing	50	nsubj	_	_
+46	in	in	ADP	APPR	_	48	case	_	_
+47	der	der	DET	ART	Case=Dat|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	48	det	_	_
+48	Nähe	Nähe	NOUN	NN	Case=Dat|Gender=Fem|Number=Sing	50	obl	_	_
+49	gewesen	sein	AUX	VAPP	VerbForm=Part	50	aux	_	_
+50	sei	sein	VERB	VAFIN	Mood=Sub|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	28	conj	_	SpaceAfter=No
+51	.	.	PUNCT	$.	_	7	punct	_	_
 
 # sent_id = test-s504
 # text = Rita Neubauer (Havanna) fürchtet noch Schlimmeres.
@@ -9747,70 +9912,73 @@
 9	.	.	PUNCT	$.	_	6	punct	_	_
 
 # sent_id = test-s505
-# text = Romancier, Journalist und Bühnenautor beschrieb in sieben Romanen und vier Sachbüchern beschrieb Jose Yglesias vor allem das Leben mittel- und südamerikanischer Emigranten und Exilkubaner in den USA sowie derer, die zu Hause blieben.
-1	Romancier	Romancier	NOUN	NN	Case=Nom|Gender=Masc|Number=Sing	6	nsubj	_	SpaceAfter=No
-2	,	,	PUNCT	$,	_	3	punct	_	_
-3	Journalist	Journalist	NOUN	NN	Case=Nom|Gender=Masc|Number=Sing	1	conj	_	_
-4	und	und	CCONJ	KON	_	5	cc	_	_
-5	Bühnenautor	Bühnenautor	NOUN	NN	Case=Nom|Gender=Masc|Number=Sing	3	conj	_	_
-6	beschrieb	beschreiben	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	13	dep	_	_
-7	in	in	ADP	APPR	_	9	case	_	_
-8	sieben	sieben	NUM	CARD	NumType=Card	9	nummod	_	_
-9	Romanen	Roman	NOUN	NN	Case=Dat|Gender=Masc|Number=Plur	6	obl	_	_
-10	und	und	CCONJ	KON	_	12	cc	_	_
-11	vier	vier	NUM	CARD	NumType=Card	12	nummod	_	_
-12	Sachbüchern	Sachbuch	NOUN	NN	Case=Dat|Gender=Neut|Number=Plur	9	conj	_	_
-13	beschrieb	beschreiben	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	0	root	_	_
-14	Jose	Jose	PROPN	NE	Case=Nom|Gender=Masc|Number=Sing	13	nsubj	_	_
-15	Yglesias	Yglesias	PROPN	NE	Case=Nom|Gender=Masc|Number=Sing	14	flat	_	_
-16	vor	vor	ADP	APPR	_	17	case	_	_
-17	allem	alle	PRON	PIS	Case=Dat|Definite=Ind|Gender=Neut|Number=Sing|PronType=Ind	13	obl	_	_
-18	das	der	DET	ART	Case=Acc|Definite=Def|Gender=Neut|Number=Sing|PronType=Art	19	det	_	_
-19	Leben	Leben	NOUN	NN	Case=Acc|Gender=Neut|Number=Sing	13	obj	_	_
-20	mittel	mitteln	NOUN	TRUNC	Case=Gen|Gender=Masc|Number=Plur	23	compound	_	SpaceAfter=No
-21	-	-	PUNCT	$(	_	23	punct	_	_
-22	und	und	CCONJ	KON	_	23	cc	_	_
-23	südamerikanischer	südamerikanisch	ADJ	ADJA	Case=Gen|Gender=Masc|Number=Plur	24	amod	_	_
-24	Emigranten	Emigrant	NOUN	NN	Case=Gen|Gender=Masc|Number=Plur	19	nmod	_	_
-25	und	und	CCONJ	KON	_	26	cc	_	_
-26	Exilkubaner	Exilkubaner	NOUN	NN	Case=Gen|Gender=Masc|Number=Plur	24	conj	_	_
-27	in	in	ADP	APPR	_	29	case	_	_
-28	den	der	DET	ART	Case=Dat|Definite=Def|Number=Plur|PronType=Art	29	det	_	_
-29	USA	USA	PROPN	NE	Case=Dat|Number=Plur	26	nmod	_	_
-30	sowie	sowie	CCONJ	KON	_	31	cc	_	_
-31	derer	der	PRON	PDS	Case=Gen|Number=Plur|PronType=Dem	24	conj	_	SpaceAfter=No
-32	,	,	PUNCT	$,	_	13	punct	_	_
-33	die	der	PRON	PRELS	Case=Nom|Number=Plur|PronType=Rel	36	nsubj	_	_
-34	zu	zu	ADP	APPR	_	35	case	_	_
-35	Hause	Haus	NOUN	NN	Case=Dat|Gender=Neut|Number=Sing	36	obl	_	_
-36	blieben	bleiben	VERB	VVFIN	Mood=Ind|Number=Plur|Person=3|Tense=Past|VerbForm=Fin	31	acl	_	SpaceAfter=No
-37	.	.	PUNCT	$.	_	13	punct	_	_
+# text = Der Romancier, Journalist und Bühnenautor beschrieb in sieben Romanen und vier Sachbüchern beschrieb Jose Yglesias vor allem das Leben mittel- und südamerikanischer Emigranten und Exilkubaner in den USA sowie derer, die zu Hause blieben.
+1	Der	der	DET	ART	Case=Nom|Definite=Def|Gender=Masc|Number=Sing|PronType=Art	2	dep	_	FixTigerDep=Yes
+2	Romancier	Romancier	NOUN	NN	Case=Nom|Gender=Masc|Number=Sing	7	nsubj	_	SpaceAfter=No
+3	,	,	PUNCT	$,	_	4	punct	_	_
+4	Journalist	Journalist	NOUN	NN	Case=Nom|Gender=Masc|Number=Sing	2	conj	_	_
+5	und	und	CCONJ	KON	_	6	cc	_	_
+6	Bühnenautor	Bühnenautor	NOUN	NN	Case=Nom|Gender=Masc|Number=Sing	4	conj	_	_
+7	beschrieb	beschreiben	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	14	dep	_	_
+8	in	in	ADP	APPR	_	10	case	_	_
+9	sieben	sieben	NUM	CARD	NumType=Card	10	nummod	_	_
+10	Romanen	Roman	NOUN	NN	Case=Dat|Gender=Masc|Number=Plur	7	obl	_	_
+11	und	und	CCONJ	KON	_	13	cc	_	_
+12	vier	vier	NUM	CARD	NumType=Card	13	nummod	_	_
+13	Sachbüchern	Sachbuch	NOUN	NN	Case=Dat|Gender=Neut|Number=Plur	10	conj	_	_
+14	beschrieb	beschreiben	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	0	root	_	_
+15	Jose	Jose	PROPN	NE	Case=Nom|Gender=Masc|Number=Sing	14	nsubj	_	_
+16	Yglesias	Yglesias	PROPN	NE	Case=Nom|Gender=Masc|Number=Sing	15	flat	_	_
+17	vor	vor	ADP	APPR	_	18	case	_	_
+18	allem	alle	PRON	PIS	Case=Dat|Definite=Ind|Gender=Neut|Number=Sing|PronType=Ind	14	obl	_	_
+19	das	der	DET	ART	Case=Acc|Definite=Def|Gender=Neut|Number=Sing|PronType=Art	20	det	_	_
+20	Leben	Leben	NOUN	NN	Case=Acc|Gender=Neut|Number=Sing	14	obj	_	_
+21	mittel	mitteln	NOUN	TRUNC	Case=Gen|Gender=Masc|Number=Plur	24	compound	_	SpaceAfter=No
+22	-	-	PUNCT	$(	_	24	punct	_	_
+23	und	und	CCONJ	KON	_	24	cc	_	_
+24	südamerikanischer	südamerikanisch	ADJ	ADJA	Case=Gen|Gender=Masc|Number=Plur	25	amod	_	_
+25	Emigranten	Emigrant	NOUN	NN	Case=Gen|Gender=Masc|Number=Plur	20	nmod	_	_
+26	und	und	CCONJ	KON	_	27	cc	_	_
+27	Exilkubaner	Exilkubaner	NOUN	NN	Case=Gen|Gender=Masc|Number=Plur	25	conj	_	_
+28	in	in	ADP	APPR	_	30	case	_	_
+29	den	der	DET	ART	Case=Dat|Definite=Def|Number=Plur|PronType=Art	30	det	_	_
+30	USA	USA	PROPN	NE	Case=Dat|Number=Plur	27	nmod	_	_
+31	sowie	sowie	CCONJ	KON	_	32	cc	_	_
+32	derer	der	PRON	PDS	Case=Gen|Number=Plur|PronType=Dem	25	conj	_	SpaceAfter=No
+33	,	,	PUNCT	$,	_	14	punct	_	_
+34	die	der	PRON	PRELS	Case=Nom|Number=Plur|PronType=Rel	37	nsubj	_	_
+35	zu	zu	ADP	APPR	_	36	case	_	_
+36	Hause	Haus	NOUN	NN	Case=Dat|Gender=Neut|Number=Sing	37	obl	_	_
+37	blieben	bleiben	VERB	VVFIN	Mood=Ind|Number=Plur|Person=3|Tense=Past|VerbForm=Fin	32	acl	_	SpaceAfter=No
+38	.	.	PUNCT	$.	_	14	punct	_	_
 
 # sent_id = test-s506
-# text = Schatzmeister der beiden Parteien protestierten dagegen und kündigten juristische Schritte an.
-1	Schatzmeister	Schatzmeister	NOUN	NN	Case=Nom|Gender=Masc|Number=Plur	5	nsubj	_	_
-2	der	der	DET	ART	Case=Gen|Definite=Def|Gender=Fem|Number=Plur|PronType=Art	4	det	_	_
-3	beiden	beide	PRON	PIAT	Case=Gen|Definite=Ind|Gender=Fem|Number=Plur|PronType=Ind	4	det	_	_
-4	Parteien	Partei	NOUN	NN	Case=Gen|Gender=Fem|Number=Plur	1	nmod	_	_
-5	protestierten	protestieren	VERB	VVFIN	Mood=Ind|Number=Plur|Person=3|Tense=Past|VerbForm=Fin	0	root	_	_
-6	dagegen	dagegen	ADV	PAV	_	5	advmod	_	_
-7	und	und	CCONJ	KON	_	8	cc	_	_
-8	kündigten	kündigen	VERB	VVFIN	Mood=Ind|Number=Plur|Person=3|Tense=Past|VerbForm=Fin	5	conj	_	_
-9	juristische	juristisch	ADJ	ADJA	Case=Acc|Gender=Masc|Number=Plur	10	amod	_	_
-10	Schritte	Schritt	NOUN	NN	Case=Acc|Gender=Masc|Number=Plur	8	obj	_	_
-11	an	an	ADP	PTKVZ	_	8	compound:prt	_	SpaceAfter=No
-12	.	.	PUNCT	$.	_	5	punct	_	_
+# text = Die Schatzmeister der beiden Parteien protestierten dagegen und kündigten juristische Schritte an.
+1	Die	der	DET	ART	Case=Nom|Definite=Def|Gender=Masc|Number=Plur|PronType=Art	2	dep	_	FixTigerDep=Yes
+2	Schatzmeister	Schatzmeister	NOUN	NN	Case=Nom|Gender=Masc|Number=Plur	6	nsubj	_	_
+3	der	der	DET	ART	Case=Gen|Definite=Def|Gender=Fem|Number=Plur|PronType=Art	5	det	_	_
+4	beiden	beide	PRON	PIAT	Case=Gen|Definite=Ind|Gender=Fem|Number=Plur|PronType=Ind	5	det	_	_
+5	Parteien	Partei	NOUN	NN	Case=Gen|Gender=Fem|Number=Plur	2	nmod	_	_
+6	protestierten	protestieren	VERB	VVFIN	Mood=Ind|Number=Plur|Person=3|Tense=Past|VerbForm=Fin	0	root	_	_
+7	dagegen	dagegen	ADV	PAV	_	6	advmod	_	_
+8	und	und	CCONJ	KON	_	9	cc	_	_
+9	kündigten	kündigen	VERB	VVFIN	Mood=Ind|Number=Plur|Person=3|Tense=Past|VerbForm=Fin	6	conj	_	_
+10	juristische	juristisch	ADJ	ADJA	Case=Acc|Gender=Masc|Number=Plur	11	amod	_	_
+11	Schritte	Schritt	NOUN	NN	Case=Acc|Gender=Masc|Number=Plur	9	obj	_	_
+12	an	an	ADP	PTKVZ	_	9	compound:prt	_	SpaceAfter=No
+13	.	.	PUNCT	$.	_	6	punct	_	_
 
 # sent_id = test-s507
-# text = schnelle Verbindungen werden sie mit Programmen versorgt.
-1	schnelle	schnell	ADJ	ADJA	Case=Acc|Gender=Fem|Number=Plur	2	amod	_	_
-2	Verbindungen	Verbindung	NOUN	NN	Case=Acc|Gender=Fem|Number=Plur	7	dep	_	_
-3	werden	werden	AUX	VAFIN	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin|Voice=Pass	7	aux:pass	_	_
-4	sie	sie	PRON	PPER	Case=Nom|Number=Plur|Person=3|PronType=Prs	7	nsubj:pass	_	_
-5	mit	mit	ADP	APPR	_	6	case	_	_
-6	Programmen	Programm	NOUN	NN	Case=Dat|Gender=Neut|Number=Plur	7	obl	_	_
-7	versorgt	versorgen	VERB	VVPP	VerbForm=Part	0	root	_	SpaceAfter=No
-8	.	.	PUNCT	$.	_	7	punct	_	_
+# text = Über schnelle Verbindungen werden sie mit Programmen versorgt.
+1	Über	über	ADP	APPR	_	2	dep	_	FixTigerDep=Yes
+2	schnelle	schnell	ADJ	ADJA	Case=Acc|Gender=Fem|Number=Plur	3	amod	_	_
+3	Verbindungen	Verbindung	NOUN	NN	Case=Acc|Gender=Fem|Number=Plur	8	dep	_	_
+4	werden	werden	AUX	VAFIN	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin|Voice=Pass	8	aux:pass	_	_
+5	sie	sie	PRON	PPER	Case=Nom|Number=Plur|Person=3|PronType=Prs	8	nsubj:pass	_	_
+6	mit	mit	ADP	APPR	_	7	case	_	_
+7	Programmen	Programm	NOUN	NN	Case=Dat|Gender=Neut|Number=Plur	8	obl	_	_
+8	versorgt	versorgen	VERB	VVPP	VerbForm=Part	0	root	_	SpaceAfter=No
+9	.	.	PUNCT	$.	_	8	punct	_	_
 
 # sent_id = test-s508
 # text = Schritt des IG-Metall-Vorsitzenden Klaus Zwickel, der Unternehmern und Regierung ein ``Bündnis für Arbeit'' angeboten hat, sagte Kanzler Kohl am Mittwoch im Bundestag ``: Wir werden dieses Angebot aufnehmen und darüber sprechen.''
@@ -9862,24 +10030,26 @@
 44	''	''	PUNCT	$(	_	24	punct	_	_
 
 # sent_id = test-s509
-# text = schwere Gefühl tiefer Trauer kehrte zurück.
-1	schwere	schwer	ADJ	ADJA	Case=Nom|Gender=Neut|Number=Sing	2	amod	_	_
-2	Gefühl	Gefühl	NOUN	NN	Case=Nom|Gender=Neut|Number=Sing	5	nsubj	_	_
-3	tiefer	tief	ADJ	ADJA	Case=Gen|Gender=Fem|Number=Sing	4	amod	_	_
-4	Trauer	Trauer	NOUN	NN	Case=Gen|Gender=Fem|Number=Sing	2	nmod	_	_
-5	kehrte	kehren	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	0	root	_	_
-6	zurück	zurück	ADV	PTKVZ	_	5	compound:prt	_	SpaceAfter=No
-7	.	.	PUNCT	$.	_	5	punct	_	_
+# text = Das schwere Gefühl tiefer Trauer kehrte zurück.
+1	Das	der	DET	ART	Case=Nom|Definite=Def|Gender=Neut|Number=Sing|PronType=Art	2	dep	_	FixTigerDep=Yes
+2	schwere	schwer	ADJ	ADJA	Case=Nom|Gender=Neut|Number=Sing	3	amod	_	_
+3	Gefühl	Gefühl	NOUN	NN	Case=Nom|Gender=Neut|Number=Sing	6	nsubj	_	_
+4	tiefer	tief	ADJ	ADJA	Case=Gen|Gender=Fem|Number=Sing	5	amod	_	_
+5	Trauer	Trauer	NOUN	NN	Case=Gen|Gender=Fem|Number=Sing	3	nmod	_	_
+6	kehrte	kehren	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	0	root	_	_
+7	zurück	zurück	ADV	PTKVZ	_	6	compound:prt	_	SpaceAfter=No
+8	.	.	PUNCT	$.	_	6	punct	_	_
 
 # sent_id = test-s510
-# text = Schwiegersohn Paul Henri Cineas wurde festgenommen.
-1	Schwiegersohn	Schwiegersohn	NOUN	NN	Case=Nom|Gender=Masc|Number=Sing	6	nsubj:pass	_	_
-2	Paul	Paul	PROPN	NE	Case=Nom|Gender=Masc|Number=Sing	1	appos	_	_
-3	Henri	Henri	PROPN	NE	Case=Nom|Gender=Masc|Number=Sing	2	flat	_	_
-4	Cineas	Cineas	PROPN	NE	Case=Nom|Gender=Masc|Number=Sing	2	flat	_	_
-5	wurde	werden	AUX	VAFIN	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin|Voice=Pass	6	aux:pass	_	_
-6	festgenommen	festnehmen	VERB	VVPP	VerbForm=Part	0	root	_	SpaceAfter=No
-7	.	.	PUNCT	$.	_	6	punct	_	_
+# text = Avrils Schwiegersohn Paul Henri Cineas wurde festgenommen.
+1	Avrils	Avril	PROPN	NE	Case=Gen|Number=Sing	2	dep	_	FixTigerDep=Yes
+2	Schwiegersohn	Schwiegersohn	NOUN	NN	Case=Nom|Gender=Masc|Number=Sing	7	nsubj:pass	_	_
+3	Paul	Paul	PROPN	NE	Case=Nom|Gender=Masc|Number=Sing	2	appos	_	_
+4	Henri	Henri	PROPN	NE	Case=Nom|Gender=Masc|Number=Sing	3	flat	_	_
+5	Cineas	Cineas	PROPN	NE	Case=Nom|Gender=Masc|Number=Sing	3	flat	_	_
+6	wurde	werden	AUX	VAFIN	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin|Voice=Pass	7	aux:pass	_	_
+7	festgenommen	festnehmen	VERB	VVPP	VerbForm=Part	0	root	_	SpaceAfter=No
+8	.	.	PUNCT	$.	_	7	punct	_	_
 
 # sent_id = test-s511
 # text = "seine guten persönlichen Beziehungen zu John Major wekken Zuversicht in Hongkong und leichte Beunruhigung in Peking.
@@ -9903,92 +10073,95 @@
 18	.	.	PUNCT	$.	_	9	punct	_	_
 
 # sent_id = test-s512
-# text = Seitenhieb auf seine DDR-Erfahrungen kann sich Axel Noack, Pfarrer in Wolfen (Sachsen-Anhalt) und Mitglied im Rat der Evangelischen Kirchen in Deutschland, nicht verkneifen.
-1	Seitenhieb	Seitenhieb	NOUN	NN	Case=Acc|Gender=Masc|Number=Sing	32	obj	_	_
-2	auf	auf	ADP	APPR	_	4	case	_	_
-3	seine	sein	PRON	PPOSAT	Case=Acc|Gender=Fem|Number=Plur|Poss=Yes	4	det:poss	_	_
-4	DDR	DDR	PROPN	NN	Case=Acc|Gender=Fem|Number=Plur	6	compound	_	SpaceAfter=No
-5	-	-	PUNCT	$(	_	4	punct	_	SpaceAfter=No
-6	Erfahrungen	Erfahrung	NOUN	NN	Case=Acc|Gender=Fem|Number=Plur	1	nmod	_	_
-7	kann	können	AUX	VMFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	32	aux	_	_
-8	sich	er|es|sie	PRON	PRF	Case=Dat|Number=Sing|Person=3|PronType=Prs|Reflex=Yes	32	iobj	_	_
-9	Axel	Axel	PROPN	NE	Case=Nom|Gender=Masc|Number=Sing	32	nsubj	_	_
-10	Noack	Noack	PROPN	NE	Case=Nom|Gender=Masc|Number=Sing	9	flat	_	SpaceAfter=No
-11	,	,	PUNCT	$,	_	32	punct	_	_
-12	Pfarrer	Pfarrer	NOUN	NN	Case=Nom|Gender=Masc|Number=Sing	9	appos	_	_
-13	in	in	ADP	APPR	_	14	case	_	_
-14	Wolfen	Wolfen	PROPN	NE	Case=Dat|Gender=Neut|Number=Sing	12	nmod	_	_
-15	(	(	PUNCT	$(	_	16	punct	_	SpaceAfter=No
-16	Sachsen	Sachsen	PROPN	NE	Case=Nom|Gender=Neut|Number=Sing	14	appos	_	SpaceAfter=No
-17	-	-	PUNCT	$(	_	16	punct	_	SpaceAfter=No
-18	Anhalt	Anhalt	PROPN	NE	Case=Nom|Gender=Neut|Number=Sing	16	flat	_	SpaceAfter=No
-19	)	)	PUNCT	$(	_	16	punct	_	_
-20	und	und	CCONJ	KON	_	21	cc	_	_
-21	Mitglied	Mitglied	NOUN	NN	Case=Nom|Gender=Neut|Number=Sing	12	conj	_	_
-22-23	im	_	_	_	_	_	_	_	_
-22	in	in	ADP	APPR	_	24	case	_	_
-23	dem	der	DET	ART	Case=Dat|Definite=Def|Gender=Masc|Number=Sing|PronType=Art	24	det	_	_
-24	Rat	Rat	NOUN	NN	Case=Dat|Gender=Masc|Number=Sing	21	nmod	_	_
-25	der	der	DET	ART	Case=Gen|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	27	det	_	_
-26	Evangelischen	evangelisch	PROPN	ADJA	Case=Gen|Gender=Fem|Number=Plur	27	amod	_	_
-27	Kirchen	Kirche	PROPN	NN	Case=Gen|Gender=Fem|Number=Plur	24	nmod	_	_
-28	in	in	ADP	APPR	_	29	case	_	_
-29	Deutschland	Deutschland	PROPN	NE	Case=Dat|Gender=Neut|Number=Sing	27	nmod	_	SpaceAfter=No
-30	,	,	PUNCT	$,	_	32	punct	_	_
-31	nicht	nicht	PART	PTKNEG	Polarity=Neg	32	advmod	_	_
-32	verkneifen	verkneifen	VERB	VVINF	VerbForm=Inf	0	root	_	SpaceAfter=No
-33	.	.	PUNCT	$.	_	32	punct	_	_
+# text = Den Seitenhieb auf seine DDR-Erfahrungen kann sich Axel Noack, Pfarrer in Wolfen (Sachsen-Anhalt) und Mitglied im Rat der Evangelischen Kirchen in Deutschland, nicht verkneifen.
+1	Den	der	DET	ART	Case=Acc|Definite=Def|Gender=Masc|Number=Sing|PronType=Art	2	dep	_	FixTigerDep=Yes
+2	Seitenhieb	Seitenhieb	NOUN	NN	Case=Acc|Gender=Masc|Number=Sing	33	obj	_	_
+3	auf	auf	ADP	APPR	_	5	case	_	_
+4	seine	sein	PRON	PPOSAT	Case=Acc|Gender=Fem|Number=Plur|Poss=Yes	5	det:poss	_	_
+5	DDR	DDR	PROPN	NN	Case=Acc|Gender=Fem|Number=Plur	7	compound	_	SpaceAfter=No
+6	-	-	PUNCT	$(	_	5	punct	_	SpaceAfter=No
+7	Erfahrungen	Erfahrung	NOUN	NN	Case=Acc|Gender=Fem|Number=Plur	2	nmod	_	_
+8	kann	können	AUX	VMFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	33	aux	_	_
+9	sich	er|es|sie	PRON	PRF	Case=Dat|Number=Sing|Person=3|PronType=Prs|Reflex=Yes	33	iobj	_	_
+10	Axel	Axel	PROPN	NE	Case=Nom|Gender=Masc|Number=Sing	33	nsubj	_	_
+11	Noack	Noack	PROPN	NE	Case=Nom|Gender=Masc|Number=Sing	10	flat	_	SpaceAfter=No
+12	,	,	PUNCT	$,	_	33	punct	_	_
+13	Pfarrer	Pfarrer	NOUN	NN	Case=Nom|Gender=Masc|Number=Sing	10	appos	_	_
+14	in	in	ADP	APPR	_	15	case	_	_
+15	Wolfen	Wolfen	PROPN	NE	Case=Dat|Gender=Neut|Number=Sing	13	nmod	_	_
+16	(	(	PUNCT	$(	_	17	punct	_	SpaceAfter=No
+17	Sachsen	Sachsen	PROPN	NE	Case=Nom|Gender=Neut|Number=Sing	15	appos	_	SpaceAfter=No
+18	-	-	PUNCT	$(	_	17	punct	_	SpaceAfter=No
+19	Anhalt	Anhalt	PROPN	NE	Case=Nom|Gender=Neut|Number=Sing	17	flat	_	SpaceAfter=No
+20	)	)	PUNCT	$(	_	17	punct	_	_
+21	und	und	CCONJ	KON	_	22	cc	_	_
+22	Mitglied	Mitglied	NOUN	NN	Case=Nom|Gender=Neut|Number=Sing	13	conj	_	_
+23-24	im	_	_	_	_	_	_	_	_
+23	in	in	ADP	APPR	_	25	case	_	_
+24	dem	der	DET	ART	Case=Dat|Definite=Def|Gender=Masc|Number=Sing|PronType=Art	25	det	_	_
+25	Rat	Rat	NOUN	NN	Case=Dat|Gender=Masc|Number=Sing	22	nmod	_	_
+26	der	der	DET	ART	Case=Gen|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	28	det	_	_
+27	Evangelischen	evangelisch	PROPN	ADJA	Case=Gen|Gender=Fem|Number=Plur	28	amod	_	_
+28	Kirchen	Kirche	PROPN	NN	Case=Gen|Gender=Fem|Number=Plur	25	nmod	_	_
+29	in	in	ADP	APPR	_	30	case	_	_
+30	Deutschland	Deutschland	PROPN	NE	Case=Dat|Gender=Neut|Number=Sing	28	nmod	_	SpaceAfter=No
+31	,	,	PUNCT	$,	_	33	punct	_	_
+32	nicht	nicht	PART	PTKNEG	Polarity=Neg	33	advmod	_	_
+33	verkneifen	verkneifen	VERB	VVINF	VerbForm=Inf	0	root	_	SpaceAfter=No
+34	.	.	PUNCT	$.	_	33	punct	_	_
 
 # sent_id = test-s513
-# text = Senat hatte am Donnerstag mit 173 gegen 140 Stimmen für die von Christdemokraten, Sozialisten, Sozialdemokraten und Liberalen gebildete Regierung votiert.
-1	Senat	Senat	NOUN	NN	Case=Nom|Gender=Masc|Number=Sing	23	nsubj	_	_
-2	hatte	haben	AUX	VAFIN	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	23	aux	_	_
-3-4	am	_	_	_	_	_	_	_	_
-3	an	an	ADP	APPR	_	5	case	_	_
-4	dem	der	DET	ART	Case=Dat|Definite=Def|Gender=Masc|Number=Sing|PronType=Art	5	det	_	_
-5	Donnerstag	Donnerstag	PROPN	NN	Case=Dat|Gender=Masc|Number=Sing	23	obl	_	_
-6	mit	mit	ADP	APPR	_	10	case	_	_
-7	173	173	NUM	CARD	NumType=Card	10	nummod	_	_
-8	gegen	gegen	ADP	APPR	_	7	case	_	_
-9	140	140	NUM	CARD	NumType=Card	8	nummod	_	_
-10	Stimmen	Stimme	NOUN	NN	Case=Acc|Gender=Fem|Number=Plur	23	obl	_	_
-11	für	für	ADP	APPR	_	22	case	_	_
-12	die	der	DET	ART	Case=Acc|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	22	det	_	_
-13	von	von	ADP	APPR	_	14	case	_	_
-14	Christdemokraten	Christdemokrat	PROPN	NN	Case=Dat|Gender=Masc|Number=Plur	21	nmod	_	SpaceAfter=No
-15	,	,	PUNCT	$,	_	16	punct	_	_
-16	Sozialisten	Sozialist	PROPN	NN	Case=Dat|Gender=Masc|Number=Plur	14	conj	_	SpaceAfter=No
-17	,	,	PUNCT	$,	_	18	punct	_	_
-18	Sozialdemokraten	Sozialdemokrat	PROPN	NN	Case=Dat|Gender=Masc|Number=Plur	14	conj	_	_
-19	und	und	CCONJ	KON	_	20	cc	_	_
-20	Liberalen	Liberale	PROPN	NN	Case=Dat|Number=Plur	14	conj	_	_
-21	gebildete	gebildet	ADJ	ADJA	Case=Acc|Gender=Fem|Number=Sing	22	amod	_	_
-22	Regierung	Regierung	NOUN	NN	Case=Acc|Gender=Fem|Number=Sing	23	obl	_	_
-23	votiert	votieren	VERB	VVPP	VerbForm=Part	0	root	_	SpaceAfter=No
-24	.	.	PUNCT	$.	_	23	punct	_	_
+# text = Der Senat hatte am Donnerstag mit 173 gegen 140 Stimmen für die von Christdemokraten, Sozialisten, Sozialdemokraten und Liberalen gebildete Regierung votiert.
+1	Der	der	DET	ART	Case=Nom|Definite=Def|Gender=Masc|Number=Sing|PronType=Art	2	dep	_	FixTigerDep=Yes
+2	Senat	Senat	NOUN	NN	Case=Nom|Gender=Masc|Number=Sing	24	nsubj	_	_
+3	hatte	haben	AUX	VAFIN	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	24	aux	_	_
+4-5	am	_	_	_	_	_	_	_	_
+4	an	an	ADP	APPR	_	6	case	_	_
+5	dem	der	DET	ART	Case=Dat|Definite=Def|Gender=Masc|Number=Sing|PronType=Art	6	det	_	_
+6	Donnerstag	Donnerstag	PROPN	NN	Case=Dat|Gender=Masc|Number=Sing	24	obl	_	_
+7	mit	mit	ADP	APPR	_	11	case	_	_
+8	173	173	NUM	CARD	NumType=Card	11	nummod	_	_
+9	gegen	gegen	ADP	APPR	_	8	case	_	_
+10	140	140	NUM	CARD	NumType=Card	9	nummod	_	_
+11	Stimmen	Stimme	NOUN	NN	Case=Acc|Gender=Fem|Number=Plur	24	obl	_	_
+12	für	für	ADP	APPR	_	23	case	_	_
+13	die	der	DET	ART	Case=Acc|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	23	det	_	_
+14	von	von	ADP	APPR	_	15	case	_	_
+15	Christdemokraten	Christdemokrat	PROPN	NN	Case=Dat|Gender=Masc|Number=Plur	22	nmod	_	SpaceAfter=No
+16	,	,	PUNCT	$,	_	17	punct	_	_
+17	Sozialisten	Sozialist	PROPN	NN	Case=Dat|Gender=Masc|Number=Plur	15	conj	_	SpaceAfter=No
+18	,	,	PUNCT	$,	_	19	punct	_	_
+19	Sozialdemokraten	Sozialdemokrat	PROPN	NN	Case=Dat|Gender=Masc|Number=Plur	15	conj	_	_
+20	und	und	CCONJ	KON	_	21	cc	_	_
+21	Liberalen	liberale	PROPN	NN	Case=Dat|Number=Plur	15	conj	_	_
+22	gebildete	gebildet	ADJ	ADJA	Case=Acc|Gender=Fem|Number=Sing	23	amod	_	_
+23	Regierung	Regierung	NOUN	NN	Case=Acc|Gender=Fem|Number=Sing	24	obl	_	_
+24	votiert	votieren	VERB	VVPP	VerbForm=Part	0	root	_	SpaceAfter=No
+25	.	.	PUNCT	$.	_	24	punct	_	_
 
 # sent_id = test-s514
-# text = Sie, daß Sie sich das nicht mehr gefallen lassen'', ruft er den Frauen und Männern zu.
-1	Sie	Sie|sie	PRON	PPER	Case=Nom|Number=Plur|Person=3|PronType=Prs	10	appos	_	SpaceAfter=No
-2	,	,	PUNCT	$,	_	13	punct	_	_
-3	daß	daß	SCONJ	KOUS	_	10	mark	_	_
-4	Sie	Sie|sie	PRON	PPER	Case=Nom|Number=Plur|Person=3|PronType=Prs	10	nsubj	_	_
-5	sich	er|es|sie	PRON	PRF	Case=Dat|Number=Plur|Person=3|PronType=Prs|Reflex=Yes	10	iobj	_	_
-6	das	der	PRON	PDS	Case=Acc|Gender=Neut|Number=Sing|PronType=Dem	10	obj	_	_
-7	nicht	nicht	PART	PTKNEG	Polarity=Neg	10	advmod	_	_
-8	mehr	mehr	ADV	ADV	_	10	advmod	_	_
-9	gefallen	gefallen	VERB	VVINF	VerbForm=Inf	10	xcomp	_	_
-10	lassen	lassen	VERB	VVFIN	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	13	ccomp	_	SpaceAfter=No
-11	''	''	PUNCT	$(	_	13	punct	_	SpaceAfter=No
-12	,	,	PUNCT	$,	_	13	punct	_	_
-13	ruft	rufen	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	0	root	_	_
-14	er	er	PRON	PPER	Case=Nom|Gender=Masc|Number=Sing|Person=3|PronType=Prs	13	nsubj	_	_
-15	den	der	DET	ART	Case=Dat|Definite=Def|Number=Plur|PronType=Art	16	det	_	_
-16	Frauen	Frau	NOUN	NN	Case=Dat|Gender=Fem|Number=Plur	13	iobj	_	_
-17	und	und	CCONJ	KON	_	18	cc	_	_
-18	Männern	Mann	NOUN	NN	Case=Dat|Gender=Masc|Number=Plur	16	conj	_	_
-19	zu	zu	ADP	PTKVZ	_	13	compound:prt	_	SpaceAfter=No
-20	.	.	PUNCT	$.	_	13	punct	_	_
+# text = Sagen Sie, daß Sie sich das nicht mehr gefallen lassen'', ruft er den Frauen und Männern zu.
+1	Sagen	sagen	VERB	VVFIN	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	2	dep	_	FixTigerDep=Yes
+2	Sie	Sie|sie	PRON	PPER	Case=Nom|Number=Plur|Person=3|PronType=Prs	11	appos	_	SpaceAfter=No
+3	,	,	PUNCT	$,	_	14	punct	_	_
+4	daß	daß	SCONJ	KOUS	_	11	mark	_	_
+5	Sie	Sie|sie	PRON	PPER	Case=Nom|Number=Plur|Person=3|PronType=Prs	11	nsubj	_	_
+6	sich	er|es|sie	PRON	PRF	Case=Dat|Number=Plur|Person=3|PronType=Prs|Reflex=Yes	11	iobj	_	_
+7	das	der	PRON	PDS	Case=Acc|Gender=Neut|Number=Sing|PronType=Dem	11	obj	_	_
+8	nicht	nicht	PART	PTKNEG	Polarity=Neg	11	advmod	_	_
+9	mehr	mehr	ADV	ADV	_	11	advmod	_	_
+10	gefallen	gefallen	VERB	VVINF	VerbForm=Inf	11	xcomp	_	_
+11	lassen	lassen	VERB	VVFIN	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	14	ccomp	_	SpaceAfter=No
+12	''	''	PUNCT	$(	_	14	punct	_	SpaceAfter=No
+13	,	,	PUNCT	$,	_	14	punct	_	_
+14	ruft	rufen	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	0	root	_	_
+15	er	er	PRON	PPER	Case=Nom|Gender=Masc|Number=Sing|Person=3|PronType=Prs	14	nsubj	_	_
+16	den	der	DET	ART	Case=Dat|Definite=Def|Number=Plur|PronType=Art	17	det	_	_
+17	Frauen	Frau	NOUN	NN	Case=Dat|Gender=Fem|Number=Plur	14	iobj	_	_
+18	und	und	CCONJ	KON	_	19	cc	_	_
+19	Männern	Mann	NOUN	NN	Case=Dat|Gender=Masc|Number=Plur	17	conj	_	_
+20	zu	zu	ADP	PTKVZ	_	14	compound:prt	_	SpaceAfter=No
+21	.	.	PUNCT	$.	_	14	punct	_	_
 
 # sent_id = test-s515
 # text = Sie ruinieren den sozialen Frieden.
@@ -10000,99 +10173,104 @@
 6	.	.	PUNCT	$.	_	2	punct	_	_
 
 # sent_id = test-s516
-# text = Siehe auch Seiten 2 und 3)
-1	Siehe	sehen	VERB	VVIMP	Mood=Imp|Number=Sing|Person=2|VerbForm=Fin	0	root	_	_
-2	auch	auch	ADV	ADV	_	1	advmod	_	_
-3	Seiten	Seite	NOUN	NN	Case=Acc|Gender=Fem|Number=Plur	1	obj	_	_
-4	2	2	NUM	CARD	NumType=Card	3	nummod	_	_
-5	und	und	CCONJ	KON	_	6	cc	_	_
-6	3	3	NUM	CARD	NumType=Card	4	conj	_	SpaceAfter=No
-7	)	)	PUNCT	$(	_	1	punct	_	_
+# text = (Siehe auch Seiten 2 und 3)
+1	(	(	PUNCT	$(	_	2	punct	_	FixTigerDep=Yes|SpaceAfter=No
+2	Siehe	sehen	VERB	VVIMP	Mood=Imp|Number=Sing|Person=2|VerbForm=Fin	0	root	_	_
+3	auch	auch	ADV	ADV	_	2	advmod	_	_
+4	Seiten	Seite	NOUN	NN	Case=Acc|Gender=Fem|Number=Plur	2	obj	_	_
+5	2	2	NUM	CARD	NumType=Card	4	nummod	_	_
+6	und	und	CCONJ	KON	_	7	cc	_	_
+7	3	3	NUM	CARD	NumType=Card	5	conj	_	SpaceAfter=No
+8	)	)	PUNCT	$(	_	2	punct	_	_
 
 # sent_id = test-s517
-# text = So sicher sind wir uns heute nicht mehr'', sagt Braun.
-1	So	so	ADV	ADV	_	2	advmod	_	_
-2	sicher	sicher	ADJ	ADJD	_	11	ccomp	_	_
-3	sind	sein	AUX	VAFIN	Mood=Ind|Number=Plur|Person=1|Tense=Pres|VerbForm=Fin	2	cop	_	_
-4	wir	wir	PRON	PPER	Case=Nom|Number=Plur|Person=1|PronType=Prs	2	nsubj	_	_
-5	uns	wir	PRON	PPER	Case=Dat|Number=Plur|Person=1|PronType=Prs	3	iobj	_	_
-6	heute	heute	ADV	ADV	_	2	advmod	_	_
-7	nicht	nicht	PART	PTKNEG	Polarity=Neg	3	advmod	_	_
-8	mehr	mehr	ADV	ADV	_	7	advmod	_	SpaceAfter=No
-9	''	''	PUNCT	$(	_	11	punct	_	SpaceAfter=No
-10	,	,	PUNCT	$,	_	11	punct	_	_
-11	sagt	sagen	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	0	root	_	_
-12	Braun	Braun	PROPN	NE	Case=Nom|Number=Sing	11	nsubj	_	SpaceAfter=No
-13	.	.	PUNCT	$.	_	11	punct	_	_
+# text = ``So sicher sind wir uns heute nicht mehr'', sagt Braun.
+1	``	``	PUNCT	$(	_	2	punct	_	FixTigerDep=Yes|SpaceAfter=No
+2	So	so	ADV	ADV	_	3	advmod	_	_
+3	sicher	sicher	ADJ	ADJD	_	12	ccomp	_	_
+4	sind	sein	AUX	VAFIN	Mood=Ind|Number=Plur|Person=1|Tense=Pres|VerbForm=Fin	3	cop	_	_
+5	wir	wir	PRON	PPER	Case=Nom|Number=Plur|Person=1|PronType=Prs	3	nsubj	_	_
+6	uns	wir	PRON	PPER	Case=Dat|Number=Plur|Person=1|PronType=Prs	4	iobj	_	_
+7	heute	heute	ADV	ADV	_	3	advmod	_	_
+8	nicht	nicht	PART	PTKNEG	Polarity=Neg	4	advmod	_	_
+9	mehr	mehr	ADV	ADV	_	8	advmod	_	SpaceAfter=No
+10	''	''	PUNCT	$(	_	12	punct	_	SpaceAfter=No
+11	,	,	PUNCT	$,	_	12	punct	_	_
+12	sagt	sagen	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	0	root	_	_
+13	Braun	Braun	PROPN	NE	Case=Nom|Number=Sing	12	nsubj	_	SpaceAfter=No
+14	.	.	PUNCT	$.	_	12	punct	_	_
 
 # sent_id = test-s518
-# text = Sohn Yuval sprach das traditionelle jüdische Totengebet.
-1	Sohn	Sohn	NOUN	NN	Case=Nom|Gender=Masc|Number=Sing	2	compound	_	_
-2	Yuval	Yuval	PROPN	NE	Case=Nom|Gender=Masc|Number=Sing	3	nsubj	_	_
-3	sprach	sprechen	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	0	root	_	_
-4	das	der	DET	ART	Case=Acc|Definite=Def|Gender=Neut|Number=Sing|PronType=Art	7	det	_	_
-5	traditionelle	traditionell	ADJ	ADJA	Case=Acc|Gender=Neut|Number=Sing	7	amod	_	_
-6	jüdische	jüdisch	ADJ	ADJA	Case=Acc|Gender=Neut|Number=Sing	7	amod	_	_
-7	Totengebet	Totengebet	NOUN	NN	Case=Acc|Gender=Neut|Number=Sing	3	obj	_	SpaceAfter=No
-8	.	.	PUNCT	$.	_	3	punct	_	_
+# text = Rabins Sohn Yuval sprach das traditionelle jüdische Totengebet.
+1	Rabins	Rabin	PROPN	NE	Case=Gen|Gender=Masc|Number=Sing	2	dep	_	FixTigerDep=Yes
+2	Sohn	Sohn	NOUN	NN	Case=Nom|Gender=Masc|Number=Sing	3	compound	_	_
+3	Yuval	Yuval	PROPN	NE	Case=Nom|Gender=Masc|Number=Sing	4	nsubj	_	_
+4	sprach	sprechen	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	0	root	_	_
+5	das	der	DET	ART	Case=Acc|Definite=Def|Gender=Neut|Number=Sing|PronType=Art	8	det	_	_
+6	traditionelle	traditionell	ADJ	ADJA	Case=Acc|Gender=Neut|Number=Sing	8	amod	_	_
+7	jüdische	jüdisch	ADJ	ADJA	Case=Acc|Gender=Neut|Number=Sing	8	amod	_	_
+8	Totengebet	Totengebet	NOUN	NN	Case=Acc|Gender=Neut|Number=Sing	4	obj	_	SpaceAfter=No
+9	.	.	PUNCT	$.	_	4	punct	_	_
 
 # sent_id = test-s519
-# text = Soyinka bringt gern Festbräuche auf die Bühne, und trotz seiner bitteren Erfahrungen gibt er der lächelnden Komödie, die nicht zu seinen besten gehören mag, einen hoffnungsvollen, fast märchenhaften Schluß.
-1	Soyinka	Soyinka	PROPN	NE	Case=Nom|Gender=Masc|Number=Sing	2	nsubj	_	_
-2	bringt	bringen	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	0	root	_	_
-3	gern	gern	ADV	ADV	_	2	advmod	_	_
-4	Festbräuche	Festbrauch	NOUN	NN	Case=Acc|Gender=Masc|Number=Plur	2	obj	_	_
-5	auf	auf	ADP	APPR	_	7	case	_	_
-6	die	der	DET	ART	Case=Acc|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	7	det	_	_
-7	Bühne	Bühne	NOUN	NN	Case=Acc|Gender=Fem|Number=Sing	2	obl	_	SpaceAfter=No
-8	,	,	PUNCT	$,	_	14	punct	_	_
-9	und	und	CCONJ	KON	_	14	cc	_	_
-10	trotz	trotz	ADP	APPR	_	13	case	_	_
-11	seiner	sein	PRON	PPOSAT	Case=Gen|Gender=Fem|Number=Plur|Poss=Yes	13	det:poss	_	_
-12	bitteren	bitter	ADJ	ADJA	Case=Gen|Gender=Fem|Number=Plur	13	amod	_	_
-13	Erfahrungen	Erfahrung	NOUN	NN	Case=Gen|Gender=Fem|Number=Plur	14	obl	_	_
-14	gibt	geben	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	2	conj	_	_
-15	er	er	PRON	PPER	Case=Nom|Gender=Masc|Number=Sing|Person=3|PronType=Prs	14	nsubj	_	_
-16	der	der	DET	ART	Case=Dat|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	18	det	_	_
-17	lächelnden	lächelnd	ADJ	ADJA	Case=Dat|Gender=Fem|Number=Sing	18	amod	_	_
-18	Komödie	Komödie	NOUN	NN	Case=Dat|Gender=Fem|Number=Sing	14	iobj	_	SpaceAfter=No
-19	,	,	PUNCT	$,	_	2	punct	_	_
-20	die	der	PRON	PRELS	Case=Nom|Gender=Fem|Number=Sing|PronType=Rel	25	nsubj	_	_
-21	nicht	nicht	PART	PTKNEG	Polarity=Neg	25	advmod	_	_
-22	zu	zu	ADP	APPR	_	24	case	_	_
-23	seinen	sein	PRON	PPOSAT	Case=Dat|Gender=Fem|Number=Plur|Poss=Yes	24	det:poss	_	_
-24	besten	gut	ADJ	ADJA	Case=Dat|Gender=Fem|Number=Plur	25	amod	_	_
-25	gehören	gehören	VERB	VVINF	VerbForm=Inf	18	acl	_	_
-26	mag	mögen	AUX	VMFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	25	aux	_	SpaceAfter=No
-27	,	,	PUNCT	$,	_	2	punct	_	_
-28	einen	ein	DET	ART	Case=Acc|Definite=Ind|Gender=Masc|Number=Sing|PronType=Art	33	det	_	_
-29	hoffnungsvollen	hoffnungsvoll	ADJ	ADJA	Case=Acc|Gender=Masc|Number=Sing	33	amod	_	SpaceAfter=No
-30	,	,	PUNCT	$,	_	32	punct	_	_
-31	fast	fast	ADV	ADV	_	32	advmod	_	_
-32	märchenhaften	märchenhaft	ADJ	ADJA	Case=Acc|Gender=Masc|Number=Sing	29	conj	_	_
-33	Schluß	Schluß	NOUN	NN	Case=Acc|Gender=Masc|Number=Sing	14	obj	_	SpaceAfter=No
-34	.	.	PUNCT	$.	_	2	punct	_	_
+# text = Wole Soyinka bringt gern Festbräuche auf die Bühne, und trotz seiner bitteren Erfahrungen gibt er der lächelnden Komödie, die nicht zu seinen besten gehören mag, einen hoffnungsvollen, fast märchenhaften Schluß.
+1	Wole	Wole	PROPN	NE	Case=Nom|Gender=Masc|Number=Sing	2	dep	_	FixTigerDep=Yes
+2	Soyinka	Soyinka	PROPN	NE	Case=Nom|Gender=Masc|Number=Sing	3	nsubj	_	_
+3	bringt	bringen	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	0	root	_	_
+4	gern	gern	ADV	ADV	_	3	advmod	_	_
+5	Festbräuche	Festbrauch	NOUN	NN	Case=Acc|Gender=Masc|Number=Plur	3	obj	_	_
+6	auf	auf	ADP	APPR	_	8	case	_	_
+7	die	der	DET	ART	Case=Acc|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	8	det	_	_
+8	Bühne	Bühne	NOUN	NN	Case=Acc|Gender=Fem|Number=Sing	3	obl	_	SpaceAfter=No
+9	,	,	PUNCT	$,	_	15	punct	_	_
+10	und	und	CCONJ	KON	_	15	cc	_	_
+11	trotz	trotz	ADP	APPR	_	14	case	_	_
+12	seiner	sein	PRON	PPOSAT	Case=Gen|Gender=Fem|Number=Plur|Poss=Yes	14	det:poss	_	_
+13	bitteren	bitter	ADJ	ADJA	Case=Gen|Gender=Fem|Number=Plur	14	amod	_	_
+14	Erfahrungen	Erfahrung	NOUN	NN	Case=Gen|Gender=Fem|Number=Plur	15	obl	_	_
+15	gibt	geben	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	3	conj	_	_
+16	er	er	PRON	PPER	Case=Nom|Gender=Masc|Number=Sing|Person=3|PronType=Prs	15	nsubj	_	_
+17	der	der	DET	ART	Case=Dat|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	19	det	_	_
+18	lächelnden	lächelnd	ADJ	ADJA	Case=Dat|Gender=Fem|Number=Sing	19	amod	_	_
+19	Komödie	Komödie	NOUN	NN	Case=Dat|Gender=Fem|Number=Sing	15	iobj	_	SpaceAfter=No
+20	,	,	PUNCT	$,	_	3	punct	_	_
+21	die	der	PRON	PRELS	Case=Nom|Gender=Fem|Number=Sing|PronType=Rel	26	nsubj	_	_
+22	nicht	nicht	PART	PTKNEG	Polarity=Neg	26	advmod	_	_
+23	zu	zu	ADP	APPR	_	25	case	_	_
+24	seinen	sein	PRON	PPOSAT	Case=Dat|Gender=Fem|Number=Plur|Poss=Yes	25	det:poss	_	_
+25	besten	gut	ADJ	ADJA	Case=Dat|Gender=Fem|Number=Plur	26	amod	_	_
+26	gehören	gehören	VERB	VVINF	VerbForm=Inf	19	acl	_	_
+27	mag	mögen	AUX	VMFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	26	aux	_	SpaceAfter=No
+28	,	,	PUNCT	$,	_	3	punct	_	_
+29	einen	ein	DET	ART	Case=Acc|Definite=Ind|Gender=Masc|Number=Sing|PronType=Art	34	det	_	_
+30	hoffnungsvollen	hoffnungsvoll	ADJ	ADJA	Case=Acc|Gender=Masc|Number=Sing	34	amod	_	SpaceAfter=No
+31	,	,	PUNCT	$,	_	33	punct	_	_
+32	fast	fast	ADV	ADV	_	33	advmod	_	_
+33	märchenhaften	märchenhaft	ADJ	ADJA	Case=Acc|Gender=Masc|Number=Sing	30	conj	_	_
+34	Schluß	Schluß	NOUN	NN	Case=Acc|Gender=Masc|Number=Sing	15	obj	_	SpaceAfter=No
+35	.	.	PUNCT	$.	_	3	punct	_	_
 
 # sent_id = test-s520
-# text = SPD-Abgeordneten Otto Schily und Friedhelm Julius Beucher nannten die Antworten ``lückenhaft und ausweichend''.
-1	SPD	SPD	PROPN	NN	Case=Nom|Gender=Masc|Number=Plur	3	compound	_	SpaceAfter=No
-2	-	-	PUNCT	$(	_	1	punct	_	SpaceAfter=No
-3	Abgeordneten	abgeordnet	NOUN	NN	Case=Nom|Gender=Masc|Number=Plur	14	nsubj	_	_
-4	Otto	Otto	PROPN	NE	Case=Nom|Gender=Masc|Number=Sing	1	appos	_	_
-5	Schily	Schily	PROPN	NE	Case=Nom|Gender=Masc|Number=Sing	4	flat	_	_
-6	und	und	CCONJ	KON	_	7	cc	_	_
-7	Friedhelm	Friedhelm	PROPN	NE	Case=Nom|Gender=Masc|Number=Sing	4	conj	_	_
-8	Julius	Julius	PROPN	NE	Case=Nom|Gender=Masc|Number=Sing	7	flat	_	_
-9	Beucher	Beucher	PROPN	NE	Case=Nom|Gender=Masc|Number=Sing	7	flat	_	_
-10	nannten	nennen	AUX	VVFIN	Mood=Ind|Number=Plur|Person=3|Tense=Past|VerbForm=Fin	14	cop	_	_
-11	die	der	DET	ART	Case=Acc|Definite=Def|Gender=Fem|Number=Plur|PronType=Art	12	det	_	_
-12	Antworten	Antwort	NOUN	NN	Case=Acc|Gender=Fem|Number=Plur	14	obj	_	_
-13	``	``	PUNCT	$(	_	14	punct	_	SpaceAfter=No
-14	lückenhaft	lückenhaft	ADJ	ADJD	_	0	root	_	_
-15	und	und	CCONJ	KON	_	16	cc	_	_
-16	ausweichend	ausweichend	ADJ	ADJD	_	14	conj	_	SpaceAfter=No
-17	''	''	PUNCT	$(	_	14	punct	_	SpaceAfter=No
-18	.	.	PUNCT	$.	_	14	punct	_	_
+# text = Die SPD-Abgeordneten Otto Schily und Friedhelm Julius Beucher nannten die Antworten ``lückenhaft und ausweichend''.
+1	Die	der	DET	ART	Case=Nom|Definite=Def|Gender=Masc|Number=Plur|PronType=Art	2	dep	_	FixTigerDep=Yes
+2	SPD	SPD	PROPN	NN	Case=Nom|Gender=Masc|Number=Plur	4	compound	_	SpaceAfter=No
+3	-	-	PUNCT	$(	_	2	punct	_	SpaceAfter=No
+4	Abgeordneten	abgeordnet	NOUN	NN	Case=Nom|Gender=Masc|Number=Plur	15	nsubj	_	_
+5	Otto	Otto	PROPN	NE	Case=Nom|Gender=Masc|Number=Sing	2	appos	_	_
+6	Schily	Schily	PROPN	NE	Case=Nom|Gender=Masc|Number=Sing	5	flat	_	_
+7	und	und	CCONJ	KON	_	8	cc	_	_
+8	Friedhelm	Friedhelm	PROPN	NE	Case=Nom|Gender=Masc|Number=Sing	5	conj	_	_
+9	Julius	Julius	PROPN	NE	Case=Nom|Gender=Masc|Number=Sing	8	flat	_	_
+10	Beucher	Beucher	PROPN	NE	Case=Nom|Gender=Masc|Number=Sing	8	flat	_	_
+11	nannten	nennen	AUX	VVFIN	Mood=Ind|Number=Plur|Person=3|Tense=Past|VerbForm=Fin	15	cop	_	_
+12	die	der	DET	ART	Case=Acc|Definite=Def|Gender=Fem|Number=Plur|PronType=Art	13	det	_	_
+13	Antworten	Antwort	NOUN	NN	Case=Acc|Gender=Fem|Number=Plur	15	obj	_	_
+14	``	``	PUNCT	$(	_	15	punct	_	SpaceAfter=No
+15	lückenhaft	lückenhaft	ADJ	ADJD	_	0	root	_	_
+16	und	und	CCONJ	KON	_	17	cc	_	_
+17	ausweichend	ausweichend	ADJ	ADJD	_	15	conj	_	SpaceAfter=No
+18	''	''	PUNCT	$(	_	15	punct	_	SpaceAfter=No
+19	.	.	PUNCT	$.	_	15	punct	_	_
 
 # sent_id = test-s521
 # text = SPD solle sich doch bitte, auch in Schwerin, ``in der Sache profilieren --'' sowohl gegenüber der CDU als auch in die andere Richtung:
@@ -10126,314 +10304,326 @@
 28	:	:	PUNCT	$.	_	15	punct	_	_
 
 # sent_id = test-s522
-# text = SPD unterstütze den China-Besuch Kohls, weil dieses Land nicht isoliert werden dürfe.
-1	SPD	SPD	PROPN	NE	Case=Nom|Gender=Fem|Number=Sing	2	nsubj	_	_
-2	unterstütze	unterstützen	VERB	VVFIN	Mood=Sub|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	0	root	_	_
-3	den	der	DET	ART	Case=Acc|Definite=Def|Gender=Masc|Number=Sing|PronType=Art	4	det	_	_
-4	China	China	PROPN	NN	Case=Acc|Gender=Masc|Number=Sing	6	compound	_	SpaceAfter=No
-5	-	-	PUNCT	$(	_	4	punct	_	SpaceAfter=No
-6	Besuch	Besuch	NOUN	NN	Case=Acc|Gender=Masc|Number=Sing	2	obj	_	_
-7	Kohls	Kohl	PROPN	NE	Case=Gen|Number=Sing	4	nmod	_	SpaceAfter=No
-8	,	,	PUNCT	$,	_	2	punct	_	_
-9	weil	weil	SCONJ	KOUS	_	13	mark	_	_
-10	dieses	dies	PRON	PDAT	Case=Nom|Gender=Neut|Number=Sing|PronType=Dem	11	det	_	_
-11	Land	Land	NOUN	NN	Case=Nom|Gender=Neut|Number=Sing	13	nsubj:pass	_	_
-12	nicht	nicht	PART	PTKNEG	Polarity=Neg	13	advmod	_	_
-13	isoliert	isolieren	VERB	VVPP	VerbForm=Part	2	advcl	_	_
-14	werden	werden	AUX	VAINF	VerbForm=Inf|Voice=Pass	13	aux:pass	_	_
-15	dürfe	dürfen	AUX	VMFIN	Mood=Sub|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	13	aux	_	SpaceAfter=No
-16	.	.	PUNCT	$.	_	2	punct	_	_
+# text = Die SPD unterstütze den China-Besuch Kohls, weil dieses Land nicht isoliert werden dürfe.
+1	Die	der	DET	ART	Case=Nom|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	2	dep	_	FixTigerDep=Yes
+2	SPD	SPD	PROPN	NE	Case=Nom|Gender=Fem|Number=Sing	3	nsubj	_	_
+3	unterstütze	unterstützen	VERB	VVFIN	Mood=Sub|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	0	root	_	_
+4	den	der	DET	ART	Case=Acc|Definite=Def|Gender=Masc|Number=Sing|PronType=Art	5	det	_	_
+5	China	China	PROPN	NN	Case=Acc|Gender=Masc|Number=Sing	7	compound	_	SpaceAfter=No
+6	-	-	PUNCT	$(	_	5	punct	_	SpaceAfter=No
+7	Besuch	Besuch	NOUN	NN	Case=Acc|Gender=Masc|Number=Sing	3	obj	_	_
+8	Kohls	Kohl	PROPN	NE	Case=Gen|Number=Sing	5	nmod	_	SpaceAfter=No
+9	,	,	PUNCT	$,	_	3	punct	_	_
+10	weil	weil	SCONJ	KOUS	_	14	mark	_	_
+11	dieses	dies	PRON	PDAT	Case=Nom|Gender=Neut|Number=Sing|PronType=Dem	12	det	_	_
+12	Land	Land	NOUN	NN	Case=Nom|Gender=Neut|Number=Sing	14	nsubj:pass	_	_
+13	nicht	nicht	PART	PTKNEG	Polarity=Neg	14	advmod	_	_
+14	isoliert	isolieren	VERB	VVPP	VerbForm=Part	3	advcl	_	_
+15	werden	werden	AUX	VAINF	VerbForm=Inf|Voice=Pass	14	aux:pass	_	_
+16	dürfe	dürfen	AUX	VMFIN	Mood=Sub|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	14	aux	_	SpaceAfter=No
+17	.	.	PUNCT	$.	_	3	punct	_	_
 
 # sent_id = test-s523
-# text = Sprecher Thomas Schlier kritisiert, für den Bürger sei bisher nicht klar, was bei einer Umstellung aus seiner Geldanlage und seinen Krediten werde und wie sich die Zinsen dann entwickeln.
-1	Sprecher	Sprecher	NOUN	NN	Case=Nom|Gender=Masc|Number=Sing	4	nsubj	_	_
-2	Thomas	Thomas	PROPN	NE	Case=Nom|Gender=Masc|Number=Sing	1	appos	_	_
-3	Schlier	Schlier	PROPN	NE	Case=Nom|Gender=Masc|Number=Sing	2	flat	_	_
-4	kritisiert	kritisieren	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	0	root	_	SpaceAfter=No
-5	,	,	PUNCT	$,	_	4	punct	_	_
-6	für	für	ADP	APPR	_	8	case	_	_
-7	den	der	DET	ART	Case=Acc|Definite=Def|Gender=Masc|Number=Sing|PronType=Art	8	det	_	_
-8	Bürger	Bürger	NOUN	NN	Case=Acc|Gender=Masc|Number=Sing	9	obl	_	_
-9	sei	sein	VERB	VAFIN	Mood=Sub|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	4	ccomp	_	_
-10	bisher	bisher	ADV	ADV	_	9	advmod	_	_
-11	nicht	nicht	PART	PTKNEG	Polarity=Neg	12	advmod	_	_
-12	klar	klar	ADV	ADJD	_	9	advmod	_	SpaceAfter=No
-13	,	,	PUNCT	$,	_	4	punct	_	_
-14	was	was	PRON	PWS	Case=Nom|Gender=Neut|Number=Sing|PronType=Int	24	nsubj	_	_
-15	bei	bei	ADP	APPR	_	17	case	_	_
-16	einer	ein	DET	ART	Case=Dat|Definite=Ind|Gender=Fem|Number=Sing|PronType=Art	17	det	_	_
-17	Umstellung	Umstellung	NOUN	NN	Case=Dat|Gender=Fem|Number=Sing	24	obl	_	_
-18	aus	aus	ADP	APPR	_	20	case	_	_
-19	seiner	sein	PRON	PPOSAT	Case=Dat|Gender=Fem|Number=Sing|Poss=Yes	20	det:poss	_	_
-20	Geldanlage	Geldanlage	NOUN	NN	Case=Dat|Gender=Fem|Number=Sing	24	obl	_	_
-21	und	und	CCONJ	KON	_	23	cc	_	_
-22	seinen	sein	PRON	PPOSAT	Case=Dat|Gender=Masc|Number=Plur|Poss=Yes	23	det:poss	_	_
-23	Krediten	Kredit	NOUN	NN	Case=Dat|Gender=Masc|Number=Plur	20	conj	_	_
-24	werde	werden	VERB	VAFIN	Mood=Sub|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin|Voice=Pass	12	ccomp	_	_
-25	und	und	CCONJ	KON	_	31	cc	_	_
-26	wie	wie	ADV	PWAV	PronType=Int	31	advmod	_	_
-27	sich	er|es|sie	PRON	PRF	Case=Acc|Number=Plur|Person=3|PronType=Prs|Reflex=Yes	31	obj	_	_
-28	die	der	DET	ART	Case=Nom|Definite=Def|Gender=Masc|Number=Plur|PronType=Art	29	det	_	_
-29	Zinsen	Zins	NOUN	NN	Case=Nom|Gender=Masc|Number=Plur	31	nsubj	_	_
-30	dann	dann	ADV	ADV	_	31	advmod	_	_
-31	entwickeln	entwickeln	VERB	VVFIN	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	24	conj	_	SpaceAfter=No
-32	.	.	PUNCT	$.	_	4	punct	_	_
+# text = Ihr Sprecher Thomas Schlier kritisiert, für den Bürger sei bisher nicht klar, was bei einer Umstellung aus seiner Geldanlage und seinen Krediten werde und wie sich die Zinsen dann entwickeln.
+1	Ihr	ihr	DET	PPOSAT	Case=Nom|Gender=Masc|Number=Sing|Poss=Yes	2	dep	_	FixTigerDep=Yes
+2	Sprecher	Sprecher	NOUN	NN	Case=Nom|Gender=Masc|Number=Sing	5	nsubj	_	_
+3	Thomas	Thomas	PROPN	NE	Case=Nom|Gender=Masc|Number=Sing	2	appos	_	_
+4	Schlier	Schlier	PROPN	NE	Case=Nom|Gender=Masc|Number=Sing	3	flat	_	_
+5	kritisiert	kritisieren	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	0	root	_	SpaceAfter=No
+6	,	,	PUNCT	$,	_	5	punct	_	_
+7	für	für	ADP	APPR	_	9	case	_	_
+8	den	der	DET	ART	Case=Acc|Definite=Def|Gender=Masc|Number=Sing|PronType=Art	9	det	_	_
+9	Bürger	Bürger	NOUN	NN	Case=Acc|Gender=Masc|Number=Sing	10	obl	_	_
+10	sei	sein	VERB	VAFIN	Mood=Sub|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	5	ccomp	_	_
+11	bisher	bisher	ADV	ADV	_	10	advmod	_	_
+12	nicht	nicht	PART	PTKNEG	Polarity=Neg	13	advmod	_	_
+13	klar	klar	ADV	ADJD	_	10	advmod	_	SpaceAfter=No
+14	,	,	PUNCT	$,	_	5	punct	_	_
+15	was	was	PRON	PWS	Case=Nom|Gender=Neut|Number=Sing|PronType=Int	25	nsubj	_	_
+16	bei	bei	ADP	APPR	_	18	case	_	_
+17	einer	ein	DET	ART	Case=Dat|Definite=Ind|Gender=Fem|Number=Sing|PronType=Art	18	det	_	_
+18	Umstellung	Umstellung	NOUN	NN	Case=Dat|Gender=Fem|Number=Sing	25	obl	_	_
+19	aus	aus	ADP	APPR	_	21	case	_	_
+20	seiner	sein	PRON	PPOSAT	Case=Dat|Gender=Fem|Number=Sing|Poss=Yes	21	det:poss	_	_
+21	Geldanlage	Geldanlage	NOUN	NN	Case=Dat|Gender=Fem|Number=Sing	25	obl	_	_
+22	und	und	CCONJ	KON	_	24	cc	_	_
+23	seinen	sein	PRON	PPOSAT	Case=Dat|Gender=Masc|Number=Plur|Poss=Yes	24	det:poss	_	_
+24	Krediten	Kredit	NOUN	NN	Case=Dat|Gender=Masc|Number=Plur	21	conj	_	_
+25	werde	werden	VERB	VAFIN	Mood=Sub|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin|Voice=Pass	13	ccomp	_	_
+26	und	und	CCONJ	KON	_	32	cc	_	_
+27	wie	wie	ADV	PWAV	PronType=Int	32	advmod	_	_
+28	sich	er|es|sie	PRON	PRF	Case=Acc|Number=Plur|Person=3|PronType=Prs|Reflex=Yes	32	obj	_	_
+29	die	der	DET	ART	Case=Nom|Definite=Def|Gender=Masc|Number=Plur|PronType=Art	30	det	_	_
+30	Zinsen	Zins	NOUN	NN	Case=Nom|Gender=Masc|Number=Plur	32	nsubj	_	_
+31	dann	dann	ADV	ADV	_	32	advmod	_	_
+32	entwickeln	entwickeln	VERB	VVFIN	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	25	conj	_	SpaceAfter=No
+33	.	.	PUNCT	$.	_	5	punct	_	_
 
 # sent_id = test-s524
-# text = Staats- und Regierungschefs der sieben führenden Industrienationen (G7) und die EG-Kommission wollen die Lage der Weltwirtschaft und Hilfen für die ehemaligen Ostblock-Länder erörtern.
-1	Staats	Staat	NOUN	TRUNC	Case=Nom|Gender=Masc|Number=Plur	30	compound	_	SpaceAfter=No
-2	-	-	PUNCT	$(	_	4	punct	_	_
-3	und	und	CCONJ	KON	_	4	cc	_	_
-4	Regierungschefs	Regierungschef	NOUN	NN	Case=Nom|Gender=Masc|Number=Plur	1	conj	_	_
-5	der	der	DET	ART	Case=Gen|Definite=Def|Gender=Fem|Number=Plur|PronType=Art	8	det	_	_
-6	sieben	sieben	NUM	CARD	NumType=Card	8	nummod	_	_
-7	führenden	führend	ADJ	ADJA	Case=Gen|Gender=Fem|Number=Plur	8	amod	_	_
-8	Industrienationen	Industrienation	NOUN	NN	Case=Gen|Gender=Fem|Number=Plur	1	nmod	_	_
-9	(	(	PUNCT	$(	_	10	punct	_	SpaceAfter=No
-10	G7	G7	PROPN	NE	Case=Nom|Gender=Fem|Number=Plur	8	appos	_	SpaceAfter=No
-11	)	)	PUNCT	$(	_	10	punct	_	_
-12	und	und	CCONJ	KON	_	14	cc	_	_
-13	die	der	DET	ART	Case=Nom|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	14	det	_	_
-14	EG	EG	PROPN	NN	Case=Nom|Gender=Fem|Number=Sing	16	compound	_	SpaceAfter=No
-15	-	-	PUNCT	$(	_	14	punct	_	SpaceAfter=No
-16	Kommission	Kommission	NOUN	NN	Case=Nom|Gender=Fem|Number=Sing	1	conj	_	_
-17	wollen	wollen	AUX	VMFIN	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	30	aux	_	_
-18	die	der	DET	ART	Case=Acc|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	19	det	_	_
-19	Lage	Lage	NOUN	NN	Case=Acc|Gender=Fem|Number=Sing	30	obj	_	_
-20	der	der	DET	ART	Case=Gen|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	21	det	_	_
-21	Weltwirtschaft	Weltwirtschaft	NOUN	NN	Case=Gen|Gender=Fem|Number=Sing	19	nmod	_	_
-22	und	und	CCONJ	KON	_	23	cc	_	_
-23	Hilfen	Hilfe	NOUN	NN	Case=Acc|Gender=Fem|Number=Plur	19	conj	_	_
-24	für	für	ADP	APPR	_	27	case	_	_
-25	die	der	DET	ART	Case=Acc|Definite=Def|Gender=Neut|Number=Plur|PronType=Art	27	det	_	_
-26	ehemaligen	ehemalig	ADJ	ADJA	Case=Acc|Gender=Neut|Number=Plur	27	amod	_	_
-27	Ostblock	Ostblock	PROPN	NN	Case=Acc|Gender=Neut|Number=Plur	29	compound	_	SpaceAfter=No
-28	-	-	PUNCT	$(	_	27	punct	_	SpaceAfter=No
-29	Länder	Land	NOUN	NN	Case=Acc|Gender=Neut|Number=Plur	23	nmod	_	_
-30	erörtern	erörtern	VERB	VVINF	VerbForm=Inf	0	root	_	SpaceAfter=No
-31	.	.	PUNCT	$.	_	30	punct	_	_
+# text = Die Staats- und Regierungschefs der sieben führenden Industrienationen (G7) und die EG-Kommission wollen die Lage der Weltwirtschaft und Hilfen für die ehemaligen Ostblock-Länder erörtern.
+1	Die	der	DET	ART	Case=Nom|Definite=Def|Gender=Masc|Number=Plur|PronType=Art	2	dep	_	FixTigerDep=Yes
+2	Staats	Staat	NOUN	TRUNC	Case=Nom|Gender=Masc|Number=Plur	31	compound	_	SpaceAfter=No
+3	-	-	PUNCT	$(	_	5	punct	_	_
+4	und	und	CCONJ	KON	_	5	cc	_	_
+5	Regierungschefs	Regierungschef	NOUN	NN	Case=Nom|Gender=Masc|Number=Plur	2	conj	_	_
+6	der	der	DET	ART	Case=Gen|Definite=Def|Gender=Fem|Number=Plur|PronType=Art	9	det	_	_
+7	sieben	sieben	NUM	CARD	NumType=Card	9	nummod	_	_
+8	führenden	führend	ADJ	ADJA	Case=Gen|Gender=Fem|Number=Plur	9	amod	_	_
+9	Industrienationen	Industrienation	NOUN	NN	Case=Gen|Gender=Fem|Number=Plur	2	nmod	_	_
+10	(	(	PUNCT	$(	_	11	punct	_	SpaceAfter=No
+11	G7	G7	PROPN	NE	Case=Nom|Gender=Fem|Number=Plur	9	appos	_	SpaceAfter=No
+12	)	)	PUNCT	$(	_	11	punct	_	_
+13	und	und	CCONJ	KON	_	15	cc	_	_
+14	die	der	DET	ART	Case=Nom|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	15	det	_	_
+15	EG	EG	PROPN	NN	Case=Nom|Gender=Fem|Number=Sing	17	compound	_	SpaceAfter=No
+16	-	-	PUNCT	$(	_	15	punct	_	SpaceAfter=No
+17	Kommission	Kommission	NOUN	NN	Case=Nom|Gender=Fem|Number=Sing	2	conj	_	_
+18	wollen	wollen	AUX	VMFIN	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	31	aux	_	_
+19	die	der	DET	ART	Case=Acc|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	20	det	_	_
+20	Lage	Lage	NOUN	NN	Case=Acc|Gender=Fem|Number=Sing	31	obj	_	_
+21	der	der	DET	ART	Case=Gen|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	22	det	_	_
+22	Weltwirtschaft	Weltwirtschaft	NOUN	NN	Case=Gen|Gender=Fem|Number=Sing	20	nmod	_	_
+23	und	und	CCONJ	KON	_	24	cc	_	_
+24	Hilfen	Hilfe	NOUN	NN	Case=Acc|Gender=Fem|Number=Plur	20	conj	_	_
+25	für	für	ADP	APPR	_	28	case	_	_
+26	die	der	DET	ART	Case=Acc|Definite=Def|Gender=Neut|Number=Plur|PronType=Art	28	det	_	_
+27	ehemaligen	ehemalig	ADJ	ADJA	Case=Acc|Gender=Neut|Number=Plur	28	amod	_	_
+28	Ostblock	Ostblock	PROPN	NN	Case=Acc|Gender=Neut|Number=Plur	30	compound	_	SpaceAfter=No
+29	-	-	PUNCT	$(	_	28	punct	_	SpaceAfter=No
+30	Länder	Land	NOUN	NN	Case=Acc|Gender=Neut|Number=Plur	24	nmod	_	_
+31	erörtern	erörtern	VERB	VVINF	VerbForm=Inf	0	root	_	SpaceAfter=No
+32	.	.	PUNCT	$.	_	31	punct	_	_
 
 # sent_id = test-s525
-# text = Staats- und Regierungschefs sollten auf ihrem Gipfeltreffen Mitte Dezember in Madrid über die Eckpunkte eines Szenarios für den Übergang in die Endstufe des Geldverbundes sowie über den endgültigen Namen der gemeinsamen Währung entscheiden, meint die Organisation des privaten Kreditgewerbes.
-1	Staats	Staat	NOUN	TRUNC	Case=Nom|Gender=Masc|Number=Plur	34	compound	_	SpaceAfter=No
-2	-	-	PUNCT	$(	_	4	punct	_	_
-3	und	und	CCONJ	KON	_	4	cc	_	_
-4	Regierungschefs	Regierungschef	NOUN	NN	Case=Nom|Gender=Masc|Number=Plur	1	conj	_	_
-5	sollten	sollen	AUX	VMFIN	Mood=Sub|Number=Plur|Person=3|Tense=Past|VerbForm=Fin	34	aux	_	_
-6	auf	auf	ADP	APPR	_	8	case	_	_
-7	ihrem	ihr	PRON	PPOSAT	Case=Dat|Gender=Neut|Number=Sing|Poss=Yes	8	det:poss	_	_
-8	Gipfeltreffen	Gipfeltreffen	NOUN	NN	Case=Dat|Gender=Neut|Number=Sing	34	obl	_	_
-9	Mitte	Mitte	NOUN	NN	Gender=Fem|Number=Sing	10	compound	_	_
-10	Dezember	Dezember	PROPN	NN	Gender=Masc|Number=Sing	8	nmod	_	_
-11	in	in	ADP	APPR	_	12	case	_	_
-12	Madrid	Madrid	PROPN	NE	Case=Dat|Gender=Neut|Number=Sing	8	nmod	_	_
-13	über	über	ADP	APPR	_	15	case	_	_
-14	die	der	DET	ART	Case=Acc|Definite=Def|Gender=Masc|Number=Plur|PronType=Art	15	det	_	_
-15	Eckpunkte	Eckpunkt	NOUN	NN	Case=Acc|Gender=Masc|Number=Plur	34	obl	_	_
-16	eines	ein	DET	ART	Case=Gen|Definite=Ind|Gender=Neut|Number=Sing|PronType=Art	17	det	_	_
-17	Szenarios	Szenario	NOUN	NN	Case=Gen|Gender=Neut|Number=Sing	15	nmod	_	_
-18	für	für	ADP	APPR	_	20	case	_	_
-19	den	der	DET	ART	Case=Acc|Definite=Def|Gender=Masc|Number=Sing|PronType=Art	20	det	_	_
-20	Übergang	Übergang	NOUN	NN	Case=Acc|Gender=Masc|Number=Sing	17	nmod	_	_
-21	in	in	ADP	APPR	_	23	case	_	_
-22	die	der	DET	ART	Case=Acc|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	23	det	_	_
-23	Endstufe	Endstufe	NOUN	NN	Case=Acc|Gender=Fem|Number=Sing	20	nmod	_	_
-24	des	der	DET	ART	Case=Gen|Definite=Def|Gender=Masc|Number=Sing|PronType=Art	25	det	_	_
-25	Geldverbundes	Geldverbund	NOUN	NN	Case=Gen|Gender=Masc|Number=Sing	23	nmod	_	_
-26	sowie	sowie	CCONJ	KON	_	34	cc	_	_
-27	über	über	ADP	APPR	_	30	case	_	_
-28	den	der	DET	ART	Case=Acc|Definite=Def|Gender=Masc|Number=Sing|PronType=Art	30	det	_	_
-29	endgültigen	endgültig	ADJ	ADJA	Case=Acc|Gender=Masc|Number=Sing	30	amod	_	_
-30	Namen	Name	NOUN	NN	Case=Acc|Gender=Masc|Number=Sing	34	obl	_	_
-31	der	der	DET	ART	Case=Gen|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	33	det	_	_
-32	gemeinsamen	gemeinsam	ADJ	ADJA	Case=Gen|Gender=Fem|Number=Sing	33	amod	_	_
-33	Währung	Währung	NOUN	NN	Case=Gen|Gender=Fem|Number=Sing	30	nmod	_	_
-34	entscheiden	entscheiden	VERB	VVINF	VerbForm=Inf	36	ccomp	_	SpaceAfter=No
-35	,	,	PUNCT	$,	_	36	punct	_	_
-36	meint	meinen	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	0	root	_	_
-37	die	der	DET	ART	Case=Nom|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	38	det	_	_
-38	Organisation	Organisation	NOUN	NN	Case=Nom|Gender=Fem|Number=Sing	36	nsubj	_	_
-39	des	der	DET	ART	Case=Gen|Definite=Def|Gender=Neut|Number=Sing|PronType=Art	41	det	_	_
-40	privaten	privat	ADJ	ADJA	Case=Gen|Gender=Neut|Number=Sing	41	amod	_	_
-41	Kreditgewerbes	Kreditgewerbe	NOUN	NN	Case=Gen|Gender=Neut|Number=Sing	38	nmod	_	SpaceAfter=No
-42	.	.	PUNCT	$.	_	36	punct	_	_
+# text = Die Staats- und Regierungschefs sollten auf ihrem Gipfeltreffen Mitte Dezember in Madrid über die Eckpunkte eines Szenarios für den Übergang in die Endstufe des Geldverbundes sowie über den endgültigen Namen der gemeinsamen Währung entscheiden, meint die Organisation des privaten Kreditgewerbes.
+1	Die	der	DET	ART	Case=Nom|Definite=Def|Gender=Masc|Number=Plur|PronType=Art	2	dep	_	FixTigerDep=Yes
+2	Staats	Staat	NOUN	TRUNC	Case=Nom|Gender=Masc|Number=Plur	35	compound	_	SpaceAfter=No
+3	-	-	PUNCT	$(	_	5	punct	_	_
+4	und	und	CCONJ	KON	_	5	cc	_	_
+5	Regierungschefs	Regierungschef	NOUN	NN	Case=Nom|Gender=Masc|Number=Plur	2	conj	_	_
+6	sollten	sollen	AUX	VMFIN	Mood=Sub|Number=Plur|Person=3|Tense=Past|VerbForm=Fin	35	aux	_	_
+7	auf	auf	ADP	APPR	_	9	case	_	_
+8	ihrem	ihr	PRON	PPOSAT	Case=Dat|Gender=Neut|Number=Sing|Poss=Yes	9	det:poss	_	_
+9	Gipfeltreffen	Gipfeltreffen	NOUN	NN	Case=Dat|Gender=Neut|Number=Sing	35	obl	_	_
+10	Mitte	Mitte	NOUN	NN	Gender=Fem|Number=Sing	11	compound	_	_
+11	Dezember	Dezember	PROPN	NN	Gender=Masc|Number=Sing	9	nmod	_	_
+12	in	in	ADP	APPR	_	13	case	_	_
+13	Madrid	Madrid	PROPN	NE	Case=Dat|Gender=Neut|Number=Sing	9	nmod	_	_
+14	über	über	ADP	APPR	_	16	case	_	_
+15	die	der	DET	ART	Case=Acc|Definite=Def|Gender=Masc|Number=Plur|PronType=Art	16	det	_	_
+16	Eckpunkte	Eckpunkt	NOUN	NN	Case=Acc|Gender=Masc|Number=Plur	35	obl	_	_
+17	eines	ein	DET	ART	Case=Gen|Definite=Ind|Gender=Neut|Number=Sing|PronType=Art	18	det	_	_
+18	Szenarios	Szenario	NOUN	NN	Case=Gen|Gender=Neut|Number=Sing	16	nmod	_	_
+19	für	für	ADP	APPR	_	21	case	_	_
+20	den	der	DET	ART	Case=Acc|Definite=Def|Gender=Masc|Number=Sing|PronType=Art	21	det	_	_
+21	Übergang	Übergang	NOUN	NN	Case=Acc|Gender=Masc|Number=Sing	18	nmod	_	_
+22	in	in	ADP	APPR	_	24	case	_	_
+23	die	der	DET	ART	Case=Acc|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	24	det	_	_
+24	Endstufe	Endstufe	NOUN	NN	Case=Acc|Gender=Fem|Number=Sing	21	nmod	_	_
+25	des	der	DET	ART	Case=Gen|Definite=Def|Gender=Masc|Number=Sing|PronType=Art	26	det	_	_
+26	Geldverbundes	Geldverbund	NOUN	NN	Case=Gen|Gender=Masc|Number=Sing	24	nmod	_	_
+27	sowie	sowie	CCONJ	KON	_	35	cc	_	_
+28	über	über	ADP	APPR	_	31	case	_	_
+29	den	der	DET	ART	Case=Acc|Definite=Def|Gender=Masc|Number=Sing|PronType=Art	31	det	_	_
+30	endgültigen	endgültig	ADJ	ADJA	Case=Acc|Gender=Masc|Number=Sing	31	amod	_	_
+31	Namen	Name	NOUN	NN	Case=Acc|Gender=Masc|Number=Sing	35	obl	_	_
+32	der	der	DET	ART	Case=Gen|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	34	det	_	_
+33	gemeinsamen	gemeinsam	ADJ	ADJA	Case=Gen|Gender=Fem|Number=Sing	34	amod	_	_
+34	Währung	Währung	NOUN	NN	Case=Gen|Gender=Fem|Number=Sing	31	nmod	_	_
+35	entscheiden	entscheiden	VERB	VVINF	VerbForm=Inf	37	ccomp	_	SpaceAfter=No
+36	,	,	PUNCT	$,	_	37	punct	_	_
+37	meint	meinen	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	0	root	_	_
+38	die	der	DET	ART	Case=Nom|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	39	det	_	_
+39	Organisation	Organisation	NOUN	NN	Case=Nom|Gender=Fem|Number=Sing	37	nsubj	_	_
+40	des	der	DET	ART	Case=Gen|Definite=Def|Gender=Neut|Number=Sing|PronType=Art	42	det	_	_
+41	privaten	privat	ADJ	ADJA	Case=Gen|Gender=Neut|Number=Sing	42	amod	_	_
+42	Kreditgewerbes	Kreditgewerbe	NOUN	NN	Case=Gen|Gender=Neut|Number=Sing	39	nmod	_	SpaceAfter=No
+43	.	.	PUNCT	$.	_	37	punct	_	_
 
 # sent_id = test-s526
-# text = Staatsbürger in anderen Republiken der Gemeinschaft Unabhängiger Staaten (GUS) müßten zwar beschützt werden, doch dürfe dies nur mit politischen Mitteln geschehen, sagte Jelzin in Moskau.
-1	Staatsbürger	Staatsbürger	NOUN	NN	Case=Nom|Gender=Masc|Number=Plur	14	nsubj:pass	_	_
-2	in	in	ADP	APPR	_	4	case	_	_
-3	anderen	anderer	ADJ	ADJA	Case=Dat|Gender=Fem|Number=Plur	4	amod	_	_
-4	Republiken	Republik	NOUN	NN	Case=Dat|Gender=Fem|Number=Plur	1	nmod	_	_
-5	der	der	DET	ART	Case=Gen|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	6	det	_	_
-6	Gemeinschaft	Gemeinschaft	PROPN	NN	Case=Gen|Gender=Fem|Number=Sing	4	nmod	_	_
-7	Unabhängiger	unabhängig	PROPN	ADJA	Case=Gen|Gender=Masc|Number=Plur	6	amod	_	_
-8	Staaten	Staat	PROPN	NN	Case=Gen|Gender=Masc|Number=Plur	6	flat	_	_
-9	(	(	PUNCT	$(	_	10	punct	_	SpaceAfter=No
-10	GUS	GUS	PROPN	NE	Case=Gen|Gender=Fem|Number=Sing	6	appos	_	SpaceAfter=No
-11	)	)	PUNCT	$(	_	10	punct	_	_
-12	müßten	müssen	AUX	VMFIN	Mood=Sub|Number=Plur|Person=3|Tense=Past|VerbForm=Fin	14	aux	_	_
-13	zwar	zwar	ADV	ADV	_	14	advmod	_	_
-14	beschützt	beschützen	VERB	VVPP	VerbForm=Part	26	ccomp	_	_
-15	werden	werden	AUX	VAINF	VerbForm=Inf|Voice=Pass	14	aux:pass	_	SpaceAfter=No
-16	,	,	PUNCT	$,	_	14	punct	_	_
-17	doch	doch	SCONJ	KON	_	24	mark	_	_
-18	dürfe	dürfen	AUX	VMFIN	Mood=Sub|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	24	aux	_	_
-19	dies	dies	PRON	PDS	Case=Nom|Gender=Neut|Number=Sing|PronType=Dem	24	nsubj	_	_
-20	nur	nur	ADV	ADV	_	24	advmod	_	_
-21	mit	mit	ADP	APPR	_	23	case	_	_
-22	politischen	politisch	ADJ	ADJA	Case=Dat|Gender=Neut|Number=Plur	23	amod	_	_
-23	Mitteln	Mittel	NOUN	NN	Case=Dat|Gender=Neut|Number=Plur	24	obl	_	_
-24	geschehen	geschehen	VERB	VVINF	VerbForm=Inf	14	advcl	_	SpaceAfter=No
-25	,	,	PUNCT	$,	_	26	punct	_	_
-26	sagte	sagen	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	0	root	_	_
-27	Jelzin	Jelzin	PROPN	NE	Case=Nom|Number=Sing	26	nsubj	_	_
-28	in	in	ADP	APPR	_	29	case	_	_
-29	Moskau	Moskau	PROPN	NE	Case=Dat|Gender=Neut|Number=Sing	26	obl	_	SpaceAfter=No
-30	.	.	PUNCT	$.	_	26	punct	_	_
+# text = Russische Staatsbürger in anderen Republiken der Gemeinschaft Unabhängiger Staaten (GUS) müßten zwar beschützt werden, doch dürfe dies nur mit politischen Mitteln geschehen, sagte Jelzin in Moskau.
+1	Russische	russisch	ADJ	ADJA	Case=Nom|Gender=Masc|Number=Plur	2	dep	_	FixTigerDep=Yes
+2	Staatsbürger	Staatsbürger	NOUN	NN	Case=Nom|Gender=Masc|Number=Plur	15	nsubj:pass	_	_
+3	in	in	ADP	APPR	_	5	case	_	_
+4	anderen	anderer	ADJ	ADJA	Case=Dat|Gender=Fem|Number=Plur	5	amod	_	_
+5	Republiken	Republik	NOUN	NN	Case=Dat|Gender=Fem|Number=Plur	2	nmod	_	_
+6	der	der	DET	ART	Case=Gen|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	7	det	_	_
+7	Gemeinschaft	Gemeinschaft	PROPN	NN	Case=Gen|Gender=Fem|Number=Sing	5	nmod	_	_
+8	Unabhängiger	unabhängig	PROPN	ADJA	Case=Gen|Gender=Masc|Number=Plur	7	amod	_	_
+9	Staaten	Staat	PROPN	NN	Case=Gen|Gender=Masc|Number=Plur	7	flat	_	_
+10	(	(	PUNCT	$(	_	11	punct	_	SpaceAfter=No
+11	GUS	GUS	PROPN	NE	Case=Gen|Gender=Fem|Number=Sing	7	appos	_	SpaceAfter=No
+12	)	)	PUNCT	$(	_	11	punct	_	_
+13	müßten	müssen	AUX	VMFIN	Mood=Sub|Number=Plur|Person=3|Tense=Past|VerbForm=Fin	15	aux	_	_
+14	zwar	zwar	ADV	ADV	_	15	advmod	_	_
+15	beschützt	beschützen	VERB	VVPP	VerbForm=Part	27	ccomp	_	_
+16	werden	werden	AUX	VAINF	VerbForm=Inf|Voice=Pass	15	aux:pass	_	SpaceAfter=No
+17	,	,	PUNCT	$,	_	15	punct	_	_
+18	doch	doch	SCONJ	KON	_	25	mark	_	_
+19	dürfe	dürfen	AUX	VMFIN	Mood=Sub|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	25	aux	_	_
+20	dies	dies	PRON	PDS	Case=Nom|Gender=Neut|Number=Sing|PronType=Dem	25	nsubj	_	_
+21	nur	nur	ADV	ADV	_	25	advmod	_	_
+22	mit	mit	ADP	APPR	_	24	case	_	_
+23	politischen	politisch	ADJ	ADJA	Case=Dat|Gender=Neut|Number=Plur	24	amod	_	_
+24	Mitteln	Mittel	NOUN	NN	Case=Dat|Gender=Neut|Number=Plur	25	obl	_	_
+25	geschehen	geschehen	VERB	VVINF	VerbForm=Inf	15	advcl	_	SpaceAfter=No
+26	,	,	PUNCT	$,	_	27	punct	_	_
+27	sagte	sagen	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	0	root	_	_
+28	Jelzin	Jelzin	PROPN	NE	Case=Nom|Number=Sing	27	nsubj	_	_
+29	in	in	ADP	APPR	_	30	case	_	_
+30	Moskau	Moskau	PROPN	NE	Case=Dat|Gender=Neut|Number=Sing	27	obl	_	SpaceAfter=No
+31	.	.	PUNCT	$.	_	27	punct	_	_
 
 # sent_id = test-s527
-# text = Statistik erfaßt, wieviele Anhänger Kwasniewski und Walesa ohne das ``Nicht'', also ohne das Schreckbild ihres Gegners, auf sich vereinen könnten:
-1	Statistik	Statistik	NOUN	NN	Case=Nom|Gender=Fem|Number=Sing	2	nsubj	_	_
-2	erfaßt	erfassen	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	0	root	_	SpaceAfter=No
-3	,	,	PUNCT	$,	_	2	punct	_	_
-4	wieviele	wieviele	PRON	PWAT	Case=Acc|Gender=Masc|Number=Plur|PronType=Int	5	amod	_	_
-5	Anhänger	Anhänger	NOUN	NN	Case=Acc|Gender=Masc|Number=Plur	24	obj	_	_
-6	Kwasniewski	Kwasniewski	PROPN	NE	Case=Nom|Number=Sing	24	nsubj	_	_
-7	und	und	CCONJ	KON	_	8	cc	_	_
-8	Walesa	Walesa	PROPN	NE	Case=Nom|Number=Sing	6	conj	_	_
-9	ohne	ohne	ADP	APPR	_	12	case	_	_
-10	das	der	DET	ART	Case=Acc|Definite=Def|Gender=Neut|Number=Sing|PronType=Art	12	det	_	_
-11	``	``	PUNCT	$(	_	12	punct	_	SpaceAfter=No
-12	Nicht	Nicht	NOUN	PTKNEG	Polarity=Neg	24	obl	_	SpaceAfter=No
-13	''	''	PUNCT	$(	_	12	punct	_	SpaceAfter=No
-14	,	,	PUNCT	$,	_	24	punct	_	_
-15	also	also	ADV	ADV	_	18	advmod	_	_
-16	ohne	ohne	ADP	APPR	_	18	case	_	_
-17	das	der	DET	ART	Case=Acc|Definite=Def|Gender=Neut|Number=Sing|PronType=Art	18	det	_	_
-18	Schreckbild	Schreckbild	NOUN	NN	Case=Acc|Gender=Neut|Number=Sing	12	nmod	_	_
-19	ihres	ihr	PRON	PPOSAT	Case=Gen|Gender=Masc|Number=Sing|Poss=Yes	20	det:poss	_	_
-20	Gegners	Gegner	NOUN	NN	Case=Gen|Gender=Masc|Number=Sing	18	nmod	_	SpaceAfter=No
-21	,	,	PUNCT	$,	_	24	punct	_	_
-22	auf	auf	ADP	APPR	_	23	case	_	_
-23	sich	er|es|sie	PRON	PRF	Case=Acc|Number=Plur|Person=3|PronType=Prs|Reflex=Yes	24	obl	_	_
-24	vereinen	vereinen	VERB	VVINF	VerbForm=Inf	2	ccomp	_	_
-25	könnten	können	AUX	VMFIN	Mood=Sub|Number=Plur|Person=3|Tense=Past|VerbForm=Fin	24	aux	_	SpaceAfter=No
-26	:	:	PUNCT	$.	_	24	punct	_	_
+# text = Keine Statistik erfaßt, wieviele Anhänger Kwasniewski und Walesa ohne das ``Nicht'', also ohne das Schreckbild ihres Gegners, auf sich vereinen könnten:
+1	Keine	keiner	DET	PIAT	Case=Nom|Definite=Ind|Gender=Fem|Number=Sing|Polarity=Neg|PronType=Neg	2	dep	_	FixTigerDep=Yes
+2	Statistik	Statistik	NOUN	NN	Case=Nom|Gender=Fem|Number=Sing	3	nsubj	_	_
+3	erfaßt	erfassen	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	0	root	_	SpaceAfter=No
+4	,	,	PUNCT	$,	_	3	punct	_	_
+5	wieviele	wieviele	PRON	PWAT	Case=Acc|Gender=Masc|Number=Plur|PronType=Int	6	amod	_	_
+6	Anhänger	Anhänger	NOUN	NN	Case=Acc|Gender=Masc|Number=Plur	25	obj	_	_
+7	Kwasniewski	Kwasniewski	PROPN	NE	Case=Nom|Number=Sing	25	nsubj	_	_
+8	und	und	CCONJ	KON	_	9	cc	_	_
+9	Walesa	Walesa	PROPN	NE	Case=Nom|Number=Sing	7	conj	_	_
+10	ohne	ohne	ADP	APPR	_	13	case	_	_
+11	das	der	DET	ART	Case=Acc|Definite=Def|Gender=Neut|Number=Sing|PronType=Art	13	det	_	_
+12	``	``	PUNCT	$(	_	13	punct	_	SpaceAfter=No
+13	Nicht	Nicht	NOUN	PTKNEG	Polarity=Neg	25	obl	_	SpaceAfter=No
+14	''	''	PUNCT	$(	_	13	punct	_	SpaceAfter=No
+15	,	,	PUNCT	$,	_	25	punct	_	_
+16	also	also	ADV	ADV	_	19	advmod	_	_
+17	ohne	ohne	ADP	APPR	_	19	case	_	_
+18	das	der	DET	ART	Case=Acc|Definite=Def|Gender=Neut|Number=Sing|PronType=Art	19	det	_	_
+19	Schreckbild	Schreckbild	NOUN	NN	Case=Acc|Gender=Neut|Number=Sing	13	nmod	_	_
+20	ihres	ihr	PRON	PPOSAT	Case=Gen|Gender=Masc|Number=Sing|Poss=Yes	21	det:poss	_	_
+21	Gegners	Gegner	NOUN	NN	Case=Gen|Gender=Masc|Number=Sing	19	nmod	_	SpaceAfter=No
+22	,	,	PUNCT	$,	_	25	punct	_	_
+23	auf	auf	ADP	APPR	_	24	case	_	_
+24	sich	er|es|sie	PRON	PRF	Case=Acc|Number=Plur|Person=3|PronType=Prs|Reflex=Yes	25	obl	_	_
+25	vereinen	vereinen	VERB	VVINF	VerbForm=Inf	3	ccomp	_	_
+26	könnten	können	AUX	VMFIN	Mood=Sub|Number=Plur|Person=3|Tense=Past|VerbForm=Fin	25	aux	_	SpaceAfter=No
+27	:	:	PUNCT	$.	_	25	punct	_	_
 
 # sent_id = test-s528
-# text = Strafverfolger in Hannover sehen das anders.
-1	Strafverfolger	Strafverfolger	NOUN	NN	Case=Nom|Gender=Masc|Number=Plur	4	nsubj	_	_
-2	in	in	ADP	APPR	_	3	case	_	_
-3	Hannover	Hannover	PROPN	NE	Case=Dat|Gender=Neut|Number=Sing	1	nmod	_	_
-4	sehen	sehen	VERB	VVFIN	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	0	root	_	_
-5	das	der	PRON	PDS	Case=Acc|Gender=Neut|Number=Sing|PronType=Dem	4	obj	_	_
-6	anders	anders	ADV	ADV	_	4	advmod	_	SpaceAfter=No
-7	.	.	PUNCT	$.	_	4	punct	_	_
+# text = Die Strafverfolger in Hannover sehen das anders.
+1	Die	der	DET	ART	Case=Nom|Definite=Def|Gender=Masc|Number=Plur|PronType=Art	2	dep	_	FixTigerDep=Yes
+2	Strafverfolger	Strafverfolger	NOUN	NN	Case=Nom|Gender=Masc|Number=Plur	5	nsubj	_	_
+3	in	in	ADP	APPR	_	4	case	_	_
+4	Hannover	Hannover	PROPN	NE	Case=Dat|Gender=Neut|Number=Sing	2	nmod	_	_
+5	sehen	sehen	VERB	VVFIN	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	0	root	_	_
+6	das	der	PRON	PDS	Case=Acc|Gender=Neut|Number=Sing|PronType=Dem	5	obj	_	_
+7	anders	anders	ADV	ADV	_	5	advmod	_	SpaceAfter=No
+8	.	.	PUNCT	$.	_	5	punct	_	_
 
 # sent_id = test-s529
-# text = Stuart Card vom Xerox-Parc-Institut glaubt an die Neulinge:
-1	Stuart	Stuart	PROPN	NE	Case=Nom|Gender=Masc|Number=Sing	10	nsubj	_	_
-2	Card	Card	PROPN	NE	Case=Nom|Gender=Masc|Number=Sing	1	flat	_	_
-3-4	vom	_	_	_	_	_	_	_	_
-3	von	von	ADP	APPR	_	5	case	_	_
-4	dem	der	DET	ART	Case=Dat|Definite=Def|Gender=Masc|Number=Sing|PronType=Art	5	det	_	_
-5	Xerox	Xerox	PROPN	NN	Case=Dat|Gender=Neut|Number=Sing	7	compound	_	SpaceAfter=No
-6	-	-	PUNCT	$(	_	5	punct	_	SpaceAfter=No
-7	Parc	Parc	PROPN	NN	Case=Dat|Gender=Neut|Number=Sing	9	compound	_	SpaceAfter=No
-8	-	-	PUNCT	$(	_	7	punct	_	SpaceAfter=No
-9	Institut	Institut	NOUN	NN	Case=Dat|Gender=Neut|Number=Sing	1	nmod	_	_
-10	glaubt	glauben	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	0	root	_	_
-11	an	an	ADP	APPR	_	13	case	_	_
-12	die	der	DET	ART	Case=Acc|Definite=Def|Gender=Masc|Number=Plur|PronType=Art	13	det	_	_
-13	Neulinge	Neuling	NOUN	NN	Case=Acc|Gender=Masc|Number=Plur	10	obl	_	SpaceAfter=No
-14	:	:	PUNCT	$.	_	10	punct	_	_
+# text = Auch Stuart Card vom Xerox-Parc-Institut glaubt an die Neulinge:
+1	Auch	auch	ADV	ADV	_	2	dep	_	FixTigerDep=Yes
+2	Stuart	Stuart	PROPN	NE	Case=Nom|Gender=Masc|Number=Sing	11	nsubj	_	_
+3	Card	Card	PROPN	NE	Case=Nom|Gender=Masc|Number=Sing	2	flat	_	_
+4-5	vom	_	_	_	_	_	_	_	_
+4	von	von	ADP	APPR	_	6	case	_	_
+5	dem	der	DET	ART	Case=Dat|Definite=Def|Gender=Masc|Number=Sing|PronType=Art	6	det	_	_
+6	Xerox	Xerox	PROPN	NN	Case=Dat|Gender=Neut|Number=Sing	8	compound	_	SpaceAfter=No
+7	-	-	PUNCT	$(	_	6	punct	_	SpaceAfter=No
+8	Parc	Parc	PROPN	NN	Case=Dat|Gender=Neut|Number=Sing	10	compound	_	SpaceAfter=No
+9	-	-	PUNCT	$(	_	8	punct	_	SpaceAfter=No
+10	Institut	Institut	NOUN	NN	Case=Dat|Gender=Neut|Number=Sing	2	nmod	_	_
+11	glaubt	glauben	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	0	root	_	_
+12	an	an	ADP	APPR	_	14	case	_	_
+13	die	der	DET	ART	Case=Acc|Definite=Def|Gender=Masc|Number=Plur|PronType=Art	14	det	_	_
+14	Neulinge	Neuling	NOUN	NN	Case=Acc|Gender=Masc|Number=Plur	11	obl	_	SpaceAfter=No
+15	:	:	PUNCT	$.	_	11	punct	_	_
 
 # sent_id = test-s530
-# text = Student aus Sofia, der die Kulturstätten Europas mit Eurorail bereisen möchte -- er wird abgelehnt, denn er kann ja kaum die vorgeschriebene Geldsumme vorweisen.
-1	Student	Student	NOUN	NN	Case=Nom|Gender=Masc|Number=Sing	16	parataxis	_	_
-2	aus	aus	ADP	APPR	_	3	case	_	_
-3	Sofia	Sofia	PROPN	NE	Case=Dat|Gender=Neut|Number=Sing	1	nmod	_	SpaceAfter=No
-4	,	,	PUNCT	$,	_	16	punct	_	_
-5	der	der	PRON	PRELS	Case=Nom|Gender=Masc|Number=Sing|PronType=Rel	11	nsubj	_	_
-6	die	der	DET	ART	Case=Acc|Definite=Def|Gender=Fem|Number=Plur|PronType=Art	7	det	_	_
-7	Kulturstätten	Kulturstätte	NOUN	NN	Case=Acc|Gender=Fem|Number=Plur	11	obj	_	_
-8	Europas	Europa	PROPN	NE	Case=Gen|Gender=Neut|Number=Sing	7	nmod	_	_
-9	mit	mit	ADP	APPR	_	10	case	_	_
-10	Eurorail	Eurorail	PROPN	NE	Case=Dat|Number=Sing	11	obl	_	_
-11	bereisen	bereisen	VERB	VVINF	VerbForm=Inf	1	acl	_	_
-12	möchte	mögen	AUX	VMFIN	Mood=Sub|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	11	aux	_	_
-13	--	--	PUNCT	$(	_	11	punct	_	_
-14	er	er	PRON	PPER	Case=Nom|Gender=Masc|Number=Sing|Person=3|PronType=Prs	16	nsubj:pass	_	_
-15	wird	werden	AUX	VAFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin|Voice=Pass	16	aux:pass	_	_
-16	abgelehnt	ablehnen	VERB	VVPP	VerbForm=Part	0	root	_	SpaceAfter=No
-17	,	,	PUNCT	$,	_	16	punct	_	_
-18	denn	denn	SCONJ	KON	_	26	mark	_	_
-19	er	er	PRON	PPER	Case=Nom|Gender=Masc|Number=Sing|Person=3|PronType=Prs	26	nsubj	_	_
-20	kann	können	AUX	VMFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	26	aux	_	_
-21	ja	ja	ADV	ADV	_	22	advmod	_	_
-22	kaum	kaum	ADV	ADV	_	26	advmod	_	_
-23	die	der	DET	ART	Case=Acc|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	25	det	_	_
-24	vorgeschriebene	vorgeschrieben	ADJ	ADJA	Case=Acc|Gender=Fem|Number=Sing	25	amod	_	_
-25	Geldsumme	Geldsumme	NOUN	NN	Case=Acc|Gender=Fem|Number=Sing	26	obj	_	_
-26	vorweisen	vorweisen	VERB	VVINF	VerbForm=Inf	16	advcl	_	SpaceAfter=No
-27	.	.	PUNCT	$.	_	16	punct	_	_
+# text = Ein Student aus Sofia, der die Kulturstätten Europas mit Eurorail bereisen möchte -- er wird abgelehnt, denn er kann ja kaum die vorgeschriebene Geldsumme vorweisen.
+1	Ein	ein	DET	ART	Case=Nom|Definite=Ind|Gender=Masc|Number=Sing|PronType=Art	2	dep	_	FixTigerDep=Yes
+2	Student	Student	NOUN	NN	Case=Nom|Gender=Masc|Number=Sing	17	parataxis	_	_
+3	aus	aus	ADP	APPR	_	4	case	_	_
+4	Sofia	Sofia	PROPN	NE	Case=Dat|Gender=Neut|Number=Sing	2	nmod	_	SpaceAfter=No
+5	,	,	PUNCT	$,	_	17	punct	_	_
+6	der	der	PRON	PRELS	Case=Nom|Gender=Masc|Number=Sing|PronType=Rel	12	nsubj	_	_
+7	die	der	DET	ART	Case=Acc|Definite=Def|Gender=Fem|Number=Plur|PronType=Art	8	det	_	_
+8	Kulturstätten	Kulturstätte	NOUN	NN	Case=Acc|Gender=Fem|Number=Plur	12	obj	_	_
+9	Europas	Europa	PROPN	NE	Case=Gen|Gender=Neut|Number=Sing	8	nmod	_	_
+10	mit	mit	ADP	APPR	_	11	case	_	_
+11	Eurorail	Eurorail	PROPN	NE	Case=Dat|Number=Sing	12	obl	_	_
+12	bereisen	bereisen	VERB	VVINF	VerbForm=Inf	2	acl	_	_
+13	möchte	mögen	AUX	VMFIN	Mood=Sub|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	12	aux	_	_
+14	--	--	PUNCT	$(	_	12	punct	_	_
+15	er	er	PRON	PPER	Case=Nom|Gender=Masc|Number=Sing|Person=3|PronType=Prs	17	nsubj:pass	_	_
+16	wird	werden	AUX	VAFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin|Voice=Pass	17	aux:pass	_	_
+17	abgelehnt	ablehnen	VERB	VVPP	VerbForm=Part	0	root	_	SpaceAfter=No
+18	,	,	PUNCT	$,	_	17	punct	_	_
+19	denn	denn	SCONJ	KON	_	27	mark	_	_
+20	er	er	PRON	PPER	Case=Nom|Gender=Masc|Number=Sing|Person=3|PronType=Prs	27	nsubj	_	_
+21	kann	können	AUX	VMFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	27	aux	_	_
+22	ja	ja	ADV	ADV	_	23	advmod	_	_
+23	kaum	kaum	ADV	ADV	_	27	advmod	_	_
+24	die	der	DET	ART	Case=Acc|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	26	det	_	_
+25	vorgeschriebene	vorgeschrieben	ADJ	ADJA	Case=Acc|Gender=Fem|Number=Sing	26	amod	_	_
+26	Geldsumme	Geldsumme	NOUN	NN	Case=Acc|Gender=Fem|Number=Sing	27	obj	_	_
+27	vorweisen	vorweisen	VERB	VVINF	VerbForm=Inf	17	advcl	_	SpaceAfter=No
+28	.	.	PUNCT	$.	_	17	punct	_	_
 
 # sent_id = test-s531
-# text = Stunden später wurde in Belfast ein Katholik angeschossen und schwer verletzt.
-1	Stunden	Stunde	NOUN	NN	Case=Acc|Gender=Fem|Number=Plur	8	obl	_	_
-2	später	spät	ADV	ADJD	_	1	advmod	_	_
-3	wurde	werden	AUX	VAFIN	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin|Voice=Pass	8	aux:pass	_	_
-4	in	in	ADP	APPR	_	5	case	_	_
-5	Belfast	Belfast	PROPN	NE	Case=Dat|Gender=Neut|Number=Sing	8	obl	_	_
-6	ein	ein	DET	ART	Case=Nom|Definite=Ind|Gender=Masc|Number=Sing|PronType=Art	7	det	_	_
-7	Katholik	Katholik	NOUN	NN	Case=Nom|Gender=Masc|Number=Sing	8	nsubj:pass	_	_
-8	angeschossen	anschießen	VERB	VVPP	VerbForm=Part	0	root	_	_
-9	und	und	CCONJ	KON	_	11	cc	_	_
-10	schwer	schwer	ADV	ADJD	_	11	advmod	_	_
-11	verletzt	verletzen	VERB	VVPP	VerbForm=Part	8	conj	_	SpaceAfter=No
-12	.	.	PUNCT	$.	_	8	punct	_	_
+# text = Wenige Stunden später wurde in Belfast ein Katholik angeschossen und schwer verletzt.
+1	Wenige	weniger	DET	PIAT	Case=Acc|Definite=Ind|Gender=Fem|Number=Plur|PronType=Ind	2	dep	_	FixTigerDep=Yes
+2	Stunden	Stunde	NOUN	NN	Case=Acc|Gender=Fem|Number=Plur	9	obl	_	_
+3	später	spät	ADV	ADJD	_	2	advmod	_	_
+4	wurde	werden	AUX	VAFIN	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin|Voice=Pass	9	aux:pass	_	_
+5	in	in	ADP	APPR	_	6	case	_	_
+6	Belfast	Belfast	PROPN	NE	Case=Dat|Gender=Neut|Number=Sing	9	obl	_	_
+7	ein	ein	DET	ART	Case=Nom|Definite=Ind|Gender=Masc|Number=Sing|PronType=Art	8	det	_	_
+8	Katholik	Katholik	NOUN	NN	Case=Nom|Gender=Masc|Number=Sing	9	nsubj:pass	_	_
+9	angeschossen	anschießen	VERB	VVPP	VerbForm=Part	0	root	_	_
+10	und	und	CCONJ	KON	_	12	cc	_	_
+11	schwer	schwer	ADV	ADJD	_	12	advmod	_	_
+12	verletzt	verletzen	VERB	VVPP	VerbForm=Part	9	conj	_	SpaceAfter=No
+13	.	.	PUNCT	$.	_	9	punct	_	_
 
 # sent_id = test-s532
-# text = Sturm in der Ostsee hat an die Strände Mecklenburg-Vorpommerns scharfe Flak-Granaten und Panzerfäuste gespült.
-1	Sturm	Sturm	NOUN	NN	Case=Nom|Gender=Masc|Number=Sing	18	nsubj	_	_
-2	in	in	ADP	APPR	_	4	case	_	_
-3	der	der	DET	ART	Case=Dat|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	4	det	_	_
-4	Ostsee	Ostsee	NOUN	NE	Case=Dat|Gender=Fem|Number=Sing	1	nmod	_	_
-5	hat	haben	AUX	VAFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	18	aux	_	_
-6	an	an	ADP	APPR	_	8	case	_	_
-7	die	der	DET	ART	Case=Acc|Definite=Def|Gender=Masc|Number=Plur|PronType=Art	8	det	_	_
-8	Strände	Strand	NOUN	NN	Case=Acc|Gender=Masc|Number=Plur	18	obl	_	_
-9	Mecklenburg	Mecklenburg	PROPN	NE	Case=Gen|Gender=Neut|Number=Sing	8	nmod	_	SpaceAfter=No
-10	-	-	PUNCT	$(	_	9	punct	_	SpaceAfter=No
-11	Vorpommerns	Vorpommern	PROPN	NE	Case=Gen|Gender=Neut|Number=Sing	9	flat	_	_
-12	scharfe	scharf	ADJ	ADJA	Case=Acc|Gender=Fem|Number=Plur	15	amod	_	_
-13	Flak	Flak	NOUN	NN	Case=Acc|Gender=Fem|Number=Plur	15	compound	_	SpaceAfter=No
-14	-	-	PUNCT	$(	_	13	punct	_	SpaceAfter=No
-15	Granaten	Granat|Granate	NOUN	NN	Case=Acc|Gender=Fem|Number=Plur	18	obj	_	_
-16	und	und	CCONJ	KON	_	17	cc	_	_
-17	Panzerfäuste	Panzerfaust	NOUN	NN	Case=Acc|Gender=Fem|Number=Plur	15	conj	_	_
-18	gespült	spülen	VERB	VVPP	VerbForm=Part	0	root	_	SpaceAfter=No
-19	.	.	PUNCT	$.	_	18	punct	_	_
+# text = Der Sturm in der Ostsee hat an die Strände Mecklenburg-Vorpommerns scharfe Flak-Granaten und Panzerfäuste gespült.
+1	Der	der	DET	ART	Case=Nom|Definite=Def|Gender=Masc|Number=Sing|PronType=Art	2	dep	_	FixTigerDep=Yes
+2	Sturm	Sturm	NOUN	NN	Case=Nom|Gender=Masc|Number=Sing	19	nsubj	_	_
+3	in	in	ADP	APPR	_	5	case	_	_
+4	der	der	DET	ART	Case=Dat|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	5	det	_	_
+5	Ostsee	Ostsee	NOUN	NE	Case=Dat|Gender=Fem|Number=Sing	2	nmod	_	_
+6	hat	haben	AUX	VAFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	19	aux	_	_
+7	an	an	ADP	APPR	_	9	case	_	_
+8	die	der	DET	ART	Case=Acc|Definite=Def|Gender=Masc|Number=Plur|PronType=Art	9	det	_	_
+9	Strände	Strand	NOUN	NN	Case=Acc|Gender=Masc|Number=Plur	19	obl	_	_
+10	Mecklenburg	Mecklenburg	PROPN	NE	Case=Gen|Gender=Neut|Number=Sing	9	nmod	_	SpaceAfter=No
+11	-	-	PUNCT	$(	_	10	punct	_	SpaceAfter=No
+12	Vorpommerns	Vorpommern	PROPN	NE	Case=Gen|Gender=Neut|Number=Sing	10	flat	_	_
+13	scharfe	scharf	ADJ	ADJA	Case=Acc|Gender=Fem|Number=Plur	16	amod	_	_
+14	Flak	Flak	NOUN	NN	Case=Acc|Gender=Fem|Number=Plur	16	compound	_	SpaceAfter=No
+15	-	-	PUNCT	$(	_	14	punct	_	SpaceAfter=No
+16	Granaten	Granat|Granate	NOUN	NN	Case=Acc|Gender=Fem|Number=Plur	19	obj	_	_
+17	und	und	CCONJ	KON	_	18	cc	_	_
+18	Panzerfäuste	Panzerfaust	NOUN	NN	Case=Acc|Gender=Fem|Number=Plur	16	conj	_	_
+19	gespült	spülen	VERB	VVPP	VerbForm=Part	0	root	_	SpaceAfter=No
+20	.	.	PUNCT	$.	_	19	punct	_	_
 
 # sent_id = test-s533
-# text = Tage nach dem Mordanschlag auf Israels Ministerpräsidenten Yitzhak Rabin hat die Polizei zwei weitere Verdächtige festgenommen.
-1	Tage	Tag	NOUN	NN	Case=Acc|Gender=Masc|Number=Plur	4	compound	_	_
-2	nach	nach	ADP	APPR	_	4	case	_	_
-3	dem	der	DET	ART	Case=Dat|Definite=Def|Gender=Masc|Number=Sing|PronType=Art	4	det	_	_
-4	Mordanschlag	Mordanschlag	NOUN	NN	Case=Dat|Gender=Masc|Number=Sing	16	obl	_	_
-5	auf	auf	ADP	APPR	_	7	case	_	_
-6	Israels	Israel	PROPN	NE	Case=Gen|Gender=Neut|Number=Sing	7	nmod	_	_
-7	Ministerpräsidenten	Ministerpräsident	NOUN	NN	Case=Acc|Gender=Masc|Number=Sing	4	nmod	_	_
-8	Yitzhak	Yitzhak	PROPN	NE	Case=Nom|Gender=Masc|Number=Sing	7	appos	_	_
-9	Rabin	Rabin	PROPN	NE	Case=Nom|Gender=Masc|Number=Sing	8	flat	_	_
-10	hat	haben	AUX	VAFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	16	aux	_	_
-11	die	der	DET	ART	Case=Nom|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	12	det	_	_
-12	Polizei	Polizei	NOUN	NN	Case=Nom|Gender=Fem|Number=Sing	16	nsubj	_	_
-13	zwei	zwei	NUM	CARD	NumType=Card	14	nummod	_	_
-14	weitere	weit	ADJ	ADJA	Case=Acc|Number=Plur	15	amod	_	_
-15	Verdächtige	Verdächtige	NOUN	NN	Case=Acc|Number=Plur	16	obj	_	_
-16	festgenommen	festnehmen	VERB	VVPP	VerbForm=Part	0	root	_	SpaceAfter=No
-17	.	.	PUNCT	$.	_	16	punct	_	_
+# text = Fünf Tage nach dem Mordanschlag auf Israels Ministerpräsidenten Yitzhak Rabin hat die Polizei zwei weitere Verdächtige festgenommen.
+1	Fünf	fünf	NUM	CARD	NumType=Card	2	dep	_	FixTigerDep=Yes
+2	Tage	Tag	NOUN	NN	Case=Acc|Gender=Masc|Number=Plur	5	compound	_	_
+3	nach	nach	ADP	APPR	_	5	case	_	_
+4	dem	der	DET	ART	Case=Dat|Definite=Def|Gender=Masc|Number=Sing|PronType=Art	5	det	_	_
+5	Mordanschlag	Mordanschlag	NOUN	NN	Case=Dat|Gender=Masc|Number=Sing	17	obl	_	_
+6	auf	auf	ADP	APPR	_	8	case	_	_
+7	Israels	Israel	PROPN	NE	Case=Gen|Gender=Neut|Number=Sing	8	nmod	_	_
+8	Ministerpräsidenten	Ministerpräsident	NOUN	NN	Case=Acc|Gender=Masc|Number=Sing	5	nmod	_	_
+9	Yitzhak	Yitzhak	PROPN	NE	Case=Nom|Gender=Masc|Number=Sing	8	appos	_	_
+10	Rabin	Rabin	PROPN	NE	Case=Nom|Gender=Masc|Number=Sing	9	flat	_	_
+11	hat	haben	AUX	VAFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	17	aux	_	_
+12	die	der	DET	ART	Case=Nom|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	13	det	_	_
+13	Polizei	Polizei	NOUN	NN	Case=Nom|Gender=Fem|Number=Sing	17	nsubj	_	_
+14	zwei	zwei	NUM	CARD	NumType=Card	15	nummod	_	_
+15	weitere	weit	ADJ	ADJA	Case=Acc|Number=Plur	16	amod	_	_
+16	Verdächtige	Verdächtige	NOUN	NN	Case=Acc|Number=Plur	17	obj	_	_
+17	festgenommen	festnehmen	VERB	VVPP	VerbForm=Part	0	root	_	SpaceAfter=No
+18	.	.	PUNCT	$.	_	17	punct	_	_
 
 # sent_id = test-s534
 # text = Thomas Westphal bemängelte, daß die von den Jungsozialisten geforderte Lehrstellenumlage ``(Wer nicht ausbildet, muß zahlen)'' nicht eindeutig erwähnt sei.
@@ -10465,232 +10655,241 @@
 26	.	.	PUNCT	$.	_	3	punct	_	_
 
 # sent_id = test-s535
-# text = Todesurteile gegen die neun Angeklagte und ihre Hinrichtung seien ``auf der Grundlage eines Urteils eines rechtmäßig konstituierten Gerichts vollzogen worden, das die neun Männer des Mordes für schuldig befunden hatte'', sagte der juristische Berater von Staatschef Sani Abacha, Hawalu Yadudu, nach Angaben der Nachrichtenagentur NAN am Montag in Abuja.
-1	Todesurteile	Todesurteil	NOUN	NN	Case=Nom|Gender=Neut|Number=Plur	20	nsubj:pass	_	_
-2	gegen	gegen	ADP	APPR	_	5	case	_	_
-3	die	der	DET	ART	Case=Acc|Definite=Def|Number=Plur|PronType=Art	5	det	_	_
-4	neun	neun	NUM	CARD	NumType=Card	5	nummod	_	_
-5	Angeklagte	Angeklagter	NOUN	NN	Case=Acc|Number=Plur	1	nmod	_	_
-6	und	und	CCONJ	KON	_	8	cc	_	_
-7	ihre	ihr	PRON	PPOSAT	Case=Nom|Gender=Fem|Number=Sing|Poss=Yes	8	det:poss	_	_
-8	Hinrichtung	Hinrichtung	NOUN	NN	Case=Nom|Gender=Fem|Number=Sing	1	conj	_	_
-9	seien	sein	AUX	VAFIN	Mood=Sub|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	20	aux	_	_
-10	``	``	PUNCT	$(	_	35	punct	_	SpaceAfter=No
-11	auf	auf	ADP	APPR	_	13	case	_	_
-12	der	der	DET	ART	Case=Dat|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	13	det	_	_
-13	Grundlage	Grundlage	NOUN	NN	Case=Dat|Gender=Fem|Number=Sing	20	obl	_	_
-14	eines	ein	DET	ART	Case=Gen|Definite=Ind|Gender=Neut|Number=Sing|PronType=Art	15	det	_	_
-15	Urteils	Urteil	NOUN	NN	Case=Gen|Gender=Neut|Number=Sing	13	nmod	_	_
-16	eines	ein	DET	ART	Case=Gen|Definite=Ind|Gender=Neut|Number=Sing|PronType=Art	19	det	_	_
-17	rechtmäßig	rechtmäßig	ADV	ADJD	_	18	advmod	_	_
-18	konstituierten	konstituiert	ADJ	ADJA	Case=Gen|Gender=Neut|Number=Sing	19	amod	_	_
-19	Gerichts	Gericht	NOUN	NN	Case=Gen|Gender=Neut|Number=Sing	15	nmod	_	_
-20	vollzogen	vollziehen	VERB	VVPP	VerbForm=Part	35	ccomp	_	_
-21	worden	werden	AUX	VAPP	VerbForm=Part|Voice=Pass	20	aux:pass	_	SpaceAfter=No
-22	,	,	PUNCT	$,	_	35	punct	_	_
-23	das	der	PRON	PRELS	Case=Nom|Gender=Neut|Number=Sing|PronType=Rel	31	nsubj	_	_
-24	die	der	DET	ART	Case=Acc|Definite=Def|Gender=Masc|Number=Plur|PronType=Art	26	det	_	_
-25	neun	neun	NUM	CARD	NumType=Card	26	nummod	_	_
-26	Männer	Mann	NOUN	NN	Case=Acc|Gender=Masc|Number=Plur	31	obj	_	_
-27	des	der	DET	ART	Case=Gen|Definite=Def|Gender=Masc|Number=Sing|PronType=Art	28	det	_	_
-28	Mordes	Mord	NOUN	NN	Case=Gen|Gender=Masc|Number=Sing	31	iobj	_	_
-29	für	für	ADP	APPR	_	31	case	_	_
-30	schuldig	schuldig	ADJ	ADJD	_	29	xcomp	_	_
-31	befunden	befinden	VERB	VVPP	VerbForm=Part	19	acl	_	_
-32	hatte	haben	AUX	VAFIN	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	31	aux	_	SpaceAfter=No
-33	''	''	PUNCT	$(	_	35	punct	_	SpaceAfter=No
-34	,	,	PUNCT	$,	_	35	punct	_	_
-35	sagte	sagen	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	0	root	_	_
-36	der	der	DET	ART	Case=Nom|Definite=Def|Gender=Masc|Number=Sing|PronType=Art	38	det	_	_
-37	juristische	juristisch	ADJ	ADJA	Case=Nom|Gender=Masc|Number=Sing	38	amod	_	_
-38	Berater	Berater	NOUN	NN	Case=Nom|Gender=Masc|Number=Sing	35	nsubj	_	_
-39	von	von	ADP	APPR	_	41	case	_	_
-40	Staatschef	Staatschef	NOUN	NN	Case=Nom|Gender=Masc|Number=Sing	41	compound	_	_
-41	Sani	Sani	PROPN	NE	Case=Nom|Gender=Masc|Number=Sing	38	nmod	_	_
-42	Abacha	Abacha	PROPN	NE	Case=Dat|Gender=Masc|Number=Sing	41	flat	_	SpaceAfter=No
-43	,	,	PUNCT	$,	_	35	punct	_	_
-44	Hawalu	Hawalu	PROPN	NE	Case=Nom|Gender=Masc|Number=Sing	41	appos	_	_
-45	Yadudu	Yadudu	PROPN	NE	Case=Nom|Gender=Masc|Number=Sing	44	flat	_	SpaceAfter=No
-46	,	,	PUNCT	$,	_	35	punct	_	_
-47	nach	nach	ADP	APPR	_	48	case	_	_
-48	Angaben	Angabe	NOUN	NN	Case=Dat|Gender=Fem|Number=Plur	35	obl	_	_
-49	der	der	DET	ART	Case=Gen|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	50	det	_	_
-50	Nachrichtenagentur	Nachrichtenagentur	NOUN	NN	Case=Gen|Gender=Fem|Number=Sing	48	nmod	_	_
-51	NAN	Nan	PROPN	NE	Case=Nom|Number=Sing	50	flat	_	_
-52-53	am	_	_	_	_	_	_	_	_
-52	an	an	ADP	APPR	_	54	case	_	_
-53	dem	der	DET	ART	Case=Dat|Definite=Def|Gender=Masc|Number=Sing|PronType=Art	54	det	_	_
-54	Montag	Montag	PROPN	NN	Case=Dat|Gender=Masc|Number=Sing	35	obl	_	_
-55	in	in	ADP	APPR	_	56	case	_	_
-56	Abuja	Abuja	PROPN	NE	Case=Dat|Gender=Neut|Number=Sing	35	obl	_	SpaceAfter=No
-57	.	.	PUNCT	$.	_	35	punct	_	_
+# text = Die Todesurteile gegen die neun Angeklagte und ihre Hinrichtung seien ``auf der Grundlage eines Urteils eines rechtmäßig konstituierten Gerichts vollzogen worden, das die neun Männer des Mordes für schuldig befunden hatte'', sagte der juristische Berater von Staatschef Sani Abacha, Hawalu Yadudu, nach Angaben der Nachrichtenagentur NAN am Montag in Abuja.
+1	Die	der	DET	ART	Case=Nom|Definite=Def|Gender=Neut|Number=Plur|PronType=Art	2	dep	_	FixTigerDep=Yes
+2	Todesurteile	Todesurteil	NOUN	NN	Case=Nom|Gender=Neut|Number=Plur	21	nsubj:pass	_	_
+3	gegen	gegen	ADP	APPR	_	6	case	_	_
+4	die	der	DET	ART	Case=Acc|Definite=Def|Number=Plur|PronType=Art	6	det	_	_
+5	neun	neun	NUM	CARD	NumType=Card	6	nummod	_	_
+6	Angeklagte	Angeklagter	NOUN	NN	Case=Acc|Number=Plur	2	nmod	_	_
+7	und	und	CCONJ	KON	_	9	cc	_	_
+8	ihre	ihr	PRON	PPOSAT	Case=Nom|Gender=Fem|Number=Sing|Poss=Yes	9	det:poss	_	_
+9	Hinrichtung	Hinrichtung	NOUN	NN	Case=Nom|Gender=Fem|Number=Sing	2	conj	_	_
+10	seien	sein	AUX	VAFIN	Mood=Sub|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	21	aux	_	_
+11	``	``	PUNCT	$(	_	36	punct	_	SpaceAfter=No
+12	auf	auf	ADP	APPR	_	14	case	_	_
+13	der	der	DET	ART	Case=Dat|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	14	det	_	_
+14	Grundlage	Grundlage	NOUN	NN	Case=Dat|Gender=Fem|Number=Sing	21	obl	_	_
+15	eines	ein	DET	ART	Case=Gen|Definite=Ind|Gender=Neut|Number=Sing|PronType=Art	16	det	_	_
+16	Urteils	Urteil	NOUN	NN	Case=Gen|Gender=Neut|Number=Sing	14	nmod	_	_
+17	eines	ein	DET	ART	Case=Gen|Definite=Ind|Gender=Neut|Number=Sing|PronType=Art	20	det	_	_
+18	rechtmäßig	rechtmäßig	ADV	ADJD	_	19	advmod	_	_
+19	konstituierten	konstituiert	ADJ	ADJA	Case=Gen|Gender=Neut|Number=Sing	20	amod	_	_
+20	Gerichts	Gericht	NOUN	NN	Case=Gen|Gender=Neut|Number=Sing	16	nmod	_	_
+21	vollzogen	vollziehen	VERB	VVPP	VerbForm=Part	36	ccomp	_	_
+22	worden	werden	AUX	VAPP	VerbForm=Part|Voice=Pass	21	aux:pass	_	SpaceAfter=No
+23	,	,	PUNCT	$,	_	36	punct	_	_
+24	das	der	PRON	PRELS	Case=Nom|Gender=Neut|Number=Sing|PronType=Rel	32	nsubj	_	_
+25	die	der	DET	ART	Case=Acc|Definite=Def|Gender=Masc|Number=Plur|PronType=Art	27	det	_	_
+26	neun	neun	NUM	CARD	NumType=Card	27	nummod	_	_
+27	Männer	Mann	NOUN	NN	Case=Acc|Gender=Masc|Number=Plur	32	obj	_	_
+28	des	der	DET	ART	Case=Gen|Definite=Def|Gender=Masc|Number=Sing|PronType=Art	29	det	_	_
+29	Mordes	Mord	NOUN	NN	Case=Gen|Gender=Masc|Number=Sing	32	iobj	_	_
+30	für	für	ADP	APPR	_	32	case	_	_
+31	schuldig	schuldig	ADJ	ADJD	_	30	xcomp	_	_
+32	befunden	befinden	VERB	VVPP	VerbForm=Part	20	acl	_	_
+33	hatte	haben	AUX	VAFIN	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	32	aux	_	SpaceAfter=No
+34	''	''	PUNCT	$(	_	36	punct	_	SpaceAfter=No
+35	,	,	PUNCT	$,	_	36	punct	_	_
+36	sagte	sagen	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	0	root	_	_
+37	der	der	DET	ART	Case=Nom|Definite=Def|Gender=Masc|Number=Sing|PronType=Art	39	det	_	_
+38	juristische	juristisch	ADJ	ADJA	Case=Nom|Gender=Masc|Number=Sing	39	amod	_	_
+39	Berater	Berater	NOUN	NN	Case=Nom|Gender=Masc|Number=Sing	36	nsubj	_	_
+40	von	von	ADP	APPR	_	42	case	_	_
+41	Staatschef	Staatschef	NOUN	NN	Case=Nom|Gender=Masc|Number=Sing	42	compound	_	_
+42	Sani	Sani	PROPN	NE	Case=Nom|Gender=Masc|Number=Sing	39	nmod	_	_
+43	Abacha	Abacha	PROPN	NE	Case=Dat|Gender=Masc|Number=Sing	42	flat	_	SpaceAfter=No
+44	,	,	PUNCT	$,	_	36	punct	_	_
+45	Hawalu	Hawalu	PROPN	NE	Case=Nom|Gender=Masc|Number=Sing	42	appos	_	_
+46	Yadudu	Yadudu	PROPN	NE	Case=Nom|Gender=Masc|Number=Sing	45	flat	_	SpaceAfter=No
+47	,	,	PUNCT	$,	_	36	punct	_	_
+48	nach	nach	ADP	APPR	_	49	case	_	_
+49	Angaben	Angabe	NOUN	NN	Case=Dat|Gender=Fem|Number=Plur	36	obl	_	_
+50	der	der	DET	ART	Case=Gen|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	51	det	_	_
+51	Nachrichtenagentur	Nachrichtenagentur	NOUN	NN	Case=Gen|Gender=Fem|Number=Sing	49	nmod	_	_
+52	NAN	NAN	PROPN	NE	Case=Nom|Number=Sing	51	flat	_	_
+53-54	am	_	_	_	_	_	_	_	_
+53	an	an	ADP	APPR	_	55	case	_	_
+54	dem	der	DET	ART	Case=Dat|Definite=Def|Gender=Masc|Number=Sing|PronType=Art	55	det	_	_
+55	Montag	Montag	PROPN	NN	Case=Dat|Gender=Masc|Number=Sing	36	obl	_	_
+56	in	in	ADP	APPR	_	57	case	_	_
+57	Abuja	Abuja	PROPN	NE	Case=Dat|Gender=Neut|Number=Sing	36	obl	_	SpaceAfter=No
+58	.	.	PUNCT	$.	_	36	punct	_	_
 
 # sent_id = test-s536
-# text = Unabdingbare Voraussetzung'', heißt es in dem Bericht, sei ein hohes Maß an dauerhafter Konvergenz der gesamtwirtschaftlichen Leistung dieser Staaten.
-1	Unabdingbare	unabdingbar	ADJ	ADJA	Case=Nom|Gender=Fem|Number=Sing	2	amod	_	_
-2	Voraussetzung	Voraussetzung	NOUN	NN	Case=Nom|Gender=Fem|Number=Sing	14	nsubj	_	SpaceAfter=No
-3	''	''	PUNCT	$(	_	14	punct	_	SpaceAfter=No
-4	,	,	PUNCT	$,	_	14	punct	_	_
-5	heißt	heißen	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	14	parataxis	_	_
-6	es	es	PRON	PPER	Case=Nom|Gender=Neut|Number=Sing|Person=3|PronType=Prs	5	nsubj	_	_
-7	in	in	ADP	APPR	_	9	case	_	_
-8	dem	der	DET	ART	Case=Dat|Definite=Def|Gender=Masc|Number=Sing|PronType=Art	9	det	_	_
-9	Bericht	Bericht	NOUN	NN	Case=Dat|Gender=Masc|Number=Sing	5	obl	_	SpaceAfter=No
-10	,	,	PUNCT	$,	_	14	punct	_	_
-11	sei	sein	AUX	VAFIN	Mood=Sub|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	14	cop	_	_
-12	ein	ein	DET	ART	Case=Nom|Definite=Ind|Gender=Neut|Number=Sing|PronType=Art	14	det	_	_
-13	hohes	hoch	ADJ	ADJA	Case=Nom|Gender=Neut|Number=Sing	14	amod	_	_
-14	Maß	Maß	NOUN	NN	Case=Nom|Gender=Neut|Number=Sing	0	root	_	_
-15	an	an	ADP	APPR	_	17	case	_	_
-16	dauerhafter	dauerhaft	ADJ	ADJA	Case=Dat|Gender=Fem|Number=Sing	17	amod	_	_
-17	Konvergenz	Konvergenz	NOUN	NN	Case=Dat|Gender=Fem|Number=Sing	14	nmod	_	_
-18	der	der	DET	ART	Case=Gen|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	20	det	_	_
-19	gesamtwirtschaftlichen	gesamtwirtschaftlich	ADJ	ADJA	Case=Gen|Gender=Fem|Number=Sing	20	amod	_	_
-20	Leistung	Leistung	NOUN	NN	Case=Gen|Gender=Fem|Number=Sing	17	nmod	_	_
-21	dieser	dies	PRON	PDAT	Case=Gen|Gender=Masc|Number=Plur|PronType=Dem	22	det	_	_
-22	Staaten	Staat	NOUN	NN	Case=Gen|Gender=Masc|Number=Plur	20	nmod	_	SpaceAfter=No
-23	.	.	PUNCT	$.	_	14	punct	_	_
+# text = ``Unabdingbare Voraussetzung'', heißt es in dem Bericht, sei ein hohes Maß an dauerhafter Konvergenz der gesamtwirtschaftlichen Leistung dieser Staaten.
+1	``	``	PUNCT	$(	_	2	punct	_	FixTigerDep=Yes|SpaceAfter=No
+2	Unabdingbare	unabdingbar	ADJ	ADJA	Case=Nom|Gender=Fem|Number=Sing	3	amod	_	_
+3	Voraussetzung	Voraussetzung	NOUN	NN	Case=Nom|Gender=Fem|Number=Sing	15	nsubj	_	SpaceAfter=No
+4	''	''	PUNCT	$(	_	15	punct	_	SpaceAfter=No
+5	,	,	PUNCT	$,	_	15	punct	_	_
+6	heißt	heißen	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	15	parataxis	_	_
+7	es	es	PRON	PPER	Case=Nom|Gender=Neut|Number=Sing|Person=3|PronType=Prs	6	nsubj	_	_
+8	in	in	ADP	APPR	_	10	case	_	_
+9	dem	der	DET	ART	Case=Dat|Definite=Def|Gender=Masc|Number=Sing|PronType=Art	10	det	_	_
+10	Bericht	Bericht	NOUN	NN	Case=Dat|Gender=Masc|Number=Sing	6	obl	_	SpaceAfter=No
+11	,	,	PUNCT	$,	_	15	punct	_	_
+12	sei	sein	AUX	VAFIN	Mood=Sub|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	15	cop	_	_
+13	ein	ein	DET	ART	Case=Nom|Definite=Ind|Gender=Neut|Number=Sing|PronType=Art	15	det	_	_
+14	hohes	hoch	ADJ	ADJA	Case=Nom|Gender=Neut|Number=Sing	15	amod	_	_
+15	Maß	Maß	NOUN	NN	Case=Nom|Gender=Neut|Number=Sing	0	root	_	_
+16	an	an	ADP	APPR	_	18	case	_	_
+17	dauerhafter	dauerhaft	ADJ	ADJA	Case=Dat|Gender=Fem|Number=Sing	18	amod	_	_
+18	Konvergenz	Konvergenz	NOUN	NN	Case=Dat|Gender=Fem|Number=Sing	15	nmod	_	_
+19	der	der	DET	ART	Case=Gen|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	21	det	_	_
+20	gesamtwirtschaftlichen	gesamtwirtschaftlich	ADJ	ADJA	Case=Gen|Gender=Fem|Number=Sing	21	amod	_	_
+21	Leistung	Leistung	NOUN	NN	Case=Gen|Gender=Fem|Number=Sing	18	nmod	_	_
+22	dieser	dies	PRON	PDAT	Case=Gen|Gender=Masc|Number=Plur|PronType=Dem	23	det	_	_
+23	Staaten	Staat	NOUN	NN	Case=Gen|Gender=Masc|Number=Plur	21	nmod	_	SpaceAfter=No
+24	.	.	PUNCT	$.	_	15	punct	_	_
 
 # sent_id = test-s537
-# text = unterstützt deshalb die in Gaza und im Westjordanland geplanten neun Industrieparks.
-1	unterstützt	unterstützen	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	0	root	_	_
-2	deshalb	deshalb	ADV	PAV	_	1	advmod	_	_
-3	die	der	DET	ART	Case=Acc|Definite=Def|Gender=Masc|Number=Plur|PronType=Art	12	det	_	_
-4	in	in	ADP	APPR	_	5	case	_	_
-5	Gaza	Gaza	PROPN	NE	Case=Dat|Gender=Neut|Number=Sing	10	nmod	_	_
-6	und	und	CCONJ	KON	_	9	cc	_	_
-7-8	im	_	_	_	_	_	_	_	_
-7	in	in	ADP	APPR	_	9	case	_	_
-8	dem	der	DET	ART	Case=Dat|Definite=Def|Gender=Neut|Number=Sing|PronType=Art	9	det	_	_
-9	Westjordanland	Westjordanland	PROPN	NE	Case=Dat|Gender=Neut|Number=Sing	5	conj	_	_
-10	geplanten	geplant	ADJ	ADJA	Case=Acc|Gender=Masc|Number=Plur	12	amod	_	_
-11	neun	neun	NUM	CARD	NumType=Card	12	nummod	_	_
-12	Industrieparks	Industriepark	NOUN	NN	Case=Acc|Gender=Masc|Number=Plur	1	obj	_	SpaceAfter=No
-13	.	.	PUNCT	$.	_	1	punct	_	_
+# text = Sie unterstützt deshalb die in Gaza und im Westjordanland geplanten neun Industrieparks.
+1	Sie	sie	PRON	PPER	Case=Nom|Gender=Fem|Number=Sing|Person=3|PronType=Prs	2	dep	_	FixTigerDep=Yes
+2	unterstützt	unterstützen	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	0	root	_	_
+3	deshalb	deshalb	ADV	PAV	_	2	advmod	_	_
+4	die	der	DET	ART	Case=Acc|Definite=Def|Gender=Masc|Number=Plur|PronType=Art	13	det	_	_
+5	in	in	ADP	APPR	_	6	case	_	_
+6	Gaza	Gaza	PROPN	NE	Case=Dat|Gender=Neut|Number=Sing	11	nmod	_	_
+7	und	und	CCONJ	KON	_	10	cc	_	_
+8-9	im	_	_	_	_	_	_	_	_
+8	in	in	ADP	APPR	_	10	case	_	_
+9	dem	der	DET	ART	Case=Dat|Definite=Def|Gender=Neut|Number=Sing|PronType=Art	10	det	_	_
+10	Westjordanland	Westjordanland	PROPN	NE	Case=Dat|Gender=Neut|Number=Sing	6	conj	_	_
+11	geplanten	geplant	ADJ	ADJA	Case=Acc|Gender=Masc|Number=Plur	13	amod	_	_
+12	neun	neun	NUM	CARD	NumType=Card	13	nummod	_	_
+13	Industrieparks	Industriepark	NOUN	NN	Case=Acc|Gender=Masc|Number=Plur	2	obj	_	SpaceAfter=No
+14	.	.	PUNCT	$.	_	2	punct	_	_
 
 # sent_id = test-s538
-# text = Ursache für die Schwierigkeiten der Firma nennt er ``außergewöhnliche Faktoren''.
-1	Ursache	Ursache	NOUN	NN	Case=Acc|Gender=Fem|Number=Sing	7	dep	_	_
-2	für	für	ADP	APPR	_	4	case	_	_
-3	die	der	DET	ART	Case=Acc|Definite=Def|Gender=Fem|Number=Plur|PronType=Art	4	det	_	_
-4	Schwierigkeiten	Schwierigkeit	NOUN	NN	Case=Acc|Gender=Fem|Number=Plur	1	nmod	_	_
-5	der	der	DET	ART	Case=Gen|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	6	det	_	_
-6	Firma	Firma	NOUN	NN	Case=Gen|Gender=Fem|Number=Sing	4	nmod	_	_
-7	nennt	nennen	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	0	root	_	_
-8	er	er	PRON	PPER	Case=Nom|Gender=Masc|Number=Sing|Person=3|PronType=Prs	7	nsubj	_	_
-9	``	``	PUNCT	$(	_	11	punct	_	SpaceAfter=No
-10	außergewöhnliche	außergewöhnlich	ADJ	ADJA	Case=Acc|Gender=Masc|Number=Plur	11	amod	_	_
-11	Faktoren	Faktor	NOUN	NN	Case=Acc|Gender=Masc|Number=Plur	7	obj	_	SpaceAfter=No
-12	''	''	PUNCT	$(	_	11	punct	_	SpaceAfter=No
-13	.	.	PUNCT	$.	_	7	punct	_	_
+# text = Als Ursache für die Schwierigkeiten der Firma nennt er ``außergewöhnliche Faktoren''.
+1	Als	Als	ADP	APPR	_	2	dep	_	FixTigerDep=Yes
+2	Ursache	Ursache	NOUN	NN	Case=Acc|Gender=Fem|Number=Sing	8	dep	_	_
+3	für	für	ADP	APPR	_	5	case	_	_
+4	die	der	DET	ART	Case=Acc|Definite=Def|Gender=Fem|Number=Plur|PronType=Art	5	det	_	_
+5	Schwierigkeiten	Schwierigkeit	NOUN	NN	Case=Acc|Gender=Fem|Number=Plur	2	nmod	_	_
+6	der	der	DET	ART	Case=Gen|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	7	det	_	_
+7	Firma	Firma	NOUN	NN	Case=Gen|Gender=Fem|Number=Sing	5	nmod	_	_
+8	nennt	nennen	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	0	root	_	_
+9	er	er	PRON	PPER	Case=Nom|Gender=Masc|Number=Sing|Person=3|PronType=Prs	8	nsubj	_	_
+10	``	``	PUNCT	$(	_	12	punct	_	SpaceAfter=No
+11	außergewöhnliche	außergewöhnlich	ADJ	ADJA	Case=Acc|Gender=Masc|Number=Plur	12	amod	_	_
+12	Faktoren	Faktor	NOUN	NN	Case=Acc|Gender=Masc|Number=Plur	8	obj	_	SpaceAfter=No
+13	''	''	PUNCT	$(	_	12	punct	_	SpaceAfter=No
+14	.	.	PUNCT	$.	_	8	punct	_	_
 
 # sent_id = test-s539
-# text = US-Handelsbeauftragte Mickey Kantor äußerte sich über das bisherige Ergebnis zufrieden:
-1	US	US	PROPN	NN	Case=Nom|Gender=Masc|Number=Sing	3	compound	_	SpaceAfter=No
-2	-	-	PUNCT	$(	_	1	punct	_	SpaceAfter=No
-3	Handelsbeauftragte	Handelsbeauftragte	NOUN	NN	Case=Nom|Gender=Masc|Number=Sing	6	nsubj	_	_
-4	Mickey	Mickey	PROPN	NE	Case=Nom|Gender=Masc|Number=Sing	1	appos	_	_
-5	Kantor	Kantor	PROPN	NE	Case=Nom|Gender=Masc|Number=Sing	4	flat	_	_
-6	äußerte	äußern	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	0	root	_	_
-7	sich	er|es|sie	PRON	PRF	Case=Acc|Number=Sing|Person=3|PronType=Prs|Reflex=Yes	6	obj	_	_
-8	über	über	ADP	APPR	_	11	case	_	_
-9	das	der	DET	ART	Case=Acc|Definite=Def|Gender=Neut|Number=Sing|PronType=Art	11	det	_	_
-10	bisherige	bisherig	ADJ	ADJA	Case=Acc|Gender=Neut|Number=Sing	11	amod	_	_
-11	Ergebnis	Ergebnis	NOUN	NN	Case=Acc|Gender=Neut|Number=Sing	6	obl	_	_
-12	zufrieden	zufrieden	ADJ	ADJD	_	6	xcomp	_	SpaceAfter=No
-13	:	:	PUNCT	$.	_	6	punct	_	_
+# text = Der US-Handelsbeauftragte Mickey Kantor äußerte sich über das bisherige Ergebnis zufrieden:
+1	Der	der	DET	ART	Case=Nom|Definite=Def|Gender=Masc|Number=Sing|PronType=Art	2	dep	_	FixTigerDep=Yes
+2	US	US	PROPN	NN	Case=Nom|Gender=Masc|Number=Sing	4	compound	_	SpaceAfter=No
+3	-	-	PUNCT	$(	_	2	punct	_	SpaceAfter=No
+4	Handelsbeauftragte	Handelsbeauftragte	NOUN	NN	Case=Nom|Gender=Masc|Number=Sing	7	nsubj	_	_
+5	Mickey	Mickey	PROPN	NE	Case=Nom|Gender=Masc|Number=Sing	2	appos	_	_
+6	Kantor	Kantor	PROPN	NE	Case=Nom|Gender=Masc|Number=Sing	5	flat	_	_
+7	äußerte	äußern	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	0	root	_	_
+8	sich	er|es|sie	PRON	PRF	Case=Acc|Number=Sing|Person=3|PronType=Prs|Reflex=Yes	7	obj	_	_
+9	über	über	ADP	APPR	_	12	case	_	_
+10	das	der	DET	ART	Case=Acc|Definite=Def|Gender=Neut|Number=Sing|PronType=Art	12	det	_	_
+11	bisherige	bisherig	ADJ	ADJA	Case=Acc|Gender=Neut|Number=Sing	12	amod	_	_
+12	Ergebnis	Ergebnis	NOUN	NN	Case=Acc|Gender=Neut|Number=Sing	7	obl	_	_
+13	zufrieden	zufrieden	ADJ	ADJD	_	7	xcomp	_	SpaceAfter=No
+14	:	:	PUNCT	$.	_	7	punct	_	_
 
 # sent_id = test-s540
-# text = USA, die Staaten der Europäischen Union sowie Norwegen und die Schweiz beriefen ihre Botschafter aus Nigeria ab.
-1	USA	USA	PROPN	NE	Case=Nom|Number=Plur	13	nsubj	_	SpaceAfter=No
-2	,	,	PUNCT	$,	_	4	punct	_	_
-3	die	der	DET	ART	Case=Nom|Definite=Def|Gender=Masc|Number=Plur|PronType=Art	4	det	_	_
-4	Staaten	Staat	NOUN	NN	Case=Nom|Gender=Masc|Number=Plur	1	conj	_	_
-5	der	der	DET	ART	Case=Gen|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	7	det	_	_
-6	Europäischen	europäisch	PROPN	ADJA	Case=Gen|Gender=Fem|Number=Sing	7	amod	_	_
-7	Union	Union	PROPN	NN	Case=Gen|Gender=Fem|Number=Sing	4	nmod	_	_
-8	sowie	sowie	CCONJ	KON	_	9	cc	_	_
-9	Norwegen	Norwegen	PROPN	NE	Case=Nom|Gender=Neut|Number=Sing	1	conj	_	_
-10	und	und	CCONJ	KON	_	12	cc	_	_
-11	die	der	DET	ART	Case=Nom|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	12	det	_	_
-12	Schweiz	Schweiz	PROPN	NE	Case=Nom|Gender=Fem|Number=Sing	1	conj	_	_
-13	beriefen	berufen	VERB	VVFIN	Mood=Ind|Number=Plur|Person=3|Tense=Past|VerbForm=Fin	0	root	_	_
-14	ihre	ihr	PRON	PPOSAT	Case=Acc|Gender=Masc|Number=Plur|Poss=Yes	15	det:poss	_	_
-15	Botschafter	Botschafter	NOUN	NN	Case=Acc|Gender=Masc|Number=Plur	13	obj	_	_
-16	aus	aus	ADP	APPR	_	17	case	_	_
-17	Nigeria	Nigeria	PROPN	NE	Case=Dat|Gender=Neut|Number=Sing	13	obl	_	_
-18	ab	ab	ADP	PTKVZ	_	13	compound:prt	_	SpaceAfter=No
-19	.	.	PUNCT	$.	_	13	punct	_	_
+# text = Die USA, die Staaten der Europäischen Union sowie Norwegen und die Schweiz beriefen ihre Botschafter aus Nigeria ab.
+1	Die	der	DET	ART	Case=Nom|Definite=Def|Number=Plur|PronType=Art	2	dep	_	FixTigerDep=Yes
+2	USA	USA	PROPN	NE	Case=Nom|Number=Plur	14	nsubj	_	SpaceAfter=No
+3	,	,	PUNCT	$,	_	5	punct	_	_
+4	die	der	DET	ART	Case=Nom|Definite=Def|Gender=Masc|Number=Plur|PronType=Art	5	det	_	_
+5	Staaten	Staat	NOUN	NN	Case=Nom|Gender=Masc|Number=Plur	2	conj	_	_
+6	der	der	DET	ART	Case=Gen|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	8	det	_	_
+7	Europäischen	europäisch	PROPN	ADJA	Case=Gen|Gender=Fem|Number=Sing	8	amod	_	_
+8	Union	Union	PROPN	NN	Case=Gen|Gender=Fem|Number=Sing	5	nmod	_	_
+9	sowie	sowie	CCONJ	KON	_	10	cc	_	_
+10	Norwegen	Norwegen	PROPN	NE	Case=Nom|Gender=Neut|Number=Sing	2	conj	_	_
+11	und	und	CCONJ	KON	_	13	cc	_	_
+12	die	der	DET	ART	Case=Nom|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	13	det	_	_
+13	Schweiz	Schweiz	PROPN	NE	Case=Nom|Gender=Fem|Number=Sing	2	conj	_	_
+14	beriefen	berufen	VERB	VVFIN	Mood=Ind|Number=Plur|Person=3|Tense=Past|VerbForm=Fin	0	root	_	_
+15	ihre	ihr	PRON	PPOSAT	Case=Acc|Gender=Masc|Number=Plur|Poss=Yes	16	det:poss	_	_
+16	Botschafter	Botschafter	NOUN	NN	Case=Acc|Gender=Masc|Number=Plur	14	obj	_	_
+17	aus	aus	ADP	APPR	_	18	case	_	_
+18	Nigeria	Nigeria	PROPN	NE	Case=Dat|Gender=Neut|Number=Sing	14	obl	_	_
+19	ab	ab	ADP	PTKVZ	_	14	compound:prt	_	SpaceAfter=No
+20	.	.	PUNCT	$.	_	14	punct	_	_
 
 # sent_id = test-s541
-# text = Verantwortlichen mußten sich am Sonntag fragen lassen, warum ein rechtsgerichteter Jude am Vorabend mit solcher Leichtigkeit den Ministerpräsidenten erschießen konnte.
-1	Verantwortlichen	Verantwortliche	NOUN	NN	Case=Nom|Number=Plur	8	nsubj	_	_
-2	mußten	müssen	AUX	VMFIN	Mood=Ind|Number=Plur|Person=3|Tense=Past|VerbForm=Fin	8	aux	_	_
-3	sich	er|es|sie	PRON	PRF	Case=Acc|Number=Plur|Person=3|PronType=Prs|Reflex=Yes	8	obj	_	_
-4-5	am	_	_	_	_	_	_	_	_
-4	an	an	ADP	APPR	_	6	case	_	_
-5	dem	der	DET	ART	Case=Dat|Definite=Def|Gender=Masc|Number=Sing|PronType=Art	6	det	_	_
-6	Sonntag	Sonntag	PROPN	NN	Case=Dat|Gender=Masc|Number=Sing	8	obl	_	_
-7	fragen	fragen	VERB	VVINF	VerbForm=Inf	8	xcomp	_	_
-8	lassen	lassen	VERB	VVINF	VerbForm=Inf	0	root	_	SpaceAfter=No
-9	,	,	PUNCT	$,	_	8	punct	_	_
-10	warum	warum	SCONJ	PWAV	PronType=Int	22	mark	_	_
-11	ein	ein	DET	ART	Case=Nom|Definite=Ind|Gender=Masc|Number=Sing|PronType=Art	13	det	_	_
-12	rechtsgerichteter	rechtsgerichtet	ADJ	ADJA	Case=Nom|Gender=Masc|Number=Sing	13	amod	_	_
-13	Jude	Jude	NOUN	NN	Case=Nom|Gender=Masc|Number=Sing	22	nsubj	_	_
-14-15	am	_	_	_	_	_	_	_	_
-14	an	an	ADP	APPR	_	16	case	_	_
-15	dem	der	DET	ART	Case=Dat|Definite=Def|Gender=Masc|Number=Sing|PronType=Art	16	det	_	_
-16	Vorabend	Vorabend	NOUN	NN	Case=Dat|Gender=Masc|Number=Sing	22	obl	_	_
-17	mit	mit	ADP	APPR	_	19	case	_	_
-18	solcher	solch	PRON	PIAT	Case=Dat|Definite=Ind|Gender=Fem|Number=Sing|PronType=Ind	19	det	_	_
-19	Leichtigkeit	Leichtigkeit	NOUN	NN	Case=Dat|Gender=Fem|Number=Sing	22	obl	_	_
-20	den	der	DET	ART	Case=Acc|Definite=Def|Gender=Masc|Number=Sing|PronType=Art	21	det	_	_
-21	Ministerpräsidenten	Ministerpräsident	NOUN	NN	Case=Acc|Gender=Masc|Number=Sing	22	obj	_	_
-22	erschießen	erschießen	VERB	VVINF	VerbForm=Inf	7	advcl	_	_
-23	konnte	können	AUX	VMFIN	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	22	aux	_	SpaceAfter=No
-24	.	.	PUNCT	$.	_	8	punct	_	_
+# text = Die Verantwortlichen mußten sich am Sonntag fragen lassen, warum ein rechtsgerichteter Jude am Vorabend mit solcher Leichtigkeit den Ministerpräsidenten erschießen konnte.
+1	Die	der	DET	ART	Case=Nom|Definite=Def|Number=Plur|PronType=Art	2	dep	_	FixTigerDep=Yes
+2	Verantwortlichen	Verantwortliche	NOUN	NN	Case=Nom|Number=Plur	9	nsubj	_	_
+3	mußten	müssen	AUX	VMFIN	Mood=Ind|Number=Plur|Person=3|Tense=Past|VerbForm=Fin	9	aux	_	_
+4	sich	er|es|sie	PRON	PRF	Case=Acc|Number=Plur|Person=3|PronType=Prs|Reflex=Yes	9	obj	_	_
+5-6	am	_	_	_	_	_	_	_	_
+5	an	an	ADP	APPR	_	7	case	_	_
+6	dem	der	DET	ART	Case=Dat|Definite=Def|Gender=Masc|Number=Sing|PronType=Art	7	det	_	_
+7	Sonntag	Sonntag	PROPN	NN	Case=Dat|Gender=Masc|Number=Sing	9	obl	_	_
+8	fragen	fragen	VERB	VVINF	VerbForm=Inf	9	xcomp	_	_
+9	lassen	lassen	VERB	VVINF	VerbForm=Inf	0	root	_	SpaceAfter=No
+10	,	,	PUNCT	$,	_	9	punct	_	_
+11	warum	warum	SCONJ	PWAV	PronType=Int	23	mark	_	_
+12	ein	ein	DET	ART	Case=Nom|Definite=Ind|Gender=Masc|Number=Sing|PronType=Art	14	det	_	_
+13	rechtsgerichteter	rechtsgerichtet	ADJ	ADJA	Case=Nom|Gender=Masc|Number=Sing	14	amod	_	_
+14	Jude	Jude	NOUN	NN	Case=Nom|Gender=Masc|Number=Sing	23	nsubj	_	_
+15-16	am	_	_	_	_	_	_	_	_
+15	an	an	ADP	APPR	_	17	case	_	_
+16	dem	der	DET	ART	Case=Dat|Definite=Def|Gender=Masc|Number=Sing|PronType=Art	17	det	_	_
+17	Vorabend	Vorabend	NOUN	NN	Case=Dat|Gender=Masc|Number=Sing	23	obl	_	_
+18	mit	mit	ADP	APPR	_	20	case	_	_
+19	solcher	solch	PRON	PIAT	Case=Dat|Definite=Ind|Gender=Fem|Number=Sing|PronType=Ind	20	det	_	_
+20	Leichtigkeit	Leichtigkeit	NOUN	NN	Case=Dat|Gender=Fem|Number=Sing	23	obl	_	_
+21	den	der	DET	ART	Case=Acc|Definite=Def|Gender=Masc|Number=Sing|PronType=Art	22	det	_	_
+22	Ministerpräsidenten	Ministerpräsident	NOUN	NN	Case=Acc|Gender=Masc|Number=Sing	23	obj	_	_
+23	erschießen	erschießen	VERB	VVINF	VerbForm=Inf	8	advcl	_	_
+24	konnte	können	AUX	VMFIN	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	23	aux	_	SpaceAfter=No
+25	.	.	PUNCT	$.	_	9	punct	_	_
 
 # sent_id = test-s542
-# text = Verharmlosung und Dramatisierung nur die Kehrseite dieses Prozesses sind.
-1	Verharmlosung	Verharmlosung	NOUN	NN	Case=Nom|Gender=Fem|Number=Sing	6	nsubj	_	_
-2	und	und	CCONJ	KON	_	3	cc	_	_
-3	Dramatisierung	Dramatisierung	NOUN	NN	Case=Nom|Gender=Fem|Number=Sing	1	conj	_	_
-4	nur	nur	ADV	ADV	_	6	advmod	_	_
-5	die	der	DET	ART	Case=Nom|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	6	det	_	_
-6	Kehrseite	Kehrseite	NOUN	NN	Case=Nom|Gender=Fem|Number=Sing	0	root	_	_
-7	dieses	dies	PRON	PDAT	Case=Gen|Gender=Masc|Number=Sing|PronType=Dem	8	det	_	_
-8	Prozesses	Prozeß	NOUN	NN	Case=Gen|Gender=Masc|Number=Sing	6	nmod	_	_
-9	sind	sein	AUX	VAFIN	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	6	cop	_	SpaceAfter=No
-10	.	.	PUNCT	$.	_	6	punct	_	_
+# text = Wobei Verharmlosung und Dramatisierung nur die Kehrseite dieses Prozesses sind.
+1	Wobei	wobei	SCONJ	KOUS	_	2	dep	_	FixTigerDep=Yes
+2	Verharmlosung	Verharmlosung	NOUN	NN	Case=Nom|Gender=Fem|Number=Sing	7	nsubj	_	_
+3	und	und	CCONJ	KON	_	4	cc	_	_
+4	Dramatisierung	Dramatisierung	NOUN	NN	Case=Nom|Gender=Fem|Number=Sing	2	conj	_	_
+5	nur	nur	ADV	ADV	_	7	advmod	_	_
+6	die	der	DET	ART	Case=Nom|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	7	det	_	_
+7	Kehrseite	Kehrseite	NOUN	NN	Case=Nom|Gender=Fem|Number=Sing	0	root	_	_
+8	dieses	dies	PRON	PDAT	Case=Gen|Gender=Masc|Number=Sing|PronType=Dem	9	det	_	_
+9	Prozesses	Prozeß	NOUN	NN	Case=Gen|Gender=Masc|Number=Sing	7	nmod	_	_
+10	sind	sein	AUX	VAFIN	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	7	cop	_	SpaceAfter=No
+11	.	.	PUNCT	$.	_	7	punct	_	_
 
 # sent_id = test-s543
-# text = Verlagerung von 80 000 Arbeitsplätzen ins Ausland während des ersten Halbjahres 1995 hat vielerorts wie ein Schock gewirkt.
-1	Verlagerung	Verlagerung	NOUN	NN	Case=Nom|Gender=Fem|Number=Sing	19	nsubj	_	_
-2	von	von	ADP	APPR	_	5	case	_	_
-3	80	80	NUM	CARD	NumType=Card	4	compound	_	_
-4	000	000	NUM	CARD	NumType=Card	5	nummod	_	_
-5	Arbeitsplätzen	Arbeitsplatz	NOUN	NN	Case=Dat|Gender=Masc|Number=Plur	1	nmod	_	_
-6-7	ins	_	_	_	_	_	_	_	_
-6	in	in	ADP	APPR	_	8	case	_	_
-7	das	der	DET	ART	Case=Acc|Definite=Def|Gender=Neut|Number=Sing|PronType=Art	8	det	_	_
-8	Ausland	Ausland	NOUN	NN	Case=Acc|Gender=Neut|Number=Sing	1	nmod	_	_
-9	während	während	ADP	APPR	_	12	case	_	_
-10	des	der	DET	ART	Case=Gen|Definite=Def|Gender=Neut|Number=Sing|PronType=Art	12	det	_	_
-11	ersten	erster	ADJ	ADJA	Case=Gen|Gender=Neut|Number=Sing	12	amod	_	_
-12	Halbjahres	Halbjahr	NOUN	NN	Case=Gen|Gender=Neut|Number=Sing	1	nmod	_	_
-13	1995	1995	NUM	CARD	NumType=Card	12	nmod	_	_
-14	hat	haben	AUX	VAFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	19	aux	_	_
-15	vielerorts	vielerorts	ADV	ADV	_	19	advmod	_	_
-16	wie	wie	ADP	KOKOM	_	18	case	_	_
-17	ein	ein	DET	ART	Case=Nom|Definite=Ind|Gender=Neut|Number=Sing|PronType=Art	18	det	_	_
-18	Schock	Schock	NOUN	NN	Case=Nom|Gender=Neut|Number=Sing	19	obl	_	_
-19	gewirkt	wirken	VERB	VVPP	VerbForm=Part	0	root	_	SpaceAfter=No
-20	.	.	PUNCT	$.	_	19	punct	_	_
+# text = Die Verlagerung von 80 000 Arbeitsplätzen ins Ausland während des ersten Halbjahres 1995 hat vielerorts wie ein Schock gewirkt.
+1	Die	der	DET	ART	Case=Nom|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	2	dep	_	FixTigerDep=Yes
+2	Verlagerung	Verlagerung	NOUN	NN	Case=Nom|Gender=Fem|Number=Sing	20	nsubj	_	_
+3	von	von	ADP	APPR	_	6	case	_	_
+4	80	80	NUM	CARD	NumType=Card	5	compound	_	_
+5	000	000	NUM	CARD	NumType=Card	6	nummod	_	_
+6	Arbeitsplätzen	Arbeitsplatz	NOUN	NN	Case=Dat|Gender=Masc|Number=Plur	2	nmod	_	_
+7-8	ins	_	_	_	_	_	_	_	_
+7	in	in	ADP	APPR	_	9	case	_	_
+8	das	der	DET	ART	Case=Acc|Definite=Def|Gender=Neut|Number=Sing|PronType=Art	9	det	_	_
+9	Ausland	Ausland	NOUN	NN	Case=Acc|Gender=Neut|Number=Sing	2	nmod	_	_
+10	während	während	ADP	APPR	_	13	case	_	_
+11	des	der	DET	ART	Case=Gen|Definite=Def|Gender=Neut|Number=Sing|PronType=Art	13	det	_	_
+12	ersten	erster	ADJ	ADJA	Case=Gen|Gender=Neut|Number=Sing	13	amod	_	_
+13	Halbjahres	Halbjahr	NOUN	NN	Case=Gen|Gender=Neut|Number=Sing	2	nmod	_	_
+14	1995	1995	NUM	CARD	NumType=Card	13	nmod	_	_
+15	hat	haben	AUX	VAFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	20	aux	_	_
+16	vielerorts	vielerorts	ADV	ADV	_	20	advmod	_	_
+17	wie	wie	ADP	KOKOM	_	19	case	_	_
+18	ein	ein	DET	ART	Case=Nom|Definite=Ind|Gender=Neut|Number=Sing|PronType=Art	19	det	_	_
+19	Schock	Schock	NOUN	NN	Case=Nom|Gender=Neut|Number=Sing	20	obl	_	_
+20	gewirkt	wirken	VERB	VVPP	VerbForm=Part	0	root	_	SpaceAfter=No
+21	.	.	PUNCT	$.	_	20	punct	_	_
 
 # sent_id = test-s544
-# text = "verletzt wurde eine Korrespondentin des deutschen ARD-Fernsehens.
-1	"	"	PUNCT	$(	_	2	punct	_	SpaceAfter=No
+# text = Leicht verletzt wurde eine Korrespondentin des deutschen ARD-Fernsehens.
+1	Leicht	leicht	ADJ	ADJD	_	2	dep	_	FixTigerDep=Yes
 2	verletzt	verletzen	VERB	VVPP	VerbForm=Part	0	root	_	_
 3	wurde	werden	AUX	VAFIN	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin|Voice=Pass	2	aux:pass	_	_
 4	eine	ein	DET	ART	Case=Nom|Definite=Ind|Gender=Fem|Number=Sing|PronType=Art	5	det	_	_
@@ -10703,8 +10902,8 @@
 11	.	.	PUNCT	$.	_	2	punct	_	_
 
 # sent_id = test-s545
-# text = "Verletzungen können Zahlungen und Handelserleichterungen künftig ausgesetzt werden.
-1	"	"	PUNCT	$(	_	8	punct	_	SpaceAfter=No
+# text = Bei Verletzungen können Zahlungen und Handelserleichterungen künftig ausgesetzt werden.
+1	Bei	bei	ADP	APPR	_	2	dep	_	FixTigerDep=Yes
 2	Verletzungen	Verletzung	NOUN	NN	Case=Dat|Gender=Fem|Number=Plur	8	dep	_	_
 3	können	können	AUX	VMFIN	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	8	aux	_	_
 4	Zahlungen	Zahlung	NOUN	NN	Case=Nom|Gender=Fem|Number=Plur	8	nsubj:pass	_	_
@@ -10716,240 +10915,251 @@
 10	.	.	PUNCT	$.	_	8	punct	_	_
 
 # sent_id = test-s546
-# text = Verlierer in der Touristengunst war mit fast 20 Prozent Griechenland.
-1	Verlierer	Verlierer	NOUN	NN	Case=Nom|Gender=Masc|Number=Sing	0	root	_	_
-2	in	in	ADP	APPR	_	4	case	_	_
-3	der	der	DET	ART	Case=Dat|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	4	det	_	_
-4	Touristengunst	Touristengunst	NOUN	NN	Case=Dat|Gender=Fem|Number=Sing	1	nmod	_	_
-5	war	sein	AUX	VAFIN	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	1	cop	_	_
-6	mit	mit	ADP	APPR	_	9	case	_	_
-7	fast	fast	ADV	ADV	_	8	advmod	_	_
-8	20	20	NUM	CARD	NumType=Card	9	nummod	_	_
-9	Prozent	Prozent	NOUN	NN	Gender=Neut	1	nmod	_	_
-10	Griechenland	Griechenland	PROPN	NE	Case=Nom|Gender=Neut|Number=Sing	1	nsubj	_	SpaceAfter=No
-11	.	.	PUNCT	$.	_	1	punct	_	_
+# text = Großer Verlierer in der Touristengunst war mit fast 20 Prozent Griechenland.
+1	Großer	groß	ADJ	ADJA	Case=Nom|Gender=Masc|Number=Sing	2	dep	_	FixTigerDep=Yes
+2	Verlierer	Verlierer	NOUN	NN	Case=Nom|Gender=Masc|Number=Sing	0	root	_	_
+3	in	in	ADP	APPR	_	5	case	_	_
+4	der	der	DET	ART	Case=Dat|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	5	det	_	_
+5	Touristengunst	Touristengunst	NOUN	NN	Case=Dat|Gender=Fem|Number=Sing	2	nmod	_	_
+6	war	sein	AUX	VAFIN	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	2	cop	_	_
+7	mit	mit	ADP	APPR	_	10	case	_	_
+8	fast	fast	ADV	ADV	_	9	advmod	_	_
+9	20	20	NUM	CARD	NumType=Card	10	nummod	_	_
+10	Prozent	Prozent	NOUN	NN	Gender=Neut	2	nmod	_	_
+11	Griechenland	Griechenland	PROPN	NE	Case=Nom|Gender=Neut|Number=Sing	2	nsubj	_	SpaceAfter=No
+12	.	.	PUNCT	$.	_	2	punct	_	_
 
 # sent_id = test-s547
-# text = Vernichtung der irakischen C-Waffen soll laut UN in großem Umfang in Kürze beginnen und rund ein Jahr dauern.
-1	Vernichtung	Vernichtung	NOUN	NN	Case=Nom|Gender=Fem|Number=Sing	15	nsubj	_	_
-2	der	der	DET	ART	Case=Gen|Definite=Def|Gender=Fem|Number=Plur|PronType=Art	6	det	_	_
-3	irakischen	irakisch	ADJ	ADJA	Case=Gen|Gender=Fem|Number=Plur	6	amod	_	_
-4	C	C	X	NN	Case=Gen|Gender=Fem|Number=Plur	6	compound	_	SpaceAfter=No
-5	-	-	PUNCT	$(	_	4	punct	_	SpaceAfter=No
-6	Waffen	Waffe	NOUN	NN	Case=Gen|Gender=Fem|Number=Plur	1	nmod	_	_
-7	soll	sollen	AUX	VMFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	15	aux	_	_
-8	laut	laut	ADP	APPR	_	9	case	_	_
-9	UN	UN	PROPN	NE	Case=Dat|Number=Plur	15	obl	_	_
-10	in	in	ADP	APPR	_	12	case	_	_
-11	großem	groß	ADJ	ADJA	Case=Dat|Gender=Masc|Number=Sing	12	amod	_	_
-12	Umfang	Umfang	NOUN	NN	Case=Dat|Gender=Masc|Number=Sing	15	obl	_	_
-13	in	in	ADP	APPR	_	14	case	_	_
-14	Kürze	Kürze	NOUN	NN	Case=Dat|Gender=Fem|Number=Sing	15	obl	_	_
-15	beginnen	beginnen	VERB	VVINF	VerbForm=Inf	0	root	_	_
-16	und	und	CCONJ	KON	_	20	cc	_	_
-17	rund	rund	ADV	ADJD	_	18	advmod	_	_
-18	ein	ein	NUM	ART	Case=Acc|Definite=Ind|Gender=Neut|Number=Sing|PronType=Art	19	nummod	_	_
-19	Jahr	Jahr	NOUN	NN	Case=Acc|Gender=Neut|Number=Sing	20	obl	_	_
-20	dauern	dauern	VERB	VVINF	VerbForm=Inf	15	conj	_	SpaceAfter=No
-21	.	.	PUNCT	$.	_	15	punct	_	_
+# text = Die Vernichtung der irakischen C-Waffen soll laut UN in großem Umfang in Kürze beginnen und rund ein Jahr dauern.
+1	Die	der	DET	ART	Case=Nom|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	2	dep	_	FixTigerDep=Yes
+2	Vernichtung	Vernichtung	NOUN	NN	Case=Nom|Gender=Fem|Number=Sing	16	nsubj	_	_
+3	der	der	DET	ART	Case=Gen|Definite=Def|Gender=Fem|Number=Plur|PronType=Art	7	det	_	_
+4	irakischen	irakisch	ADJ	ADJA	Case=Gen|Gender=Fem|Number=Plur	7	amod	_	_
+5	C	C	X	NN	Case=Gen|Gender=Fem|Number=Plur	7	compound	_	SpaceAfter=No
+6	-	-	PUNCT	$(	_	5	punct	_	SpaceAfter=No
+7	Waffen	Waffe	NOUN	NN	Case=Gen|Gender=Fem|Number=Plur	2	nmod	_	_
+8	soll	sollen	AUX	VMFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	16	aux	_	_
+9	laut	laut	ADP	APPR	_	10	case	_	_
+10	UN	UN	PROPN	NE	Case=Dat|Number=Plur	16	obl	_	_
+11	in	in	ADP	APPR	_	13	case	_	_
+12	großem	groß	ADJ	ADJA	Case=Dat|Gender=Masc|Number=Sing	13	amod	_	_
+13	Umfang	Umfang	NOUN	NN	Case=Dat|Gender=Masc|Number=Sing	16	obl	_	_
+14	in	in	ADP	APPR	_	15	case	_	_
+15	Kürze	Kürze	NOUN	NN	Case=Dat|Gender=Fem|Number=Sing	16	obl	_	_
+16	beginnen	beginnen	VERB	VVINF	VerbForm=Inf	0	root	_	_
+17	und	und	CCONJ	KON	_	21	cc	_	_
+18	rund	rund	ADV	ADJD	_	19	advmod	_	_
+19	ein	ein	NUM	ART	Case=Acc|Definite=Ind|Gender=Neut|Number=Sing|PronType=Art	20	nummod	_	_
+20	Jahr	Jahr	NOUN	NN	Case=Acc|Gender=Neut|Number=Sing	21	obl	_	_
+21	dauern	dauern	VERB	VVINF	VerbForm=Inf	16	conj	_	SpaceAfter=No
+22	.	.	PUNCT	$.	_	16	punct	_	_
 
 # sent_id = test-s548
-# text = Vertrag läuft offiziell bis zum 31. Dezember 1992.
-1	Vertrag	Vertrag	NOUN	NN	Case=Nom|Gender=Masc|Number=Sing	2	nsubj	_	_
-2	läuft	laufen	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	0	root	_	_
-3	offiziell	offiziell	ADV	ADJD	_	2	advmod	_	_
-4	bis	bis	ADP	APPR	_	2	case	_	_
-5-6	zum	_	_	_	_	_	_	_	_
-5	zu	zu	ADP	APPR	_	8	case	_	_
-6	dem	der	DET	ART	Case=Dat|Definite=Def|Gender=Neut|Number=Sing|PronType=Art	8	det	_	_
-7	31.	31	ADJ	ADJA	Case=Dat|Gender=Masc|Number=Sing	8	amod	_	_
-8	Dezember	Dezember	NOUN	NN	Case=Dat|Gender=Masc|Number=Sing	4	nmod	_	_
-9	1992	1992	NUM	CARD	NumType=Card	8	nmod	_	SpaceAfter=No
-10	.	.	PUNCT	$.	_	2	punct	_	_
+# text = Sein Vertrag läuft offiziell bis zum 31. Dezember 1992.
+1	Sein	sein	DET	PPOSAT	Case=Nom|Gender=Masc|Number=Sing|Poss=Yes	2	dep	_	FixTigerDep=Yes
+2	Vertrag	Vertrag	NOUN	NN	Case=Nom|Gender=Masc|Number=Sing	3	nsubj	_	_
+3	läuft	laufen	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	0	root	_	_
+4	offiziell	offiziell	ADV	ADJD	_	3	advmod	_	_
+5	bis	bis	ADP	APPR	_	3	case	_	_
+6-7	zum	_	_	_	_	_	_	_	_
+6	zu	zu	ADP	APPR	_	9	case	_	_
+7	dem	der	DET	ART	Case=Dat|Definite=Def|Gender=Neut|Number=Sing|PronType=Art	9	det	_	_
+8	31.	31	ADJ	ADJA	Case=Dat|Gender=Masc|Number=Sing	9	amod	_	_
+9	Dezember	Dezember	NOUN	NN	Case=Dat|Gender=Masc|Number=Sing	5	nmod	_	_
+10	1992	1992	NUM	CARD	NumType=Card	9	nmod	_	SpaceAfter=No
+11	.	.	PUNCT	$.	_	3	punct	_	_
 
 # sent_id = test-s549
-# text = Vertreter der Ukraine teilte mit, daß der Streit über die Kontrolle der in der Ukraine stationierten strategischen Atomraketen ausgeklammert worden sei.
-1	Vertreter	Vertreter	NOUN	NN	Case=Nom|Gender=Masc|Number=Sing	4	nsubj	_	_
-2	der	der	DET	ART	Case=Gen|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	3	det	_	_
-3	Ukraine	Ukraine	PROPN	NE	Case=Gen|Gender=Fem|Number=Sing	1	nmod	_	_
-4	teilte	teilen	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	0	root	_	_
-5	mit	mit	ADP	PTKVZ	_	4	compound:prt	_	SpaceAfter=No
-6	,	,	PUNCT	$,	_	4	punct	_	_
-7	daß	daß	CCONJ	KOUS	_	20	cc	_	_
-8	der	der	DET	ART	Case=Nom|Definite=Def|Gender=Masc|Number=Sing|PronType=Art	9	det	_	_
-9	Streit	Streit	NOUN	NN	Case=Nom|Gender=Masc|Number=Sing	20	nsubj:pass	_	_
-10	über	über	ADP	APPR	_	12	case	_	_
-11	die	der	DET	ART	Case=Acc|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	12	det	_	_
-12	Kontrolle	Kontrolle	NOUN	NN	Case=Acc|Gender=Fem|Number=Sing	9	nmod	_	_
-13	der	der	DET	ART	Case=Gen|Definite=Def|Gender=Fem|Number=Plur|PronType=Art	19	det	_	_
-14	in	in	ADP	APPR	_	16	case	_	_
-15	der	der	DET	ART	Case=Dat|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	16	det	_	_
-16	Ukraine	Ukraine	PROPN	NE	Case=Dat|Gender=Fem|Number=Sing	17	nmod	_	_
-17	stationierten	stationiert	ADJ	ADJA	Case=Gen|Gender=Fem|Number=Plur	19	amod	_	_
-18	strategischen	strategisch	ADJ	ADJA	Case=Gen|Gender=Fem|Number=Plur	19	amod	_	_
-19	Atomraketen	Atomrakete	NOUN	NN	Case=Gen|Gender=Fem|Number=Plur	12	nmod	_	_
-20	ausgeklammert	ausklammern	VERB	VVPP	VerbForm=Part	4	ccomp	_	_
-21	worden	werden	AUX	VAPP	VerbForm=Part|Voice=Pass	20	aux:pass	_	_
-22	sei	sein	AUX	VAFIN	Mood=Sub|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	20	aux	_	SpaceAfter=No
-23	.	.	PUNCT	$.	_	4	punct	_	_
+# text = Ein Vertreter der Ukraine teilte mit, daß der Streit über die Kontrolle der in der Ukraine stationierten strategischen Atomraketen ausgeklammert worden sei.
+1	Ein	ein	DET	ART	Case=Nom|Definite=Ind|Gender=Masc|Number=Sing|PronType=Art	2	dep	_	FixTigerDep=Yes
+2	Vertreter	Vertreter	NOUN	NN	Case=Nom|Gender=Masc|Number=Sing	5	nsubj	_	_
+3	der	der	DET	ART	Case=Gen|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	4	det	_	_
+4	Ukraine	Ukraine	PROPN	NE	Case=Gen|Gender=Fem|Number=Sing	2	nmod	_	_
+5	teilte	teilen	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	0	root	_	_
+6	mit	mit	ADP	PTKVZ	_	5	compound:prt	_	SpaceAfter=No
+7	,	,	PUNCT	$,	_	5	punct	_	_
+8	daß	daß	CCONJ	KOUS	_	21	cc	_	_
+9	der	der	DET	ART	Case=Nom|Definite=Def|Gender=Masc|Number=Sing|PronType=Art	10	det	_	_
+10	Streit	Streit	NOUN	NN	Case=Nom|Gender=Masc|Number=Sing	21	nsubj:pass	_	_
+11	über	über	ADP	APPR	_	13	case	_	_
+12	die	der	DET	ART	Case=Acc|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	13	det	_	_
+13	Kontrolle	Kontrolle	NOUN	NN	Case=Acc|Gender=Fem|Number=Sing	10	nmod	_	_
+14	der	der	DET	ART	Case=Gen|Definite=Def|Gender=Fem|Number=Plur|PronType=Art	20	det	_	_
+15	in	in	ADP	APPR	_	17	case	_	_
+16	der	der	DET	ART	Case=Dat|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	17	det	_	_
+17	Ukraine	Ukraine	PROPN	NE	Case=Dat|Gender=Fem|Number=Sing	18	nmod	_	_
+18	stationierten	stationiert	ADJ	ADJA	Case=Gen|Gender=Fem|Number=Plur	20	amod	_	_
+19	strategischen	strategisch	ADJ	ADJA	Case=Gen|Gender=Fem|Number=Plur	20	amod	_	_
+20	Atomraketen	Atomrakete	NOUN	NN	Case=Gen|Gender=Fem|Number=Plur	13	nmod	_	_
+21	ausgeklammert	ausklammern	VERB	VVPP	VerbForm=Part	5	ccomp	_	_
+22	worden	werden	AUX	VAPP	VerbForm=Part|Voice=Pass	21	aux:pass	_	_
+23	sei	sein	AUX	VAFIN	Mood=Sub|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	21	aux	_	SpaceAfter=No
+24	.	.	PUNCT	$.	_	5	punct	_	_
 
 # sent_id = test-s550
-# text = Volontäre wohnen zusammen mit dem wissenschaftlichen Team in einfachen Unerkünften.
-1	Volontäre	Volontär	NOUN	NN	Case=Nom|Gender=Masc|Number=Plur	2	nsubj	_	_
-2	wohnen	wohnen	VERB	VVFIN	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	0	root	_	_
-3	zusammen	zusammen	ADV	ADV	_	2	advmod	_	_
-4	mit	mit	ADP	APPR	_	7	case	_	_
-5	dem	der	DET	ART	Case=Dat|Definite=Def|Gender=Neut|Number=Sing|PronType=Art	7	det	_	_
-6	wissenschaftlichen	wissenschaftlich	ADJ	ADJA	Case=Dat|Gender=Neut|Number=Sing	7	amod	_	_
-7	Team	Team	NOUN	NN	Case=Dat|Gender=Neut|Number=Sing	2	obl	_	_
-8	in	in	ADP	APPR	_	10	case	_	_
-9	einfachen	einfach	ADJ	ADJA	Case=Dat|Gender=Fem|Number=Sing	10	amod	_	_
-10	Unerkünften	Unterkünften	NOUN	NN	Case=Dat|Gender=Fem|Number=Sing	2	obl	_	SpaceAfter=No
-11	.	.	PUNCT	$.	_	2	punct	_	_
+# text = Die Volontäre wohnen zusammen mit dem wissenschaftlichen Team in einfachen Unerkünften.
+1	Die	der	DET	ART	Case=Nom|Definite=Def|Gender=Masc|Number=Plur|PronType=Art	2	dep	_	FixTigerDep=Yes
+2	Volontäre	Volontär	NOUN	NN	Case=Nom|Gender=Masc|Number=Plur	3	nsubj	_	_
+3	wohnen	wohnen	VERB	VVFIN	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	0	root	_	_
+4	zusammen	zusammen	ADV	ADV	_	3	advmod	_	_
+5	mit	mit	ADP	APPR	_	8	case	_	_
+6	dem	der	DET	ART	Case=Dat|Definite=Def|Gender=Neut|Number=Sing|PronType=Art	8	det	_	_
+7	wissenschaftlichen	wissenschaftlich	ADJ	ADJA	Case=Dat|Gender=Neut|Number=Sing	8	amod	_	_
+8	Team	Team	NOUN	NN	Case=Dat|Gender=Neut|Number=Sing	3	obl	_	_
+9	in	in	ADP	APPR	_	11	case	_	_
+10	einfachen	einfach	ADJ	ADJA	Case=Dat|Gender=Fem|Number=Sing	11	amod	_	_
+11	Unerkünften	Unterkünften	NOUN	NN	Case=Dat|Gender=Fem|Number=Sing	3	obl	_	SpaceAfter=No
+12	.	.	PUNCT	$.	_	3	punct	_	_
 
 # sent_id = test-s551
-# text = vor Entsetzen habe er mit ansehen müssen, wie sein Freund in den vermeintlich sicheren Tod stürzte, berichtete der unverletzt gebliebene Jones.
-1	vor	vor	ADP	APPR	_	2	case	_	_
-2	Entsetzen	Entsetzen	NOUN	NN	Case=Dat|Gender=Neut|Number=Sing	6	obl	_	_
-3	habe	haben	AUX	VAFIN	Mood=Sub|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	6	aux	_	_
-4	er	er	PRON	PPER	Case=Nom|Gender=Masc|Number=Sing|Person=3|PronType=Prs	6	nsubj	_	_
-5	mit	mit	ADP	ADV	_	6	compound:prt	_	_
-6	ansehen	ansehen	VERB	VVINF	VerbForm=Inf	19	ccomp	_	_
-7	müssen	müssen	AUX	VMINF	VerbForm=Inf	6	aux	_	SpaceAfter=No
-8	,	,	PUNCT	$,	_	19	punct	_	_
-9	wie	wie	SCONJ	PWAV	PronType=Int	17	mark	_	_
-10	sein	sein	PRON	PPOSAT	Case=Nom|Gender=Masc|Number=Sing|Poss=Yes	11	det:poss	_	_
-11	Freund	Freund	NOUN	NN	Case=Nom|Gender=Masc|Number=Sing	17	nsubj	_	_
-12	in	in	ADP	APPR	_	16	case	_	_
-13	den	der	DET	ART	Case=Acc|Definite=Def|Gender=Masc|Number=Sing|PronType=Art	16	det	_	_
-14	vermeintlich	vermeintlich	ADV	ADJD	_	15	advmod	_	_
-15	sicheren	sicher	ADJ	ADJA	Case=Acc|Gender=Masc|Number=Sing	16	amod	_	_
-16	Tod	Tod	NOUN	NN	Case=Acc|Gender=Masc|Number=Sing	17	obl	_	_
-17	stürzte	stürzen	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	6	advcl	_	SpaceAfter=No
-18	,	,	PUNCT	$,	_	19	punct	_	_
-19	berichtete	berichten	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	0	root	_	_
-20	der	der	DET	ART	Case=Nom|Definite=Def|Gender=Masc|Number=Sing|PronType=Art	23	det	_	_
-21	unverletzt	unverletzt	ADJ	ADJD	_	22	xcomp	_	_
-22	gebliebene	geblieben	ADJ	ADJA	Case=Nom|Gender=Masc|Number=Sing	23	amod	_	_
-23	Jones	Jones	PROPN	NE	Case=Nom|Gender=Masc|Number=Sing	19	nsubj	_	SpaceAfter=No
-24	.	.	PUNCT	$.	_	19	punct	_	_
+# text = Starr vor Entsetzen habe er mit ansehen müssen, wie sein Freund in den vermeintlich sicheren Tod stürzte, berichtete der unverletzt gebliebene Jones.
+1	Starr	starr	ADJ	ADJD	_	2	dep	_	FixTigerDep=Yes
+2	vor	vor	ADP	APPR	_	3	case	_	_
+3	Entsetzen	Entsetzen	NOUN	NN	Case=Dat|Gender=Neut|Number=Sing	7	obl	_	_
+4	habe	haben	AUX	VAFIN	Mood=Sub|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	7	aux	_	_
+5	er	er	PRON	PPER	Case=Nom|Gender=Masc|Number=Sing|Person=3|PronType=Prs	7	nsubj	_	_
+6	mit	mit	ADP	ADV	_	7	compound:prt	_	_
+7	ansehen	ansehen	VERB	VVINF	VerbForm=Inf	20	ccomp	_	_
+8	müssen	müssen	AUX	VMINF	VerbForm=Inf	7	aux	_	SpaceAfter=No
+9	,	,	PUNCT	$,	_	20	punct	_	_
+10	wie	wie	SCONJ	PWAV	PronType=Int	18	mark	_	_
+11	sein	sein	PRON	PPOSAT	Case=Nom|Gender=Masc|Number=Sing|Poss=Yes	12	det:poss	_	_
+12	Freund	Freund	NOUN	NN	Case=Nom|Gender=Masc|Number=Sing	18	nsubj	_	_
+13	in	in	ADP	APPR	_	17	case	_	_
+14	den	der	DET	ART	Case=Acc|Definite=Def|Gender=Masc|Number=Sing|PronType=Art	17	det	_	_
+15	vermeintlich	vermeintlich	ADV	ADJD	_	16	advmod	_	_
+16	sicheren	sicher	ADJ	ADJA	Case=Acc|Gender=Masc|Number=Sing	17	amod	_	_
+17	Tod	Tod	NOUN	NN	Case=Acc|Gender=Masc|Number=Sing	18	obl	_	_
+18	stürzte	stürzen	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	7	advcl	_	SpaceAfter=No
+19	,	,	PUNCT	$,	_	20	punct	_	_
+20	berichtete	berichten	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	0	root	_	_
+21	der	der	DET	ART	Case=Nom|Definite=Def|Gender=Masc|Number=Sing|PronType=Art	24	det	_	_
+22	unverletzt	unverletzt	ADJ	ADJD	_	23	xcomp	_	_
+23	gebliebene	geblieben	ADJ	ADJA	Case=Nom|Gender=Masc|Number=Sing	24	amod	_	_
+24	Jones	Jones	PROPN	NE	Case=Nom|Gender=Masc|Number=Sing	20	nsubj	_	SpaceAfter=No
+25	.	.	PUNCT	$.	_	20	punct	_	_
 
 # sent_id = test-s552
-# text = Vorteil sei daß bei gleichem Einsatz mehr Quartiere herausspringen als im herkömmlichen sozialen Wohnungsbau.
-1	Vorteil	Vorteil	NOUN	NN	Case=Nom|Gender=Masc|Number=Sing	2	nsubj	_	_
-2	sei	sein	VERB	VAFIN	Mood=Sub|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	0	root	_	_
-3	daß	daß	SCONJ	KOUS	_	9	mark	_	_
-4	bei	bei	ADP	APPR	_	6	case	_	_
-5	gleichem	gleich	ADJ	ADJA	Case=Dat|Gender=Masc|Number=Sing	6	amod	_	_
-6	Einsatz	Einsatz	NOUN	NN	Case=Dat|Gender=Masc|Number=Sing	9	obl	_	_
-7	mehr	mehr	ADJ	PIAT	Definite=Ind|PronType=Ind	8	amod	_	_
-8	Quartiere	Quartier	NOUN	NN	Case=Nom|Gender=Neut|Number=Plur	9	nsubj	_	_
-9	herausspringen	herausspringen	VERB	VVFIN	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	2	ccomp	_	_
-10	als	als	ADP	KOKOM	_	9	case	_	_
-11-12	im	_	_	_	_	_	_	_	_
-11	in	in	ADP	APPR	_	15	case	_	_
-12	dem	der	DET	ART	Case=Dat|Definite=Def|Gender=Neut|Number=Sing|PronType=Art	15	det	_	_
-13	herkömmlichen	herkömmlich	ADJ	ADJA	Case=Dat|Gender=Masc|Number=Sing	15	amod	_	_
-14	sozialen	sozial	ADJ	ADJA	Case=Dat|Gender=Masc|Number=Sing	15	amod	_	_
-15	Wohnungsbau	Wohnungsbau	NOUN	NN	Case=Dat|Gender=Masc|Number=Sing	10	nmod	_	SpaceAfter=No
-16	.	.	PUNCT	$.	_	2	punct	_	_
+# text = Der Vorteil sei daß bei gleichem Einsatz mehr Quartiere herausspringen als im herkömmlichen sozialen Wohnungsbau.
+1	Der	der	DET	ART	Case=Nom|Definite=Def|Gender=Masc|Number=Sing|PronType=Art	2	dep	_	FixTigerDep=Yes
+2	Vorteil	Vorteil	NOUN	NN	Case=Nom|Gender=Masc|Number=Sing	3	nsubj	_	_
+3	sei	sein	VERB	VAFIN	Mood=Sub|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	0	root	_	_
+4	daß	daß	SCONJ	KOUS	_	10	mark	_	_
+5	bei	bei	ADP	APPR	_	7	case	_	_
+6	gleichem	gleich	ADJ	ADJA	Case=Dat|Gender=Masc|Number=Sing	7	amod	_	_
+7	Einsatz	Einsatz	NOUN	NN	Case=Dat|Gender=Masc|Number=Sing	10	obl	_	_
+8	mehr	mehr	ADJ	PIAT	Definite=Ind|PronType=Ind	9	amod	_	_
+9	Quartiere	Quartier	NOUN	NN	Case=Nom|Gender=Neut|Number=Plur	10	nsubj	_	_
+10	herausspringen	herausspringen	VERB	VVFIN	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	3	ccomp	_	_
+11	als	als	ADP	KOKOM	_	10	case	_	_
+12-13	im	_	_	_	_	_	_	_	_
+12	in	in	ADP	APPR	_	16	case	_	_
+13	dem	der	DET	ART	Case=Dat|Definite=Def|Gender=Neut|Number=Sing|PronType=Art	16	det	_	_
+14	herkömmlichen	herkömmlich	ADJ	ADJA	Case=Dat|Gender=Masc|Number=Sing	16	amod	_	_
+15	sozialen	sozial	ADJ	ADJA	Case=Dat|Gender=Masc|Number=Sing	16	amod	_	_
+16	Wohnungsbau	Wohnungsbau	NOUN	NN	Case=Dat|Gender=Masc|Number=Sing	11	nmod	_	SpaceAfter=No
+17	.	.	PUNCT	$.	_	3	punct	_	_
 
 # sent_id = test-s553
-# text = Vorzüge verloren mittags innerhalb kurzer Zeit sieben Mark und wurden mit 648 Mark notiert.
-1	Vorzüge	Vorzug	NOUN	NN	Case=Nom|Gender=Masc|Number=Plur	2	nsubj	_	_
-2	verloren	verlieren	VERB	VVFIN	Mood=Ind|Number=Plur|Person=3|Tense=Past|VerbForm=Fin	0	root	_	_
-3	mittags	mittags	ADV	ADV	_	2	advmod	_	_
-4	innerhalb	innerhalb	ADP	APPR	_	6	case	_	_
-5	kurzer	kurz	ADJ	ADJA	Case=Gen|Gender=Fem|Number=Sing	6	amod	_	_
-6	Zeit	Zeit	NOUN	NN	Case=Gen|Gender=Fem|Number=Sing	2	obl	_	_
-7	sieben	sieben	NUM	CARD	NumType=Card	8	nummod	_	_
-8	Mark	Mark	NOUN	NN	Gender=Fem	2	obj	_	_
-9	und	und	CCONJ	KON	_	14	cc	_	_
-10	wurden	werden	AUX	VAFIN	Mood=Ind|Number=Plur|Person=3|Tense=Past|VerbForm=Fin|Voice=Pass	14	aux:pass	_	_
-11	mit	mit	ADP	APPR	_	13	case	_	_
-12	648	648	NUM	CARD	NumType=Card	13	nummod	_	_
-13	Mark	Mark	NOUN	NN	Gender=Fem	14	obl	_	_
-14	notiert	notieren	VERB	VVPP	VerbForm=Part	2	conj	_	SpaceAfter=No
-15	.	.	PUNCT	$.	_	2	punct	_	_
+# text = Die Vorzüge verloren mittags innerhalb kurzer Zeit sieben Mark und wurden mit 648 Mark notiert.
+1	Die	der	DET	ART	Case=Nom|Definite=Def|Gender=Masc|Number=Plur|PronType=Art	2	dep	_	FixTigerDep=Yes
+2	Vorzüge	Vorzug	NOUN	NN	Case=Nom|Gender=Masc|Number=Plur	3	nsubj	_	_
+3	verloren	verlieren	VERB	VVFIN	Mood=Ind|Number=Plur|Person=3|Tense=Past|VerbForm=Fin	0	root	_	_
+4	mittags	mittags	ADV	ADV	_	3	advmod	_	_
+5	innerhalb	innerhalb	ADP	APPR	_	7	case	_	_
+6	kurzer	kurz	ADJ	ADJA	Case=Gen|Gender=Fem|Number=Sing	7	amod	_	_
+7	Zeit	Zeit	NOUN	NN	Case=Gen|Gender=Fem|Number=Sing	3	obl	_	_
+8	sieben	sieben	NUM	CARD	NumType=Card	9	nummod	_	_
+9	Mark	Mark	NOUN	NN	Gender=Fem	3	obj	_	_
+10	und	und	CCONJ	KON	_	15	cc	_	_
+11	wurden	werden	AUX	VAFIN	Mood=Ind|Number=Plur|Person=3|Tense=Past|VerbForm=Fin|Voice=Pass	15	aux:pass	_	_
+12	mit	mit	ADP	APPR	_	14	case	_	_
+13	648	648	NUM	CARD	NumType=Card	14	nummod	_	_
+14	Mark	Mark	NOUN	NN	Gender=Fem	15	obl	_	_
+15	notiert	notieren	VERB	VVPP	VerbForm=Part	3	conj	_	SpaceAfter=No
+16	.	.	PUNCT	$.	_	3	punct	_	_
 
 # sent_id = test-s554
-# text = Wahlbeobachter des Europäischen Parlaments schätzte die Beteiligung auf etwa 50 Prozent.
-1	Wahlbeobachter	Wahlbeobachter	NOUN	NN	Case=Nom|Gender=Masc|Number=Sing	5	nsubj	_	_
-2	des	der	DET	ART	Case=Gen|Definite=Def|Gender=Neut|Number=Sing|PronType=Art	4	det	_	_
-3	Europäischen	europäisch	PROPN	ADJA	Case=Gen|Gender=Neut|Number=Sing	4	amod	_	_
-4	Parlaments	Parlament	PROPN	NN	Case=Gen|Gender=Neut|Number=Sing	1	nmod	_	_
-5	schätzte	schätzen	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	0	root	_	_
-6	die	der	DET	ART	Case=Acc|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	7	det	_	_
-7	Beteiligung	Beteiligung	NOUN	NN	Case=Acc|Gender=Fem|Number=Sing	5	obj	_	_
-8	auf	auf	ADP	APPR	_	11	case	_	_
-9	etwa	etwa	ADV	ADV	_	10	advmod	_	_
-10	50	50	NUM	CARD	NumType=Card	11	nummod	_	_
-11	Prozent	Prozent	NOUN	NN	Gender=Neut	7	nmod	_	SpaceAfter=No
-12	.	.	PUNCT	$.	_	5	punct	_	_
+# text = Ein Wahlbeobachter des Europäischen Parlaments schätzte die Beteiligung auf etwa 50 Prozent.
+1	Ein	ein	DET	ART	Case=Nom|Definite=Ind|Gender=Masc|Number=Sing|PronType=Art	2	dep	_	FixTigerDep=Yes
+2	Wahlbeobachter	Wahlbeobachter	NOUN	NN	Case=Nom|Gender=Masc|Number=Sing	6	nsubj	_	_
+3	des	der	DET	ART	Case=Gen|Definite=Def|Gender=Neut|Number=Sing|PronType=Art	5	det	_	_
+4	Europäischen	europäisch	PROPN	ADJA	Case=Gen|Gender=Neut|Number=Sing	5	amod	_	_
+5	Parlaments	Parlament	PROPN	NN	Case=Gen|Gender=Neut|Number=Sing	2	nmod	_	_
+6	schätzte	schätzen	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	0	root	_	_
+7	die	der	DET	ART	Case=Acc|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	8	det	_	_
+8	Beteiligung	Beteiligung	NOUN	NN	Case=Acc|Gender=Fem|Number=Sing	6	obj	_	_
+9	auf	auf	ADP	APPR	_	12	case	_	_
+10	etwa	etwa	ADV	ADV	_	11	advmod	_	_
+11	50	50	NUM	CARD	NumType=Card	12	nummod	_	_
+12	Prozent	Prozent	NOUN	NN	Gender=Neut	8	nmod	_	SpaceAfter=No
+13	.	.	PUNCT	$.	_	6	punct	_	_
 
 # sent_id = test-s555
-# text = Wahlmöglichkeit besteht zunächst beim Übergang von einer Ausbildung in ein festes Arbeitsverhältnis oder bei einem Wechsel im gleichen Unternehmen.
-1	Wahlmöglichkeit	Wahlmöglichkeit	NOUN	NN	Case=Nom|Gender=Fem|Number=Sing	2	nsubj	_	_
-2	besteht	bestehen	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	0	root	_	_
-3	zunächst	zunächst	ADV	ADV	_	2	advmod	_	_
-4-5	beim	_	_	_	_	_	_	_	_
-4	bei	bei	ADP	APPR	_	6	case	_	_
-5	dem	der	DET	ART	Case=Dat|Definite=Def|Gender=Masc|Number=Sing|PronType=Art	6	det	_	_
-6	Übergang	Übergang	NOUN	NN	Case=Dat|Gender=Masc|Number=Sing	2	obl	_	_
-7	von	von	ADP	APPR	_	9	case	_	_
-8	einer	ein	DET	ART	Case=Dat|Definite=Ind|Gender=Fem|Number=Sing|PronType=Art	9	det	_	_
-9	Ausbildung	Ausbildung	NOUN	NN	Case=Dat|Gender=Fem|Number=Sing	6	nmod	_	_
-10	in	in	ADP	APPR	_	13	case	_	_
-11	ein	ein	DET	ART	Case=Acc|Definite=Ind|Gender=Neut|Number=Sing|PronType=Art	13	det	_	_
-12	festes	fest	ADJ	ADJA	Case=Acc|Gender=Neut|Number=Sing	13	amod	_	_
-13	Arbeitsverhältnis	Arbeitsverhältnis	NOUN	NN	Case=Acc|Gender=Neut|Number=Sing	9	nmod	_	_
-14	oder	oder	CCONJ	KON	_	17	cc	_	_
-15	bei	bei	ADP	APPR	_	17	case	_	_
-16	einem	ein	DET	ART	Case=Dat|Definite=Ind|Gender=Masc|Number=Sing|PronType=Art	17	det	_	_
-17	Wechsel	Wechsel	NOUN	NN	Case=Dat|Gender=Masc|Number=Sing	2	conj	_	_
-18-19	im	_	_	_	_	_	_	_	_
-18	in	in	ADP	APPR	_	21	case	_	_
-19	dem	der	DET	ART	Case=Dat|Definite=Def|Gender=Neut|Number=Sing|PronType=Art	21	det	_	_
-20	gleichen	gleich	ADJ	ADJA	Case=Dat|Gender=Neut|Number=Sing	21	amod	_	_
-21	Unternehmen	Unternehmen	NOUN	NN	Case=Dat|Gender=Neut|Number=Sing	17	nmod	_	SpaceAfter=No
-22	.	.	PUNCT	$.	_	2	punct	_	_
+# text = Keine Wahlmöglichkeit besteht zunächst beim Übergang von einer Ausbildung in ein festes Arbeitsverhältnis oder bei einem Wechsel im gleichen Unternehmen.
+1	Keine	kein	DET	PIAT	Case=Nom|Definite=Ind|Gender=Fem|Number=Sing|Polarity=Neg|PronType=Neg	2	dep	_	FixTigerDep=Yes
+2	Wahlmöglichkeit	Wahlmöglichkeit	NOUN	NN	Case=Nom|Gender=Fem|Number=Sing	3	nsubj	_	_
+3	besteht	bestehen	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	0	root	_	_
+4	zunächst	zunächst	ADV	ADV	_	3	advmod	_	_
+5-6	beim	_	_	_	_	_	_	_	_
+5	bei	bei	ADP	APPR	_	7	case	_	_
+6	dem	der	DET	ART	Case=Dat|Definite=Def|Gender=Masc|Number=Sing|PronType=Art	7	det	_	_
+7	Übergang	Übergang	NOUN	NN	Case=Dat|Gender=Masc|Number=Sing	3	obl	_	_
+8	von	von	ADP	APPR	_	10	case	_	_
+9	einer	ein	DET	ART	Case=Dat|Definite=Ind|Gender=Fem|Number=Sing|PronType=Art	10	det	_	_
+10	Ausbildung	Ausbildung	NOUN	NN	Case=Dat|Gender=Fem|Number=Sing	7	nmod	_	_
+11	in	in	ADP	APPR	_	14	case	_	_
+12	ein	ein	DET	ART	Case=Acc|Definite=Ind|Gender=Neut|Number=Sing|PronType=Art	14	det	_	_
+13	festes	fest	ADJ	ADJA	Case=Acc|Gender=Neut|Number=Sing	14	amod	_	_
+14	Arbeitsverhältnis	Arbeitsverhältnis	NOUN	NN	Case=Acc|Gender=Neut|Number=Sing	10	nmod	_	_
+15	oder	oder	CCONJ	KON	_	18	cc	_	_
+16	bei	bei	ADP	APPR	_	18	case	_	_
+17	einem	ein	DET	ART	Case=Dat|Definite=Ind|Gender=Masc|Number=Sing|PronType=Art	18	det	_	_
+18	Wechsel	Wechsel	NOUN	NN	Case=Dat|Gender=Masc|Number=Sing	3	conj	_	_
+19-20	im	_	_	_	_	_	_	_	_
+19	in	in	ADP	APPR	_	22	case	_	_
+20	dem	der	DET	ART	Case=Dat|Definite=Def|Gender=Neut|Number=Sing|PronType=Art	22	det	_	_
+21	gleichen	gleich	ADJ	ADJA	Case=Dat|Gender=Neut|Number=Sing	22	amod	_	_
+22	Unternehmen	Unternehmen	NOUN	NN	Case=Dat|Gender=Neut|Number=Sing	18	nmod	_	SpaceAfter=No
+23	.	.	PUNCT	$.	_	3	punct	_	_
 
 # sent_id = test-s556
-# text = während DRV-Präsident Gerd Hesselmann noch auf die Unvergleichbarkeit touristischer Leistungen verweist, fordern andere Branchenvertreter bereits eine CD-ROM, mit der sich die Preise der verschiedenen Veranstalter vergleichen lassen.
-1	während	während	SCONJ	KOUS	_	13	mark	_	_
-2	DRV	DRV	PROPN	NN	Case=Nom|Gender=Masc|Number=Sing	4	compound	_	SpaceAfter=No
-3	-	-	PUNCT	$(	_	2	punct	_	SpaceAfter=No
-4	Präsident	Präsident	NOUN	NN	Case=Nom|Gender=Masc|Number=Sing	13	nsubj	_	_
-5	Gerd	Gerd	PROPN	NE	Case=Nom|Gender=Masc|Number=Sing	2	appos	_	_
-6	Hesselmann	Hesselmann	PROPN	NE	Case=Nom|Gender=Masc|Number=Sing	5	flat	_	_
-7	noch	noch	ADV	ADV	_	13	advmod	_	_
-8	auf	auf	ADP	APPR	_	10	case	_	_
-9	die	der	DET	ART	Case=Acc|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	10	det	_	_
-10	Unvergleichbarkeit	Unvergleichbarkeit	NOUN	NN	Case=Acc|Gender=Fem|Number=Sing	13	obl	_	_
-11	touristischer	touristisch	ADJ	ADJA	Case=Gen|Gender=Fem|Number=Plur	12	amod	_	_
-12	Leistungen	Leistung	NOUN	NN	Case=Gen|Gender=Fem|Number=Plur	10	nmod	_	_
-13	verweist	verweisen	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	15	advcl	_	SpaceAfter=No
-14	,	,	PUNCT	$,	_	15	punct	_	_
-15	fordern	fordern	VERB	VVFIN	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	0	root	_	_
-16	andere	ander	PRON	ADJA	Case=Nom|Gender=Masc|Number=Plur	17	det	_	_
-17	Branchenvertreter	Branchenvertreter	NOUN	NN	Case=Nom|Gender=Masc|Number=Plur	15	nsubj	_	_
-18	bereits	bereits	ADV	ADV	_	15	advmod	_	_
-19	eine	ein	DET	ART	Case=Acc|Definite=Ind|Gender=Fem|Number=Sing|PronType=Art	22	det	_	_
-20	CD	CD	NOUN	NN	Case=Acc|Gender=Fem|Number=Sing	22	compound	_	SpaceAfter=No
-21	-	-	PUNCT	$(	_	20	punct	_	SpaceAfter=No
-22	ROM	ROM	NOUN	NN	Case=Acc|Gender=Fem|Number=Sing	15	obj	_	SpaceAfter=No
-23	,	,	PUNCT	$,	_	15	punct	_	_
-24	mit	mit	ADP	APPR	_	25	case	_	_
-25	der	der	DET	PRELS	Case=Dat|Gender=Fem|Number=Sing|PronType=Rel	33	obl	_	_
-26	sich	er|es|sie	PRON	PRF	Case=Acc|Number=Plur|Person=3|PronType=Prs|Reflex=Yes	33	obj	_	_
-27	die	der	DET	ART	Case=Nom|Definite=Def|Gender=Masc|Number=Plur|PronType=Art	28	det	_	_
-28	Preise	Preis	NOUN	NN	Case=Nom|Gender=Masc|Number=Plur	33	nsubj	_	_
-29	der	der	DET	ART	Case=Gen|Definite=Def|Gender=Masc|Number=Plur|PronType=Art	31	det	_	_
-30	verschiedenen	verschieden	ADJ	ADJA	Case=Gen|Gender=Masc|Number=Plur	31	amod	_	_
-31	Veranstalter	Veranstalter	NOUN	NN	Case=Gen|Gender=Masc|Number=Plur	28	nmod	_	_
-32	vergleichen	vergleichen	VERB	VVINF	VerbForm=Inf	33	xcomp	_	_
-33	lassen	lassen	VERB	VVFIN	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	22	acl	_	SpaceAfter=No
-34	.	.	PUNCT	$.	_	15	punct	_	_
+# text = Und während DRV-Präsident Gerd Hesselmann noch auf die Unvergleichbarkeit touristischer Leistungen verweist, fordern andere Branchenvertreter bereits eine CD-ROM, mit der sich die Preise der verschiedenen Veranstalter vergleichen lassen.
+1	Und	und	CCONJ	KON	_	2	dep	_	FixTigerDep=Yes
+2	während	während	SCONJ	KOUS	_	14	mark	_	_
+3	DRV	DRV	PROPN	NN	Case=Nom|Gender=Masc|Number=Sing	5	compound	_	SpaceAfter=No
+4	-	-	PUNCT	$(	_	3	punct	_	SpaceAfter=No
+5	Präsident	Präsident	NOUN	NN	Case=Nom|Gender=Masc|Number=Sing	14	nsubj	_	_
+6	Gerd	Gerd	PROPN	NE	Case=Nom|Gender=Masc|Number=Sing	3	appos	_	_
+7	Hesselmann	Hesselmann	PROPN	NE	Case=Nom|Gender=Masc|Number=Sing	6	flat	_	_
+8	noch	noch	ADV	ADV	_	14	advmod	_	_
+9	auf	auf	ADP	APPR	_	11	case	_	_
+10	die	der	DET	ART	Case=Acc|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	11	det	_	_
+11	Unvergleichbarkeit	Unvergleichbarkeit	NOUN	NN	Case=Acc|Gender=Fem|Number=Sing	14	obl	_	_
+12	touristischer	touristisch	ADJ	ADJA	Case=Gen|Gender=Fem|Number=Plur	13	amod	_	_
+13	Leistungen	Leistung	NOUN	NN	Case=Gen|Gender=Fem|Number=Plur	11	nmod	_	_
+14	verweist	verweisen	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	16	advcl	_	SpaceAfter=No
+15	,	,	PUNCT	$,	_	16	punct	_	_
+16	fordern	fordern	VERB	VVFIN	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	0	root	_	_
+17	andere	ander	PRON	ADJA	Case=Nom|Gender=Masc|Number=Plur	18	det	_	_
+18	Branchenvertreter	Branchenvertreter	NOUN	NN	Case=Nom|Gender=Masc|Number=Plur	16	nsubj	_	_
+19	bereits	bereits	ADV	ADV	_	16	advmod	_	_
+20	eine	ein	DET	ART	Case=Acc|Definite=Ind|Gender=Fem|Number=Sing|PronType=Art	23	det	_	_
+21	CD	CD	NOUN	NN	Case=Acc|Gender=Fem|Number=Sing	23	compound	_	SpaceAfter=No
+22	-	-	PUNCT	$(	_	21	punct	_	SpaceAfter=No
+23	ROM	ROM	NOUN	NN	Case=Acc|Gender=Fem|Number=Sing	16	obj	_	SpaceAfter=No
+24	,	,	PUNCT	$,	_	16	punct	_	_
+25	mit	mit	ADP	APPR	_	26	case	_	_
+26	der	der	DET	PRELS	Case=Dat|Gender=Fem|Number=Sing|PronType=Rel	34	obl	_	_
+27	sich	er|es|sie	PRON	PRF	Case=Acc|Number=Plur|Person=3|PronType=Prs|Reflex=Yes	34	obj	_	_
+28	die	der	DET	ART	Case=Nom|Definite=Def|Gender=Masc|Number=Plur|PronType=Art	29	det	_	_
+29	Preise	Preis	NOUN	NN	Case=Nom|Gender=Masc|Number=Plur	34	nsubj	_	_
+30	der	der	DET	ART	Case=Gen|Definite=Def|Gender=Masc|Number=Plur|PronType=Art	32	det	_	_
+31	verschiedenen	verschieden	ADJ	ADJA	Case=Gen|Gender=Masc|Number=Plur	32	amod	_	_
+32	Veranstalter	Veranstalter	NOUN	NN	Case=Gen|Gender=Masc|Number=Plur	29	nmod	_	_
+33	vergleichen	vergleichen	VERB	VVINF	VerbForm=Inf	34	xcomp	_	_
+34	lassen	lassen	VERB	VVFIN	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	23	acl	_	SpaceAfter=No
+35	.	.	PUNCT	$.	_	16	punct	_	_
 
 # sent_id = test-s557
 # text = Wenn das Commonwealth nichts unternimmt, dann wird mein Vater hingerichtet.
@@ -10967,74 +11177,77 @@
 12	.	.	PUNCT	$.	_	11	punct	_	_
 
 # sent_id = test-s558
-# text = wenn es Druck gab, hat das Theater auch Gegendruck entwickelt und ist zu sich selbst gekommen.
-1	wenn	wenn	SCONJ	KOUS	_	4	mark	_	_
-2	es	es	PRON	PPER	Case=Nom|Gender=Neut|Number=Sing|Person=3|PronType=Prs	4	nsubj	_	_
-3	Druck	Druck	NOUN	NN	Case=Acc|Gender=Masc|Number=Sing	4	obj	_	_
-4	gab	geben	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	11	advcl	_	SpaceAfter=No
-5	,	,	PUNCT	$,	_	11	punct	_	_
-6	hat	haben	AUX	VAFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	11	aux	_	_
-7	das	der	DET	ART	Case=Nom|Definite=Def|Gender=Neut|Number=Sing|PronType=Art	8	det	_	_
-8	Theater	Theater	NOUN	NN	Case=Nom|Gender=Neut|Number=Sing	11	nsubj	_	_
-9	auch	auch	ADV	ADV	_	11	advmod	_	_
-10	Gegendruck	Gegendruck	NOUN	NN	Case=Acc|Gender=Masc|Number=Sing	11	obj	_	_
-11	entwickelt	entwickeln	VERB	VVPP	VerbForm=Part	0	root	_	_
-12	und	und	CCONJ	KON	_	17	cc	_	_
-13	ist	sein	AUX	VAFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	17	aux	_	_
-14	zu	zu	ADP	APPR	_	15	case	_	_
-15	sich	er|es|sie	PRON	PRF	Case=Dat|Number=Sing|Person=3|PronType=Prs|Reflex=Yes	17	obl	_	_
-16	selbst	selbst	ADV	ADV	_	15	advmod	_	_
-17	gekommen	kommen	VERB	VVPP	VerbForm=Part	11	conj	_	SpaceAfter=No
-18	.	.	PUNCT	$.	_	11	punct	_	_
+# text = Immer wenn es Druck gab, hat das Theater auch Gegendruck entwickelt und ist zu sich selbst gekommen.
+1	Immer	immer	ADV	ADV	_	2	dep	_	FixTigerDep=Yes
+2	wenn	wenn	SCONJ	KOUS	_	5	mark	_	_
+3	es	es	PRON	PPER	Case=Nom|Gender=Neut|Number=Sing|Person=3|PronType=Prs	5	nsubj	_	_
+4	Druck	Druck	NOUN	NN	Case=Acc|Gender=Masc|Number=Sing	5	obj	_	_
+5	gab	geben	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	12	advcl	_	SpaceAfter=No
+6	,	,	PUNCT	$,	_	12	punct	_	_
+7	hat	haben	AUX	VAFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	12	aux	_	_
+8	das	der	DET	ART	Case=Nom|Definite=Def|Gender=Neut|Number=Sing|PronType=Art	9	det	_	_
+9	Theater	Theater	NOUN	NN	Case=Nom|Gender=Neut|Number=Sing	12	nsubj	_	_
+10	auch	auch	ADV	ADV	_	12	advmod	_	_
+11	Gegendruck	Gegendruck	NOUN	NN	Case=Acc|Gender=Masc|Number=Sing	12	obj	_	_
+12	entwickelt	entwickeln	VERB	VVPP	VerbForm=Part	0	root	_	_
+13	und	und	CCONJ	KON	_	18	cc	_	_
+14	ist	sein	AUX	VAFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	18	aux	_	_
+15	zu	zu	ADP	APPR	_	16	case	_	_
+16	sich	er|es|sie	PRON	PRF	Case=Dat|Number=Sing|Person=3|PronType=Prs|Reflex=Yes	18	obl	_	_
+17	selbst	selbst	ADV	ADV	_	16	advmod	_	_
+18	gekommen	kommen	VERB	VVPP	VerbForm=Part	12	conj	_	SpaceAfter=No
+19	.	.	PUNCT	$.	_	12	punct	_	_
 
 # sent_id = test-s559
-# text = Wenn es so weit kommt, wird Rußland auch ohne die 24 Milliarden Dollar des Westens auskommen''.
-1	Wenn	wenn	SCONJ	KOUS	_	5	mark	_	_
-2	es	es	PRON	PPER	Case=Nom|Gender=Neut|Number=Sing|Person=3|PronType=Prs	5	nsubj	_	_
-3	so	so	ADV	ADV	_	4	advmod	_	_
-4	weit	weit	ADV	ADJD	_	5	advmod	_	_
-5	kommt	kommen	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	17	advcl	_	SpaceAfter=No
-6	,	,	PUNCT	$,	_	17	punct	_	_
-7	wird	werden	AUX	VAFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	17	aux	_	_
-8	Rußland	Rußland	PROPN	NE	Case=Nom|Gender=Neut|Number=Sing	17	nsubj	_	_
-9	auch	auch	ADV	ADV	_	17	advmod	_	_
-10	ohne	ohne	ADP	APPR	_	14	case	_	_
-11	die	der	DET	ART	Case=Acc|Definite=Def|Gender=Masc|Number=Plur|PronType=Art	14	det	_	_
-12	24	24	NUM	CARD	NumType=Card	13	nummod	_	_
-13	Milliarden	Milliarde	NOUN	NN	Case=Acc|Gender=Fem|Number=Plur	14	nummod	_	_
-14	Dollar	Dollar	NOUN	NN	Case=Nom|Gender=Masc|Number=Plur	17	obl	_	_
-15	des	der	DET	ART	Case=Gen|Definite=Def|Gender=Masc|Number=Sing|PronType=Art	16	det	_	_
-16	Westens	Westen	NOUN	NN	Case=Gen|Gender=Masc|Number=Sing	14	nmod	_	_
-17	auskommen	auskommen	VERB	VVINF	VerbForm=Inf	0	root	_	SpaceAfter=No
-18	''	''	PUNCT	$(	_	17	punct	_	SpaceAfter=No
-19	.	.	PUNCT	$.	_	17	punct	_	_
+# text = ``Wenn es so weit kommt, wird Rußland auch ohne die 24 Milliarden Dollar des Westens auskommen''.
+1	``	``	PUNCT	$(	_	2	punct	_	FixTigerDep=Yes|SpaceAfter=No
+2	Wenn	wenn	SCONJ	KOUS	_	6	mark	_	_
+3	es	es	PRON	PPER	Case=Nom|Gender=Neut|Number=Sing|Person=3|PronType=Prs	6	nsubj	_	_
+4	so	so	ADV	ADV	_	5	advmod	_	_
+5	weit	weit	ADV	ADJD	_	6	advmod	_	_
+6	kommt	kommen	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	18	advcl	_	SpaceAfter=No
+7	,	,	PUNCT	$,	_	18	punct	_	_
+8	wird	werden	AUX	VAFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	18	aux	_	_
+9	Rußland	Rußland	PROPN	NE	Case=Nom|Gender=Neut|Number=Sing	18	nsubj	_	_
+10	auch	auch	ADV	ADV	_	18	advmod	_	_
+11	ohne	ohne	ADP	APPR	_	15	case	_	_
+12	die	der	DET	ART	Case=Acc|Definite=Def|Gender=Masc|Number=Plur|PronType=Art	15	det	_	_
+13	24	24	NUM	CARD	NumType=Card	14	nummod	_	_
+14	Milliarden	Milliarde	NOUN	NN	Case=Acc|Gender=Fem|Number=Plur	15	nummod	_	_
+15	Dollar	Dollar	NOUN	NN	Case=Nom|Gender=Masc|Number=Plur	18	obl	_	_
+16	des	der	DET	ART	Case=Gen|Definite=Def|Gender=Masc|Number=Sing|PronType=Art	17	det	_	_
+17	Westens	Westen	NOUN	NN	Case=Gen|Gender=Masc|Number=Sing	15	nmod	_	_
+18	auskommen	auskommen	VERB	VVINF	VerbForm=Inf	0	root	_	SpaceAfter=No
+19	''	''	PUNCT	$(	_	18	punct	_	SpaceAfter=No
+20	.	.	PUNCT	$.	_	18	punct	_	_
 
 # sent_id = test-s560
-# text = Wer in Arbeitsgruppen arbeitet, kann das auch noch zwei Tage vorher mit seinen Kollegen abmachen'', sagte Personalchef Bernd Richter dazu.
-1	Wer	wer	PRON	PWS	Case=Nom|Gender=Masc|Number=Sing|PronType=Int	4	nsubj	_	_
-2	in	in	ADP	APPR	_	3	case	_	_
-3	Arbeitsgruppen	Arbeitsgruppe	NOUN	NN	Case=Dat|Gender=Fem|Number=Plur	4	obl	_	_
-4	arbeitet	arbeiten	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	16	csubj	_	SpaceAfter=No
-5	,	,	PUNCT	$,	_	19	punct	_	_
-6	kann	können	AUX	VMFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	16	aux	_	_
-7	das	der	PRON	PDS	Case=Acc|Gender=Neut|Number=Sing|PronType=Dem	16	obj	_	_
-8	auch	auch	ADV	ADV	_	16	advmod	_	_
-9	noch	noch	ADV	ADV	_	16	advmod	_	_
-10	zwei	zwei	NUM	CARD	NumType=Card	11	nummod	_	_
-11	Tage	Tag	NOUN	NN	Case=Acc|Gender=Masc|Number=Plur	12	compound	_	_
-12	vorher	vorher	ADV	ADV	_	16	advmod	_	_
-13	mit	mit	ADP	APPR	_	15	case	_	_
-14	seinen	sein	PRON	PPOSAT	Case=Dat|Gender=Masc|Number=Plur|Poss=Yes	15	det:poss	_	_
-15	Kollegen	Kollege	NOUN	NN	Case=Dat|Gender=Masc|Number=Plur	16	obl	_	_
-16	abmachen	abmachen	VERB	VVINF	VerbForm=Inf	19	ccomp	_	SpaceAfter=No
-17	''	''	PUNCT	$(	_	19	punct	_	SpaceAfter=No
-18	,	,	PUNCT	$,	_	19	punct	_	_
-19	sagte	sagen	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	0	root	_	_
-20	Personalchef	Personalchef	NOUN	NN	Case=Nom|Gender=Masc|Number=Sing	19	nsubj	_	_
-21	Bernd	Bernd	NOUN	NE	Case=Nom|Gender=Masc|Number=Sing	22	compound	_	_
-22	Richter	Richter	NOUN	NE	Case=Nom|Gender=Masc|Number=Sing	20	appos	_	_
-23	dazu	dazu	ADV	PAV	_	19	advmod	_	SpaceAfter=No
-24	.	.	PUNCT	$.	_	19	punct	_	_
+# text = ``Wer in Arbeitsgruppen arbeitet, kann das auch noch zwei Tage vorher mit seinen Kollegen abmachen'', sagte Personalchef Bernd Richter dazu.
+1	``	``	PUNCT	$(	_	2	punct	_	FixTigerDep=Yes|SpaceAfter=No
+2	Wer	wer	PRON	PWS	Case=Nom|Gender=Masc|Number=Sing|PronType=Int	5	nsubj	_	_
+3	in	in	ADP	APPR	_	4	case	_	_
+4	Arbeitsgruppen	Arbeitsgruppe	NOUN	NN	Case=Dat|Gender=Fem|Number=Plur	5	obl	_	_
+5	arbeitet	arbeiten	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	17	csubj	_	SpaceAfter=No
+6	,	,	PUNCT	$,	_	20	punct	_	_
+7	kann	können	AUX	VMFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	17	aux	_	_
+8	das	der	PRON	PDS	Case=Acc|Gender=Neut|Number=Sing|PronType=Dem	17	obj	_	_
+9	auch	auch	ADV	ADV	_	17	advmod	_	_
+10	noch	noch	ADV	ADV	_	17	advmod	_	_
+11	zwei	zwei	NUM	CARD	NumType=Card	12	nummod	_	_
+12	Tage	Tag	NOUN	NN	Case=Acc|Gender=Masc|Number=Plur	13	compound	_	_
+13	vorher	vorher	ADV	ADV	_	17	advmod	_	_
+14	mit	mit	ADP	APPR	_	16	case	_	_
+15	seinen	sein	PRON	PPOSAT	Case=Dat|Gender=Masc|Number=Plur|Poss=Yes	16	det:poss	_	_
+16	Kollegen	Kollege	NOUN	NN	Case=Dat|Gender=Masc|Number=Plur	17	obl	_	_
+17	abmachen	abmachen	VERB	VVINF	VerbForm=Inf	20	ccomp	_	SpaceAfter=No
+18	''	''	PUNCT	$(	_	20	punct	_	SpaceAfter=No
+19	,	,	PUNCT	$,	_	20	punct	_	_
+20	sagte	sagen	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	0	root	_	_
+21	Personalchef	Personalchef	NOUN	NN	Case=Nom|Gender=Masc|Number=Sing	20	nsubj	_	_
+22	Bernd	Bernd	NOUN	NE	Case=Nom|Gender=Masc|Number=Sing	23	compound	_	_
+23	Richter	Richter	NOUN	NE	Case=Nom|Gender=Masc|Number=Sing	21	appos	_	_
+24	dazu	dazu	ADV	PAV	_	20	advmod	_	SpaceAfter=No
+25	.	.	PUNCT	$.	_	20	punct	_	_
 
 # sent_id = test-s561
 # text = Wie es dem Stahl geht, so geht es dem Land.
@@ -11052,335 +11265,351 @@
 12	.	.	PUNCT	$.	_	8	punct	_	_
 
 # sent_id = test-s562
-# text = Wilhelm Heitmeyer leitet das Projekt ``Individualisierung und Gewalt'' im Sonderforschungsbereich ``Prävention und Intervention im Kindes- und Jugendalter'' der Universität Bielefeld.
-1	Wilhelm	Wilhelm	PROPN	NE	Case=Nom|Gender=Masc|Number=Sing	3	nsubj	_	_
-2	Heitmeyer	Heitmeyer	PROPN	NE	Case=Nom|Gender=Masc|Number=Sing	1	flat	_	_
-3	leitet	leiten	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	0	root	_	_
-4	das	der	DET	ART	Case=Acc|Definite=Def|Gender=Neut|Number=Sing|PronType=Art	5	det	_	_
-5	Projekt	Projekt	NOUN	NN	Case=Acc|Gender=Neut|Number=Sing	3	obj	_	_
-6	``	``	PUNCT	$(	_	7	punct	_	SpaceAfter=No
-7	Individualisierung	Individualisierung	NOUN	NN	Case=Nom|Gender=Fem|Number=Sing	5	appos	_	_
-8	und	und	CCONJ	KON	_	9	cc	_	_
-9	Gewalt	Gewalt	NOUN	NN	Case=Nom|Gender=Fem|Number=Sing	7	conj	_	SpaceAfter=No
-10	''	''	PUNCT	$(	_	7	punct	_	_
-11-12	im	_	_	_	_	_	_	_	_
-11	in	in	ADP	APPR	_	13	case	_	_
-12	dem	der	DET	ART	Case=Dat|Definite=Def|Gender=Masc|Number=Sing|PronType=Art	13	det	_	_
-13	Sonderforschungsbereich	Sonderforschungsbereich	NOUN	NN	Case=Dat|Gender=Masc|Number=Sing	5	nmod	_	_
-14	``	``	PUNCT	$(	_	15	punct	_	SpaceAfter=No
-15	Prävention	Prävention	NOUN	NN	Case=Nom|Gender=Fem|Number=Sing	13	compound	_	_
-16	und	und	CCONJ	KON	_	17	cc	_	_
-17	Intervention	Intervention	NOUN	NN	Case=Nom|Gender=Fem|Number=Sing	15	conj	_	_
-18-19	im	_	_	_	_	_	_	_	_
-18	in	in	ADP	APPR	_	20	case	_	_
-19	dem	der	DET	ART	Case=Dat|Definite=Def|Gender=Neut|Number=Sing|PronType=Art	20	det	_	_
-20	Kindes	Kind	NOUN	TRUNC	Case=Dat|Gender=Neut|Number=Sing	15	compound	_	SpaceAfter=No
-21	-	-	PUNCT	$(	_	23	punct	_	_
-22	und	und	CCONJ	KON	_	23	cc	_	_
-23	Jugendalter	Jugendalter	NOUN	NN	Case=Dat|Gender=Neut|Number=Sing	20	conj	_	SpaceAfter=No
-24	''	''	PUNCT	$(	_	15	punct	_	_
-25	der	der	DET	ART	Case=Gen|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	27	det	_	_
-26	Universität	Universität	NOUN	NN	Case=Gen|Gender=Fem|Number=Sing	27	compound	_	_
-27	Bielefeld	Bielefeld	PROPN	NE	Case=Nom|Gender=Neut|Number=Sing	13	nmod	_	SpaceAfter=No
-28	.	.	PUNCT	$.	_	3	punct	_	_
-
-# sent_id = test-s563
-# text = Wilhelm Schlegel hatte aus dem ``translated Bottom'' einen ``transferierten Zettel'' gemacht.
-1	Wilhelm	Wilhelm	PROPN	NE	Case=Nom|Gender=Masc|Number=Sing	15	nsubj	_	_
-2	Schlegel	Schlegel	PROPN	NE	Case=Nom|Gender=Masc|Number=Sing	1	flat	_	_
-3	hatte	haben	AUX	VAFIN	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	15	aux	_	_
-4	aus	aus	ADP	APPR	_	8	case	_	_
-5	dem	der	DET	ART	Case=Dat|Definite=Def|Gender=Masc|Number=Sing|PronType=Art	8	det	_	_
-6	``	``	PUNCT	$(	_	8	punct	_	SpaceAfter=No
-7	translated	translated	X	FM	Foreign=Yes	8	compound	_	_
-8	Bottom	Bottom	X	FM	Foreign=Yes	15	obl	_	SpaceAfter=No
-9	''	''	PUNCT	$(	_	8	punct	_	_
-10	einen	ein	DET	ART	Case=Acc|Definite=Ind|Gender=Masc|Number=Sing|PronType=Art	13	det	_	_
-11	``	``	PUNCT	$(	_	13	punct	_	SpaceAfter=No
-12	transferierten	transferiert	ADJ	ADJA	Case=Acc|Gender=Masc|Number=Sing	13	amod	_	_
-13	Zettel	Zettel	NOUN	NN	Case=Acc|Gender=Masc|Number=Sing	15	obj	_	SpaceAfter=No
-14	''	''	PUNCT	$(	_	13	punct	_	_
-15	gemacht	machen	VERB	VVPP	VerbForm=Part	0	root	_	SpaceAfter=No
-16	.	.	PUNCT	$.	_	15	punct	_	_
-
-# sent_id = test-s564
-# text = Wir haben alle Formulierungen vermieden, die irgendein Gesetz in Kuba verletzen könnten'', erklärt mit milder Stimme Castellanos, ``und das hat uns dennoch nicht vor dem Rausschmiß bewahrt.''
-1	Wir	wir	PRON	PPER	Case=Nom|Number=Plur|Person=1|PronType=Prs	5	nsubj	_	_
-2	haben	haben	AUX	VAFIN	Mood=Ind|Number=Plur|Person=1|Tense=Pres|VerbForm=Fin	5	aux	_	_
-3	alle	alle	PRON	PIAT	Case=Acc|Definite=Ind|Gender=Fem|Number=Plur|PronType=Ind	4	det	_	_
-4	Formulierungen	Formulierung	NOUN	NN	Case=Acc|Gender=Fem|Number=Plur	5	obj	_	_
-5	vermieden	vermeiden	VERB	VVPP	VerbForm=Part	0	root	_	SpaceAfter=No
-6	,	,	PUNCT	$,	_	32	punct	_	_
-7	die	der	PRON	PRELS	Case=Nom|Gender=Fem|Number=Plur|PronType=Rel	12	nsubj	_	_
-8	irgendein	irgendein	PRON	PIAT	Case=Acc|Definite=Ind|Gender=Neut|Number=Sing|PronType=Ind	9	det	_	_
-9	Gesetz	Gesetz	NOUN	NN	Case=Acc|Gender=Neut|Number=Sing	12	obj	_	_
-10	in	in	ADP	APPR	_	11	case	_	_
-11	Kuba	Kuba	PROPN	NE	Case=Dat|Gender=Neut|Number=Sing	9	nmod	_	_
-12	verletzen	verletzen	VERB	VVINF	VerbForm=Inf	4	acl	_	_
-13	könnten	können	AUX	VMFIN	Mood=Sub|Number=Plur|Person=3|Tense=Past|VerbForm=Fin	12	aux	_	SpaceAfter=No
-14	''	''	PUNCT	$(	_	32	punct	_	SpaceAfter=No
-15	,	,	PUNCT	$,	_	32	punct	_	_
-16	erklärt	erklären	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	5	parataxis	_	_
-17	mit	mit	ADP	APPR	_	19	case	_	_
-18	milder	mild	ADJ	ADJA	Case=Dat|Gender=Fem|Number=Sing	19	amod	_	_
-19	Stimme	Stimme	NOUN	NN	Case=Dat|Gender=Fem|Number=Sing	16	obl	_	_
-20	Castellanos	Castellanos	PROPN	NE	Case=Nom|Number=Sing	16	nsubj	_	SpaceAfter=No
-21	,	,	PUNCT	$,	_	32	punct	_	_
-22	``	``	PUNCT	$(	_	32	punct	_	SpaceAfter=No
-23	und	und	CCONJ	KON	_	32	cc	_	_
-24	das	der	PRON	PDS	Case=Nom|Gender=Neut|Number=Sing|PronType=Dem	32	nsubj	_	_
-25	hat	haben	AUX	VAFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	32	aux	_	_
-26	uns	wir	PRON	PPER	Case=Acc|Number=Plur|Person=1|PronType=Prs	32	obj	_	_
-27	dennoch	dennoch	ADV	ADV	_	32	advmod	_	_
-28	nicht	nicht	PART	PTKNEG	Polarity=Neg	32	advmod	_	_
-29	vor	vor	ADP	APPR	_	31	case	_	_
-30	dem	der	DET	ART	Case=Dat|Definite=Def|Gender=Masc|Number=Sing|PronType=Art	31	det	_	_
-31	Rausschmiß	Rausschmiß	NOUN	NN	Case=Dat|Gender=Masc|Number=Sing	32	obl	_	_
-32	bewahrt	bewahren	VERB	VVPP	VerbForm=Part	5	conj	_	SpaceAfter=No
-33	.	.	PUNCT	$.	_	5	punct	_	SpaceAfter=No
-34	''	''	PUNCT	$(	_	5	punct	_	_
-
-# sent_id = test-s565
-# text = Wir haben die faulste Regierung und den faulsten Ministerpräsidenten der Republik'', monierte Müller.
-1	Wir	wir	PRON	PPER	Case=Nom|Number=Plur|Person=1|PronType=Prs	2	nsubj	_	_
-2	haben	haben	VERB	VAFIN	Mood=Ind|Number=Plur|Person=1|Tense=Pres|VerbForm=Fin	14	ccomp	_	_
-3	die	der	DET	ART	Case=Acc|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	5	det	_	_
-4	faulste	faul	ADJ	ADJA	Case=Acc|Gender=Fem|Number=Sing	5	amod	_	_
-5	Regierung	Regierung	NOUN	NN	Case=Acc|Gender=Fem|Number=Sing	2	obj	_	_
-6	und	und	CCONJ	KON	_	9	cc	_	_
-7	den	der	DET	ART	Case=Acc|Definite=Def|Gender=Masc|Number=Sing|PronType=Art	9	det	_	_
-8	faulsten	faul	ADJ	ADJA	Case=Acc|Gender=Masc|Number=Sing	9	amod	_	_
-9	Ministerpräsidenten	Ministerpräsident	NOUN	NN	Case=Acc|Gender=Masc|Number=Sing	5	conj	_	_
-10	der	der	DET	ART	Case=Gen|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	11	det	_	_
-11	Republik	Republik	NOUN	NN	Case=Gen|Gender=Fem|Number=Sing	9	nmod	_	SpaceAfter=No
-12	''	''	PUNCT	$(	_	2	punct	_	SpaceAfter=No
-13	,	,	PUNCT	$,	_	2	punct	_	_
-14	monierte	monieren	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	0	root	_	_
-15	Müller	Müller	PROPN	NE	Case=Nom|Number=Sing	14	nsubj	_	SpaceAfter=No
-16	.	.	PUNCT	$.	_	14	punct	_	_
-
-# sent_id = test-s566
-# text = Wir in der Wirtschaft lernen von eurer Erniedrigung und von euren Skandalen, daß wir noch mehr die Öffentlichkeit meiden müssen.
-1	Wir	wir	PRON	PPER	Case=Nom|Number=Plur|Person=1|PronType=Prs	5	nsubj	_	_
-2	in	in	ADP	APPR	_	4	case	_	_
-3	der	der	DET	ART	Case=Dat|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	4	det	_	_
-4	Wirtschaft	Wirtschaft	NOUN	NN	Case=Dat|Gender=Fem|Number=Sing	1	nmod	_	_
-5	lernen	lernen	VERB	VVFIN	Mood=Ind|Number=Plur|Person=1|Tense=Pres|VerbForm=Fin	0	root	_	_
-6	von	von	ADP	APPR	_	8	case	_	_
-7	eurer	euer	PRON	PPOSAT	Case=Dat|Gender=Fem|Number=Sing|Poss=Yes	8	det:poss	_	_
-8	Erniedrigung	Erniedrigung	NOUN	NN	Case=Dat|Gender=Fem|Number=Sing	5	obl	_	_
-9	und	und	CCONJ	KON	_	12	cc	_	_
-10	von	von	ADP	APPR	_	12	case	_	_
-11	euren	euer	PRON	PPOSAT	Case=Dat|Gender=Masc|Number=Plur|Poss=Yes	12	det:poss	_	_
-12	Skandalen	Skandal	NOUN	NN	Case=Dat|Gender=Masc|Number=Plur	8	conj	_	SpaceAfter=No
-13	,	,	PUNCT	$,	_	5	punct	_	_
-14	daß	daß	SCONJ	KOUS	_	20	mark	_	_
-15	wir	wir	PRON	PPER	Case=Nom|Number=Plur|Person=1|PronType=Prs	20	nsubj	_	_
-16	noch	noch	ADV	ADV	_	17	advmod	_	_
-17	mehr	mehr	ADV	ADV	_	20	advmod	_	_
-18	die	der	DET	ART	Case=Acc|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	19	det	_	_
-19	Öffentlichkeit	Öffentlichkeit	NOUN	NN	Case=Acc|Gender=Fem|Number=Sing	20	obj	_	_
-20	meiden	meiden	VERB	VVINF	VerbForm=Inf	5	ccomp	_	_
-21	müssen	müssen	AUX	VMFIN	Mood=Ind|Number=Plur|Person=1|Tense=Pres|VerbForm=Fin	20	aux	_	SpaceAfter=No
-22	.	.	PUNCT	$.	_	5	punct	_	_
-
-# sent_id = test-s567
-# text = Wir lieben uns'', versichert McCartney.
-1	Wir	wir	PRON	PPER	Case=Nom|Number=Plur|Person=1|PronType=Prs	2	nsubj	_	_
-2	lieben	lieben	VERB	VVFIN	Mood=Ind|Number=Plur|Person=1|Tense=Pres|VerbForm=Fin	6	ccomp	_	_
-3	uns	wir	PRON	PPER	Case=Acc|Number=Plur|Person=1|PronType=Prs	2	obj	_	SpaceAfter=No
-4	''	''	PUNCT	$(	_	6	punct	_	SpaceAfter=No
-5	,	,	PUNCT	$,	_	6	punct	_	_
-6	versichert	versichern	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	0	root	_	_
-7	McCartney	McCartney	PROPN	NE	Case=Nom|Number=Sing	6	nsubj	_	SpaceAfter=No
-8	.	.	PUNCT	$.	_	6	punct	_	_
-
-# sent_id = test-s568
-# text = Wir müssen'', so die 40jährige zur FR, ``Symbole auch hinterfragen können.''
-1	Wir	wir	PRON	PPER	Case=Nom|Number=Plur|Person=1|PronType=Prs	15	nsubj	_	_
-2	müssen	müssen	AUX	VMFIN	Mood=Ind|Number=Plur|Person=1|Tense=Pres|VerbForm=Fin	15	aux	_	SpaceAfter=No
-3	''	''	PUNCT	$(	_	15	punct	_	SpaceAfter=No
-4	,	,	PUNCT	$,	_	15	punct	_	_
-5	so	so	CCONJ	ADV	_	7	cc	_	_
-6	die	der	DET	ART	Case=Nom|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	7	det	_	_
-7	40jährige	40jährige	NOUN	NN	Case=Nom|Gender=Fem|Number=Sing	15	parataxis	_	_
-8-9	zur	_	_	_	_	_	_	_	_
-8	zu	zu	ADP	APPR	_	10	case	_	_
-9	der	der	DET	ART	Case=Dat|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	10	det	_	_
-10	FR	FR	PROPN	NE	Case=Dat|Gender=Fem|Number=Sing	7	nmod	_	SpaceAfter=No
-11	,	,	PUNCT	$,	_	15	punct	_	_
-12	``	``	PUNCT	$(	_	15	punct	_	SpaceAfter=No
-13	Symbole	Symbol	NOUN	NN	Case=Acc|Gender=Neut|Number=Plur	15	obj	_	_
-14	auch	auch	ADV	ADV	_	15	advmod	_	_
-15	hinterfragen	hinterfragen	VERB	VVINF	VerbForm=Inf	0	root	_	_
-16	können	können	AUX	VMINF	VerbForm=Inf	15	aux	_	SpaceAfter=No
-17	.	.	PUNCT	$.	_	15	punct	_	SpaceAfter=No
-18	''	''	PUNCT	$(	_	15	punct	_	_
-
-# sent_id = test-s569
-# text = Wir säubern das Terrain für 1996'', sagt Stark.
-1	Wir	wir	PRON	PPER	Case=Nom|Number=Plur|Person=1|PronType=Prs	2	nsubj	_	_
-2	säubern	säubern	VERB	VVFIN	Mood=Ind|Number=Plur|Person=1|Tense=Pres|VerbForm=Fin	9	ccomp	_	_
-3	das	der	DET	ART	Case=Acc|Definite=Def|Gender=Neut|Number=Sing|PronType=Art	4	det	_	_
-4	Terrain	Terrain	NOUN	NN	Case=Acc|Gender=Neut|Number=Sing	2	obj	_	_
-5	für	für	ADP	APPR	_	6	case	_	_
-6	1996	1996	NUM	CARD	NumType=Card	2	obl	_	SpaceAfter=No
-7	''	''	PUNCT	$(	_	9	punct	_	SpaceAfter=No
-8	,	,	PUNCT	$,	_	9	punct	_	_
-9	sagt	sagen	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	0	root	_	_
-10	Stark	Stark	PROPN	NE	Case=Nom|Number=Sing	9	nsubj	_	SpaceAfter=No
-11	.	.	PUNCT	$.	_	9	punct	_	_
-
-# sent_id = test-s570
-# text = Wir sind die grünen Lotsen auf einem Containerschiff.''
-1	Wir	wir	PRON	PPER	Case=Nom|Number=Plur|Person=1|PronType=Prs	5	nsubj	_	_
-2	sind	sein	AUX	VAFIN	Mood=Ind|Number=Plur|Person=1|Tense=Pres|VerbForm=Fin	5	cop	_	_
-3	die	der	DET	ART	Case=Nom|Definite=Def|Gender=Masc|Number=Plur|PronType=Art	5	det	_	_
-4	grünen	grün	ADJ	ADJA	Case=Nom|Gender=Masc|Number=Plur	5	amod	_	_
-5	Lotsen	Lotse	NOUN	NN	Case=Nom|Gender=Masc|Number=Plur	0	root	_	_
-6	auf	auf	ADP	APPR	_	8	case	_	_
-7	einem	ein	DET	ART	Case=Dat|Definite=Ind|Gender=Neut|Number=Sing|PronType=Art	8	det	_	_
-8	Containerschiff	Containerschiff	NOUN	NN	Case=Dat|Gender=Neut|Number=Sing	5	nmod	_	SpaceAfter=No
-9	.	.	PUNCT	$.	_	5	punct	_	SpaceAfter=No
-10	''	''	PUNCT	$(	_	5	punct	_	_
-
-# sent_id = test-s571
-# text = Wir wollen noch mehr'', betont Omicevic.
-1	Wir	wir	PRON	PPER	Case=Nom|Number=Plur|Person=1|PronType=Prs	2	nsubj	_	_
-2	wollen	wollen	VERB	VMFIN	Mood=Ind|Number=Plur|Person=1|Tense=Pres|VerbForm=Fin	7	ccomp	_	_
-3	noch	noch	ADV	ADV	_	4	advmod	_	_
-4	mehr	mehr	PRON	PIS	Definite=Ind|PronType=Ind	2	obj	_	SpaceAfter=No
-5	''	''	PUNCT	$(	_	7	punct	_	SpaceAfter=No
-6	,	,	PUNCT	$,	_	7	punct	_	_
-7	betont	betonen	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	0	root	_	_
-8	Omicevic	Omicevic	PROPN	NE	Case=Nom|Number=Sing	7	nsubj	_	SpaceAfter=No
-9	.	.	PUNCT	$.	_	7	punct	_	_
-
-# sent_id = test-s572
-# text = Wirtschaft klagt über die hohen Umweltstandards, die zu einem Nachteil im Standortwettbewerb würden und andere EU-Länder begünstigten.
-1	Wirtschaft	Wirtschaft	NOUN	NN	Case=Nom|Gender=Fem|Number=Sing	2	nsubj	_	_
-2	klagt	klagen	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	0	root	_	_
-3	über	über	ADP	APPR	_	6	case	_	_
-4	die	der	DET	ART	Case=Acc|Definite=Def|Gender=Masc|Number=Plur|PronType=Art	6	det	_	_
-5	hohen	hoch	ADJ	ADJA	Case=Acc|Gender=Masc|Number=Plur	6	amod	_	_
-6	Umweltstandards	Umweltstandard	NOUN	NN	Case=Acc|Gender=Masc|Number=Plur	2	obl	_	SpaceAfter=No
-7	,	,	PUNCT	$,	_	2	punct	_	_
-8	die	der	PRON	PRELS	Case=Nom|Gender=Masc|Number=Plur|PronType=Rel	15	nsubj	_	_
-9	zu	zu	ADP	APPR	_	11	case	_	_
-10	einem	ein	DET	ART	Case=Dat|Definite=Ind|Gender=Masc|Number=Sing|PronType=Art	11	det	_	_
-11	Nachteil	Nachteil	NOUN	NN	Case=Dat|Gender=Masc|Number=Sing	15	obl	_	_
+# text = Professor Wilhelm Heitmeyer leitet das Projekt ``Individualisierung und Gewalt'' im Sonderforschungsbereich ``Prävention und Intervention im Kindes- und Jugendalter'' der Universität Bielefeld.
+1	Professor	Professor	NOUN	NN	Case=Nom|Gender=Masc|Number=Sing	2	dep	_	FixTigerDep=Yes
+2	Wilhelm	Wilhelm	PROPN	NE	Case=Nom|Gender=Masc|Number=Sing	4	nsubj	_	_
+3	Heitmeyer	Heitmeyer	PROPN	NE	Case=Nom|Gender=Masc|Number=Sing	2	flat	_	_
+4	leitet	leiten	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	0	root	_	_
+5	das	der	DET	ART	Case=Acc|Definite=Def|Gender=Neut|Number=Sing|PronType=Art	6	det	_	_
+6	Projekt	Projekt	NOUN	NN	Case=Acc|Gender=Neut|Number=Sing	4	obj	_	_
+7	``	``	PUNCT	$(	_	8	punct	_	SpaceAfter=No
+8	Individualisierung	Individualisierung	NOUN	NN	Case=Nom|Gender=Fem|Number=Sing	6	appos	_	_
+9	und	und	CCONJ	KON	_	10	cc	_	_
+10	Gewalt	Gewalt	NOUN	NN	Case=Nom|Gender=Fem|Number=Sing	8	conj	_	SpaceAfter=No
+11	''	''	PUNCT	$(	_	8	punct	_	_
 12-13	im	_	_	_	_	_	_	_	_
 12	in	in	ADP	APPR	_	14	case	_	_
 13	dem	der	DET	ART	Case=Dat|Definite=Def|Gender=Masc|Number=Sing|PronType=Art	14	det	_	_
-14	Standortwettbewerb	Standortwettbewerb	NOUN	NN	Case=Dat|Gender=Masc|Number=Sing	11	nmod	_	_
-15	würden	werden	VERB	VAFIN	Mood=Sub|Number=Plur|Person=3|Tense=Past|VerbForm=Fin|Voice=Pass	6	acl	_	_
-16	und	und	CCONJ	KON	_	21	cc	_	_
-17	andere	anderer	ADJ	ADJA	Case=Acc|Gender=Neut|Number=Plur	18	amod	_	_
-18	EU	EU	PROPN	NN	Case=Acc|Gender=Neut|Number=Plur	20	compound	_	SpaceAfter=No
-19	-	-	PUNCT	$(	_	18	punct	_	SpaceAfter=No
-20	Länder	Land	NOUN	NN	Case=Acc|Gender=Neut|Number=Plur	21	obj	_	_
-21	begünstigten	begünstigen	VERB	VVFIN	Mood=Ind|Number=Plur|Person=3|Tense=Past|VerbForm=Fin	15	conj	_	SpaceAfter=No
-22	.	.	PUNCT	$.	_	2	punct	_	_
+14	Sonderforschungsbereich	Sonderforschungsbereich	NOUN	NN	Case=Dat|Gender=Masc|Number=Sing	6	nmod	_	_
+15	``	``	PUNCT	$(	_	16	punct	_	SpaceAfter=No
+16	Prävention	Prävention	NOUN	NN	Case=Nom|Gender=Fem|Number=Sing	14	compound	_	_
+17	und	und	CCONJ	KON	_	18	cc	_	_
+18	Intervention	Intervention	NOUN	NN	Case=Nom|Gender=Fem|Number=Sing	16	conj	_	_
+19-20	im	_	_	_	_	_	_	_	_
+19	in	in	ADP	APPR	_	21	case	_	_
+20	dem	der	DET	ART	Case=Dat|Definite=Def|Gender=Neut|Number=Sing|PronType=Art	21	det	_	_
+21	Kindes	Kind	NOUN	TRUNC	Case=Dat|Gender=Neut|Number=Sing	16	compound	_	SpaceAfter=No
+22	-	-	PUNCT	$(	_	24	punct	_	_
+23	und	und	CCONJ	KON	_	24	cc	_	_
+24	Jugendalter	Jugendalter	NOUN	NN	Case=Dat|Gender=Neut|Number=Sing	21	conj	_	SpaceAfter=No
+25	''	''	PUNCT	$(	_	16	punct	_	_
+26	der	der	DET	ART	Case=Gen|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	28	det	_	_
+27	Universität	Universität	NOUN	NN	Case=Gen|Gender=Fem|Number=Sing	28	compound	_	_
+28	Bielefeld	Bielefeld	PROPN	NE	Case=Nom|Gender=Neut|Number=Sing	14	nmod	_	SpaceAfter=No
+29	.	.	PUNCT	$.	_	4	punct	_	_
+
+# sent_id = test-s563
+# text = August Wilhelm Schlegel hatte aus dem ``translated Bottom'' einen ``transferierten Zettel'' gemacht.
+1	August	August	PROPN	NE	Case=Nom|Gender=Masc|Number=Sing	2	dep	_	FixTigerDep=Yes
+2	Wilhelm	Wilhelm	PROPN	NE	Case=Nom|Gender=Masc|Number=Sing	16	nsubj	_	_
+3	Schlegel	Schlegel	PROPN	NE	Case=Nom|Gender=Masc|Number=Sing	2	flat	_	_
+4	hatte	haben	AUX	VAFIN	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	16	aux	_	_
+5	aus	aus	ADP	APPR	_	9	case	_	_
+6	dem	der	DET	ART	Case=Dat|Definite=Def|Gender=Masc|Number=Sing|PronType=Art	9	det	_	_
+7	``	``	PUNCT	$(	_	9	punct	_	SpaceAfter=No
+8	translated	translated	X	FM	Foreign=Yes	9	compound	_	_
+9	Bottom	Bottom	X	FM	Foreign=Yes	16	obl	_	SpaceAfter=No
+10	''	''	PUNCT	$(	_	9	punct	_	_
+11	einen	ein	DET	ART	Case=Acc|Definite=Ind|Gender=Masc|Number=Sing|PronType=Art	14	det	_	_
+12	``	``	PUNCT	$(	_	14	punct	_	SpaceAfter=No
+13	transferierten	transferiert	ADJ	ADJA	Case=Acc|Gender=Masc|Number=Sing	14	amod	_	_
+14	Zettel	Zettel	NOUN	NN	Case=Acc|Gender=Masc|Number=Sing	16	obj	_	SpaceAfter=No
+15	''	''	PUNCT	$(	_	14	punct	_	_
+16	gemacht	machen	VERB	VVPP	VerbForm=Part	0	root	_	SpaceAfter=No
+17	.	.	PUNCT	$.	_	16	punct	_	_
+
+# sent_id = test-s564
+# text = ``Wir haben alle Formulierungen vermieden, die irgendein Gesetz in Kuba verletzen könnten'', erklärt mit milder Stimme Castellanos, ``und das hat uns dennoch nicht vor dem Rausschmiß bewahrt.''
+1	``	``	PUNCT	$(	_	2	punct	_	FixTigerDep=Yes|SpaceAfter=No
+2	Wir	wir	PRON	PPER	Case=Nom|Number=Plur|Person=1|PronType=Prs	6	nsubj	_	_
+3	haben	haben	AUX	VAFIN	Mood=Ind|Number=Plur|Person=1|Tense=Pres|VerbForm=Fin	6	aux	_	_
+4	alle	alle	PRON	PIAT	Case=Acc|Definite=Ind|Gender=Fem|Number=Plur|PronType=Ind	5	det	_	_
+5	Formulierungen	Formulierung	NOUN	NN	Case=Acc|Gender=Fem|Number=Plur	6	obj	_	_
+6	vermieden	vermeiden	VERB	VVPP	VerbForm=Part	0	root	_	SpaceAfter=No
+7	,	,	PUNCT	$,	_	33	punct	_	_
+8	die	der	PRON	PRELS	Case=Nom|Gender=Fem|Number=Plur|PronType=Rel	13	nsubj	_	_
+9	irgendein	irgendein	PRON	PIAT	Case=Acc|Definite=Ind|Gender=Neut|Number=Sing|PronType=Ind	10	det	_	_
+10	Gesetz	Gesetz	NOUN	NN	Case=Acc|Gender=Neut|Number=Sing	13	obj	_	_
+11	in	in	ADP	APPR	_	12	case	_	_
+12	Kuba	Kuba	PROPN	NE	Case=Dat|Gender=Neut|Number=Sing	10	nmod	_	_
+13	verletzen	verletzen	VERB	VVINF	VerbForm=Inf	5	acl	_	_
+14	könnten	können	AUX	VMFIN	Mood=Sub|Number=Plur|Person=3|Tense=Past|VerbForm=Fin	13	aux	_	SpaceAfter=No
+15	''	''	PUNCT	$(	_	33	punct	_	SpaceAfter=No
+16	,	,	PUNCT	$,	_	33	punct	_	_
+17	erklärt	erklären	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	6	parataxis	_	_
+18	mit	mit	ADP	APPR	_	20	case	_	_
+19	milder	mild	ADJ	ADJA	Case=Dat|Gender=Fem|Number=Sing	20	amod	_	_
+20	Stimme	Stimme	NOUN	NN	Case=Dat|Gender=Fem|Number=Sing	17	obl	_	_
+21	Castellanos	Castellanos	PROPN	NE	Case=Nom|Number=Sing	17	nsubj	_	SpaceAfter=No
+22	,	,	PUNCT	$,	_	33	punct	_	_
+23	``	``	PUNCT	$(	_	33	punct	_	SpaceAfter=No
+24	und	und	CCONJ	KON	_	33	cc	_	_
+25	das	der	PRON	PDS	Case=Nom|Gender=Neut|Number=Sing|PronType=Dem	33	nsubj	_	_
+26	hat	haben	AUX	VAFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	33	aux	_	_
+27	uns	wir	PRON	PPER	Case=Acc|Number=Plur|Person=1|PronType=Prs	33	obj	_	_
+28	dennoch	dennoch	ADV	ADV	_	33	advmod	_	_
+29	nicht	nicht	PART	PTKNEG	Polarity=Neg	33	advmod	_	_
+30	vor	vor	ADP	APPR	_	32	case	_	_
+31	dem	der	DET	ART	Case=Dat|Definite=Def|Gender=Masc|Number=Sing|PronType=Art	32	det	_	_
+32	Rausschmiß	Rausschmiß	NOUN	NN	Case=Dat|Gender=Masc|Number=Sing	33	obl	_	_
+33	bewahrt	bewahren	VERB	VVPP	VerbForm=Part	6	conj	_	SpaceAfter=No
+34	.	.	PUNCT	$.	_	6	punct	_	SpaceAfter=No
+35	''	''	PUNCT	$(	_	6	punct	_	_
+
+# sent_id = test-s565
+# text = ``Wir haben die faulste Regierung und den faulsten Ministerpräsidenten der Republik'', monierte Müller.
+1	``	``	PUNCT	$(	_	2	punct	_	FixTigerDep=Yes|SpaceAfter=No
+2	Wir	wir	PRON	PPER	Case=Nom|Number=Plur|Person=1|PronType=Prs	3	nsubj	_	_
+3	haben	haben	VERB	VAFIN	Mood=Ind|Number=Plur|Person=1|Tense=Pres|VerbForm=Fin	15	ccomp	_	_
+4	die	der	DET	ART	Case=Acc|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	6	det	_	_
+5	faulste	faul	ADJ	ADJA	Case=Acc|Gender=Fem|Number=Sing	6	amod	_	_
+6	Regierung	Regierung	NOUN	NN	Case=Acc|Gender=Fem|Number=Sing	3	obj	_	_
+7	und	und	CCONJ	KON	_	10	cc	_	_
+8	den	der	DET	ART	Case=Acc|Definite=Def|Gender=Masc|Number=Sing|PronType=Art	10	det	_	_
+9	faulsten	faul	ADJ	ADJA	Case=Acc|Gender=Masc|Number=Sing	10	amod	_	_
+10	Ministerpräsidenten	Ministerpräsident	NOUN	NN	Case=Acc|Gender=Masc|Number=Sing	6	conj	_	_
+11	der	der	DET	ART	Case=Gen|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	12	det	_	_
+12	Republik	Republik	NOUN	NN	Case=Gen|Gender=Fem|Number=Sing	10	nmod	_	SpaceAfter=No
+13	''	''	PUNCT	$(	_	3	punct	_	SpaceAfter=No
+14	,	,	PUNCT	$,	_	3	punct	_	_
+15	monierte	monieren	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	0	root	_	_
+16	Müller	Müller	PROPN	NE	Case=Nom|Number=Sing	15	nsubj	_	SpaceAfter=No
+17	.	.	PUNCT	$.	_	15	punct	_	_
+
+# sent_id = test-s566
+# text = ``Wir in der Wirtschaft lernen von eurer Erniedrigung und von euren Skandalen, daß wir noch mehr die Öffentlichkeit meiden müssen.
+1	``	``	PUNCT	$(	_	2	punct	_	FixTigerDep=Yes|SpaceAfter=No
+2	Wir	wir	PRON	PPER	Case=Nom|Number=Plur|Person=1|PronType=Prs	6	nsubj	_	_
+3	in	in	ADP	APPR	_	5	case	_	_
+4	der	der	DET	ART	Case=Dat|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	5	det	_	_
+5	Wirtschaft	Wirtschaft	NOUN	NN	Case=Dat|Gender=Fem|Number=Sing	2	nmod	_	_
+6	lernen	lernen	VERB	VVFIN	Mood=Ind|Number=Plur|Person=1|Tense=Pres|VerbForm=Fin	0	root	_	_
+7	von	von	ADP	APPR	_	9	case	_	_
+8	eurer	euer	PRON	PPOSAT	Case=Dat|Gender=Fem|Number=Sing|Poss=Yes	9	det:poss	_	_
+9	Erniedrigung	Erniedrigung	NOUN	NN	Case=Dat|Gender=Fem|Number=Sing	6	obl	_	_
+10	und	und	CCONJ	KON	_	13	cc	_	_
+11	von	von	ADP	APPR	_	13	case	_	_
+12	euren	euer	PRON	PPOSAT	Case=Dat|Gender=Masc|Number=Plur|Poss=Yes	13	det:poss	_	_
+13	Skandalen	Skandal	NOUN	NN	Case=Dat|Gender=Masc|Number=Plur	9	conj	_	SpaceAfter=No
+14	,	,	PUNCT	$,	_	6	punct	_	_
+15	daß	daß	SCONJ	KOUS	_	21	mark	_	_
+16	wir	wir	PRON	PPER	Case=Nom|Number=Plur|Person=1|PronType=Prs	21	nsubj	_	_
+17	noch	noch	ADV	ADV	_	18	advmod	_	_
+18	mehr	mehr	ADV	ADV	_	21	advmod	_	_
+19	die	der	DET	ART	Case=Acc|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	20	det	_	_
+20	Öffentlichkeit	Öffentlichkeit	NOUN	NN	Case=Acc|Gender=Fem|Number=Sing	21	obj	_	_
+21	meiden	meiden	VERB	VVINF	VerbForm=Inf	6	ccomp	_	_
+22	müssen	müssen	AUX	VMFIN	Mood=Ind|Number=Plur|Person=1|Tense=Pres|VerbForm=Fin	21	aux	_	SpaceAfter=No
+23	.	.	PUNCT	$.	_	6	punct	_	_
+
+# sent_id = test-s567
+# text = ``Wir lieben uns'', versichert McCartney.
+1	``	``	PUNCT	$(	_	2	punct	_	FixTigerDep=Yes|SpaceAfter=No
+2	Wir	wir	PRON	PPER	Case=Nom|Number=Plur|Person=1|PronType=Prs	3	nsubj	_	_
+3	lieben	lieben	VERB	VVFIN	Mood=Ind|Number=Plur|Person=1|Tense=Pres|VerbForm=Fin	7	ccomp	_	_
+4	uns	wir	PRON	PPER	Case=Acc|Number=Plur|Person=1|PronType=Prs	3	obj	_	SpaceAfter=No
+5	''	''	PUNCT	$(	_	7	punct	_	SpaceAfter=No
+6	,	,	PUNCT	$,	_	7	punct	_	_
+7	versichert	versichern	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	0	root	_	_
+8	McCartney	McCartney	PROPN	NE	Case=Nom|Number=Sing	7	nsubj	_	SpaceAfter=No
+9	.	.	PUNCT	$.	_	7	punct	_	_
+
+# sent_id = test-s568
+# text = ``Wir müssen'', so die 40jährige zur FR, ``Symbole auch hinterfragen können.''
+1	``	``	PUNCT	$(	_	2	punct	_	FixTigerDep=Yes|SpaceAfter=No
+2	Wir	wir	PRON	PPER	Case=Nom|Number=Plur|Person=1|PronType=Prs	16	nsubj	_	_
+3	müssen	müssen	AUX	VMFIN	Mood=Ind|Number=Plur|Person=1|Tense=Pres|VerbForm=Fin	16	aux	_	SpaceAfter=No
+4	''	''	PUNCT	$(	_	16	punct	_	SpaceAfter=No
+5	,	,	PUNCT	$,	_	16	punct	_	_
+6	so	so	CCONJ	ADV	_	8	cc	_	_
+7	die	der	DET	ART	Case=Nom|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	8	det	_	_
+8	40jährige	40jährige	NOUN	NN	Case=Nom|Gender=Fem|Number=Sing	16	parataxis	_	_
+9-10	zur	_	_	_	_	_	_	_	_
+9	zu	zu	ADP	APPR	_	11	case	_	_
+10	der	der	DET	ART	Case=Dat|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	11	det	_	_
+11	FR	FR	PROPN	NE	Case=Dat|Gender=Fem|Number=Sing	8	nmod	_	SpaceAfter=No
+12	,	,	PUNCT	$,	_	16	punct	_	_
+13	``	``	PUNCT	$(	_	16	punct	_	SpaceAfter=No
+14	Symbole	Symbol	NOUN	NN	Case=Acc|Gender=Neut|Number=Plur	16	obj	_	_
+15	auch	auch	ADV	ADV	_	16	advmod	_	_
+16	hinterfragen	hinterfragen	VERB	VVINF	VerbForm=Inf	0	root	_	_
+17	können	können	AUX	VMINF	VerbForm=Inf	16	aux	_	SpaceAfter=No
+18	.	.	PUNCT	$.	_	16	punct	_	SpaceAfter=No
+19	''	''	PUNCT	$(	_	16	punct	_	_
+
+# sent_id = test-s569
+# text = ``Wir säubern das Terrain für 1996'', sagt Stark.
+1	``	``	PUNCT	$(	_	2	punct	_	FixTigerDep=Yes|SpaceAfter=No
+2	Wir	wir	PRON	PPER	Case=Nom|Number=Plur|Person=1|PronType=Prs	3	nsubj	_	_
+3	säubern	säubern	VERB	VVFIN	Mood=Ind|Number=Plur|Person=1|Tense=Pres|VerbForm=Fin	10	ccomp	_	_
+4	das	der	DET	ART	Case=Acc|Definite=Def|Gender=Neut|Number=Sing|PronType=Art	5	det	_	_
+5	Terrain	Terrain	NOUN	NN	Case=Acc|Gender=Neut|Number=Sing	3	obj	_	_
+6	für	für	ADP	APPR	_	7	case	_	_
+7	1996	1996	NUM	CARD	NumType=Card	3	obl	_	SpaceAfter=No
+8	''	''	PUNCT	$(	_	10	punct	_	SpaceAfter=No
+9	,	,	PUNCT	$,	_	10	punct	_	_
+10	sagt	sagen	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	0	root	_	_
+11	Stark	Stark	PROPN	NE	Case=Nom|Number=Sing	10	nsubj	_	SpaceAfter=No
+12	.	.	PUNCT	$.	_	10	punct	_	_
+
+# sent_id = test-s570
+# text = ``Wir sind die grünen Lotsen auf einem Containerschiff.''
+1	``	``	PUNCT	$(	_	2	punct	_	FixTigerDep=Yes|SpaceAfter=No
+2	Wir	wir	PRON	PPER	Case=Nom|Number=Plur|Person=1|PronType=Prs	6	nsubj	_	_
+3	sind	sein	AUX	VAFIN	Mood=Ind|Number=Plur|Person=1|Tense=Pres|VerbForm=Fin	6	cop	_	_
+4	die	der	DET	ART	Case=Nom|Definite=Def|Gender=Masc|Number=Plur|PronType=Art	6	det	_	_
+5	grünen	grün	ADJ	ADJA	Case=Nom|Gender=Masc|Number=Plur	6	amod	_	_
+6	Lotsen	Lotse	NOUN	NN	Case=Nom|Gender=Masc|Number=Plur	0	root	_	_
+7	auf	auf	ADP	APPR	_	9	case	_	_
+8	einem	ein	DET	ART	Case=Dat|Definite=Ind|Gender=Neut|Number=Sing|PronType=Art	9	det	_	_
+9	Containerschiff	Containerschiff	NOUN	NN	Case=Dat|Gender=Neut|Number=Sing	6	nmod	_	SpaceAfter=No
+10	.	.	PUNCT	$.	_	6	punct	_	SpaceAfter=No
+11	''	''	PUNCT	$(	_	6	punct	_	_
+
+# sent_id = test-s571
+# text = ``Wir wollen noch mehr'', betont Omicevic.
+1	``	``	PUNCT	$(	_	2	punct	_	FixTigerDep=Yes|SpaceAfter=No
+2	Wir	wir	PRON	PPER	Case=Nom|Number=Plur|Person=1|PronType=Prs	3	nsubj	_	_
+3	wollen	wollen	VERB	VMFIN	Mood=Ind|Number=Plur|Person=1|Tense=Pres|VerbForm=Fin	8	ccomp	_	_
+4	noch	noch	ADV	ADV	_	5	advmod	_	_
+5	mehr	mehr	PRON	PIS	Definite=Ind|PronType=Ind	3	obj	_	SpaceAfter=No
+6	''	''	PUNCT	$(	_	8	punct	_	SpaceAfter=No
+7	,	,	PUNCT	$,	_	8	punct	_	_
+8	betont	betonen	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	0	root	_	_
+9	Omicevic	Omicevic	PROPN	NE	Case=Nom|Number=Sing	8	nsubj	_	SpaceAfter=No
+10	.	.	PUNCT	$.	_	8	punct	_	_
+
+# sent_id = test-s572
+# text = Die Wirtschaft klagt über die hohen Umweltstandards, die zu einem Nachteil im Standortwettbewerb würden und andere EU-Länder begünstigten.
+1	Die	der	DET	ART	Case=Nom|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	2	dep	_	FixTigerDep=Yes
+2	Wirtschaft	Wirtschaft	NOUN	NN	Case=Nom|Gender=Fem|Number=Sing	3	nsubj	_	_
+3	klagt	klagen	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	0	root	_	_
+4	über	über	ADP	APPR	_	7	case	_	_
+5	die	der	DET	ART	Case=Acc|Definite=Def|Gender=Masc|Number=Plur|PronType=Art	7	det	_	_
+6	hohen	hoch	ADJ	ADJA	Case=Acc|Gender=Masc|Number=Plur	7	amod	_	_
+7	Umweltstandards	Umweltstandard	NOUN	NN	Case=Acc|Gender=Masc|Number=Plur	3	obl	_	SpaceAfter=No
+8	,	,	PUNCT	$,	_	3	punct	_	_
+9	die	der	PRON	PRELS	Case=Nom|Gender=Masc|Number=Plur|PronType=Rel	16	nsubj	_	_
+10	zu	zu	ADP	APPR	_	12	case	_	_
+11	einem	ein	DET	ART	Case=Dat|Definite=Ind|Gender=Masc|Number=Sing|PronType=Art	12	det	_	_
+12	Nachteil	Nachteil	NOUN	NN	Case=Dat|Gender=Masc|Number=Sing	16	obl	_	_
+13-14	im	_	_	_	_	_	_	_	_
+13	in	in	ADP	APPR	_	15	case	_	_
+14	dem	der	DET	ART	Case=Dat|Definite=Def|Gender=Masc|Number=Sing|PronType=Art	15	det	_	_
+15	Standortwettbewerb	Standortwettbewerb	NOUN	NN	Case=Dat|Gender=Masc|Number=Sing	12	nmod	_	_
+16	würden	werden	VERB	VAFIN	Mood=Sub|Number=Plur|Person=3|Tense=Past|VerbForm=Fin|Voice=Pass	7	acl	_	_
+17	und	und	CCONJ	KON	_	22	cc	_	_
+18	andere	anderer	ADJ	ADJA	Case=Acc|Gender=Neut|Number=Plur	19	amod	_	_
+19	EU	EU	PROPN	NN	Case=Acc|Gender=Neut|Number=Plur	21	compound	_	SpaceAfter=No
+20	-	-	PUNCT	$(	_	19	punct	_	SpaceAfter=No
+21	Länder	Land	NOUN	NN	Case=Acc|Gender=Neut|Number=Plur	22	obj	_	_
+22	begünstigten	begünstigen	VERB	VVFIN	Mood=Ind|Number=Plur|Person=3|Tense=Past|VerbForm=Fin	16	conj	_	SpaceAfter=No
+23	.	.	PUNCT	$.	_	3	punct	_	_
 
 # sent_id = test-s573
-# text = Wirtschaftsräume können indessen nur dann ihre Vorteile voll nutzen und ein eigenes kulturelles, soziales und ökologisches Entwicklungsmodell verfolgen, wenn sie über eine gemeinsame Währung und eine kohärente Wirtschafts- und Finanzpolitik verfügen.
-1	Wirtschaftsräume	Wirtschaftsraum	NOUN	NN	Case=Nom|Gender=Masc|Number=Plur	9	nsubj	_	_
-2	können	können	AUX	VMFIN	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	9	aux	_	_
-3	indessen	indessen	ADV	ADV	_	9	advmod	_	_
-4	nur	nur	ADV	ADV	_	9	advmod	_	_
-5	dann	dann	ADV	ADV	_	4	advmod	_	_
-6	ihre	ihr	PRON	PPOSAT	Case=Acc|Gender=Masc|Number=Plur|Poss=Yes	7	det:poss	_	_
-7	Vorteile	Vorteil	NOUN	NN	Case=Acc|Gender=Masc|Number=Plur	9	obj	_	_
-8	voll	voll	ADV	ADJD	_	9	advmod	_	_
-9	nutzen	nutzen	VERB	VVINF	VerbForm=Inf	0	root	_	_
-10	und	und	CCONJ	KON	_	19	cc	_	_
-11	ein	ein	DET	ART	Case=Acc|Definite=Ind|Gender=Neut|Number=Sing|PronType=Art	18	det	_	_
-12	eigenes	eigen	ADJ	ADJA	Case=Acc|Gender=Neut|Number=Sing	18	amod	_	_
-13	kulturelles	kulturell	ADJ	ADJA	Case=Acc|Gender=Neut|Number=Sing	18	amod	_	SpaceAfter=No
-14	,	,	PUNCT	$,	_	15	punct	_	_
-15	soziales	sozial	ADJ	ADJA	Case=Acc|Gender=Neut|Number=Sing	13	conj	_	_
-16	und	und	CCONJ	KON	_	17	cc	_	_
-17	ökologisches	ökologisch	ADJ	ADJA	Case=Acc|Gender=Neut|Number=Sing	15	conj	_	_
-18	Entwicklungsmodell	Entwicklungsmodell	NOUN	NN	Case=Acc|Gender=Neut|Number=Sing	19	obj	_	_
-19	verfolgen	verfolgen	VERB	VVINF	VerbForm=Inf	9	conj	_	SpaceAfter=No
-20	,	,	PUNCT	$,	_	9	punct	_	_
-21	wenn	wenn	SCONJ	KOUS	_	34	mark	_	_
-22	sie	sie	PRON	PPER	Case=Nom|Gender=Masc|Number=Plur|Person=3|PronType=Prs	34	nsubj	_	_
-23	über	über	ADP	APPR	_	26	case	_	_
-24	eine	ein	DET	ART	Case=Acc|Definite=Ind|Gender=Fem|Number=Sing|PronType=Art	26	det	_	_
-25	gemeinsame	gemeinsam	ADJ	ADJA	Case=Acc|Gender=Fem|Number=Sing	26	amod	_	_
-26	Währung	Währung	NOUN	NN	Case=Acc|Gender=Fem|Number=Sing	34	obl	_	_
-27	und	und	CCONJ	KON	_	30	cc	_	_
-28	eine	ein	DET	ART	Case=Acc|Definite=Ind|Gender=Fem|Number=Sing|PronType=Art	30	det	_	_
-29	kohärente	kohärent	ADJ	ADJA	Case=Acc|Gender=Fem|Number=Sing	30	amod	_	_
-30	Wirtschafts	Wirtschafts	NOUN	TRUNC	Case=Acc|Gender=Fem|Number=Sing	26	compound	_	SpaceAfter=No
-31	-	-	PUNCT	$(	_	33	punct	_	_
-32	und	und	CCONJ	KON	_	33	cc	_	_
-33	Finanzpolitik	Finanzpolitik	NOUN	NN	Case=Acc|Gender=Fem|Number=Sing	30	conj	_	_
-34	verfügen	verfügen	VERB	VVFIN	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	19	advcl	_	SpaceAfter=No
-35	.	.	PUNCT	$.	_	9	punct	_	_
+# text = Regionale Wirtschaftsräume können indessen nur dann ihre Vorteile voll nutzen und ein eigenes kulturelles, soziales und ökologisches Entwicklungsmodell verfolgen, wenn sie über eine gemeinsame Währung und eine kohärente Wirtschafts- und Finanzpolitik verfügen.
+1	Regionale	regional	ADJ	ADJA	Case=Nom|Gender=Masc|Number=Plur	2	dep	_	FixTigerDep=Yes
+2	Wirtschaftsräume	Wirtschaftsraum	NOUN	NN	Case=Nom|Gender=Masc|Number=Plur	10	nsubj	_	_
+3	können	können	AUX	VMFIN	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	10	aux	_	_
+4	indessen	indessen	ADV	ADV	_	10	advmod	_	_
+5	nur	nur	ADV	ADV	_	10	advmod	_	_
+6	dann	dann	ADV	ADV	_	5	advmod	_	_
+7	ihre	ihr	PRON	PPOSAT	Case=Acc|Gender=Masc|Number=Plur|Poss=Yes	8	det:poss	_	_
+8	Vorteile	Vorteil	NOUN	NN	Case=Acc|Gender=Masc|Number=Plur	10	obj	_	_
+9	voll	voll	ADV	ADJD	_	10	advmod	_	_
+10	nutzen	nutzen	VERB	VVINF	VerbForm=Inf	0	root	_	_
+11	und	und	CCONJ	KON	_	20	cc	_	_
+12	ein	ein	DET	ART	Case=Acc|Definite=Ind|Gender=Neut|Number=Sing|PronType=Art	19	det	_	_
+13	eigenes	eigen	ADJ	ADJA	Case=Acc|Gender=Neut|Number=Sing	19	amod	_	_
+14	kulturelles	kulturell	ADJ	ADJA	Case=Acc|Gender=Neut|Number=Sing	19	amod	_	SpaceAfter=No
+15	,	,	PUNCT	$,	_	16	punct	_	_
+16	soziales	sozial	ADJ	ADJA	Case=Acc|Gender=Neut|Number=Sing	14	conj	_	_
+17	und	und	CCONJ	KON	_	18	cc	_	_
+18	ökologisches	ökologisch	ADJ	ADJA	Case=Acc|Gender=Neut|Number=Sing	16	conj	_	_
+19	Entwicklungsmodell	Entwicklungsmodell	NOUN	NN	Case=Acc|Gender=Neut|Number=Sing	20	obj	_	_
+20	verfolgen	verfolgen	VERB	VVINF	VerbForm=Inf	10	conj	_	SpaceAfter=No
+21	,	,	PUNCT	$,	_	10	punct	_	_
+22	wenn	wenn	SCONJ	KOUS	_	35	mark	_	_
+23	sie	sie	PRON	PPER	Case=Nom|Gender=Masc|Number=Plur|Person=3|PronType=Prs	35	nsubj	_	_
+24	über	über	ADP	APPR	_	27	case	_	_
+25	eine	ein	DET	ART	Case=Acc|Definite=Ind|Gender=Fem|Number=Sing|PronType=Art	27	det	_	_
+26	gemeinsame	gemeinsam	ADJ	ADJA	Case=Acc|Gender=Fem|Number=Sing	27	amod	_	_
+27	Währung	Währung	NOUN	NN	Case=Acc|Gender=Fem|Number=Sing	35	obl	_	_
+28	und	und	CCONJ	KON	_	31	cc	_	_
+29	eine	ein	DET	ART	Case=Acc|Definite=Ind|Gender=Fem|Number=Sing|PronType=Art	31	det	_	_
+30	kohärente	kohärent	ADJ	ADJA	Case=Acc|Gender=Fem|Number=Sing	31	amod	_	_
+31	Wirtschafts	Wirtschafts	NOUN	TRUNC	Case=Acc|Gender=Fem|Number=Sing	27	compound	_	SpaceAfter=No
+32	-	-	PUNCT	$(	_	34	punct	_	_
+33	und	und	CCONJ	KON	_	34	cc	_	_
+34	Finanzpolitik	Finanzpolitik	NOUN	NN	Case=Acc|Gender=Fem|Number=Sing	31	conj	_	_
+35	verfügen	verfügen	VERB	VVFIN	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	20	advcl	_	SpaceAfter=No
+36	.	.	PUNCT	$.	_	10	punct	_	_
 
 # sent_id = test-s574
-# text = Wo sie fehlen, sagt man, täten es in diesem Fall auch mal Repliken.)
-1	Wo	wo	ADV	PWAV	PronType=Int	3	advmod	_	_
-2	sie	sie	PRON	PPER	Case=Nom|Number=Plur|Person=3|PronType=Prs	3	nsubj	_	_
-3	fehlen	fehlen	VERB	VVFIN	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	8	advcl	_	SpaceAfter=No
-4	,	,	PUNCT	$,	_	8	punct	_	_
-5	sagt	sagen	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	8	parataxis	_	_
-6	man	man	PRON	PIS	Case=Nom|Definite=Ind|Number=Sing|PronType=Ind	5	nsubj	_	SpaceAfter=No
-7	,	,	PUNCT	$,	_	8	punct	_	_
-8	täten	tun	VERB	VVFIN	Mood=Sub|Number=Plur|Person=3|Tense=Past|VerbForm=Fin	0	root	_	_
-9	es	es	PRON	PPER	Case=Nom|Gender=Neut|Number=Sing|Person=3|PronType=Prs	8	expl	_	_
-10	in	in	ADP	APPR	_	12	case	_	_
-11	diesem	dies	PRON	PDAT	Case=Dat|Gender=Masc|Number=Sing|PronType=Dem	12	det	_	_
-12	Fall	Fall	NOUN	NN	Case=Dat|Gender=Masc|Number=Sing	8	obl	_	_
-13	auch	auch	ADV	ADV	_	14	advmod	_	_
-14	mal	mal	ADV	ADV	_	8	advmod	_	_
-15	Repliken	Replik	NOUN	NN	Case=Nom|Gender=Fem|Number=Plur	8	nsubj	_	SpaceAfter=No
-16	.	.	PUNCT	$.	_	8	punct	_	SpaceAfter=No
-17	)	)	PUNCT	$(	_	8	punct	_	_
+# text = (Wo sie fehlen, sagt man, täten es in diesem Fall auch mal Repliken.)
+1	(	(	PUNCT	$(	_	2	punct	_	FixTigerDep=Yes|SpaceAfter=No
+2	Wo	wo	ADV	PWAV	PronType=Int	4	advmod	_	_
+3	sie	sie	PRON	PPER	Case=Nom|Number=Plur|Person=3|PronType=Prs	4	nsubj	_	_
+4	fehlen	fehlen	VERB	VVFIN	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	9	advcl	_	SpaceAfter=No
+5	,	,	PUNCT	$,	_	9	punct	_	_
+6	sagt	sagen	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	9	parataxis	_	_
+7	man	man	PRON	PIS	Case=Nom|Definite=Ind|Number=Sing|PronType=Ind	6	nsubj	_	SpaceAfter=No
+8	,	,	PUNCT	$,	_	9	punct	_	_
+9	täten	tun	VERB	VVFIN	Mood=Sub|Number=Plur|Person=3|Tense=Past|VerbForm=Fin	0	root	_	_
+10	es	es	PRON	PPER	Case=Nom|Gender=Neut|Number=Sing|Person=3|PronType=Prs	9	expl	_	_
+11	in	in	ADP	APPR	_	13	case	_	_
+12	diesem	dies	PRON	PDAT	Case=Dat|Gender=Masc|Number=Sing|PronType=Dem	13	det	_	_
+13	Fall	Fall	NOUN	NN	Case=Dat|Gender=Masc|Number=Sing	9	obl	_	_
+14	auch	auch	ADV	ADV	_	15	advmod	_	_
+15	mal	mal	ADV	ADV	_	9	advmod	_	_
+16	Repliken	Replik	NOUN	NN	Case=Nom|Gender=Fem|Number=Plur	9	nsubj	_	SpaceAfter=No
+17	.	.	PUNCT	$.	_	9	punct	_	SpaceAfter=No
+18	)	)	PUNCT	$(	_	9	punct	_	_
 
 # sent_id = test-s575
-# text = Wollt ihr den Bruch mit dem System?
-1	Wollt	wollen	VERB	VMFIN	Mood=Ind|Number=Plur|Person=2|Tense=Pres|VerbForm=Fin	0	root	_	_
-2	ihr	ihr	PRON	PPER	Case=Nom|Number=Plur|Person=2|PronType=Prs	1	nsubj	_	_
-3	den	der	DET	ART	Case=Acc|Definite=Def|Gender=Masc|Number=Sing|PronType=Art	4	det	_	_
-4	Bruch	Bruch	NOUN	NN	Case=Acc|Gender=Masc|Number=Sing	1	obj	_	_
-5	mit	mit	ADP	APPR	_	7	case	_	_
-6	dem	der	DET	ART	Case=Dat|Definite=Def|Gender=Neut|Number=Sing|PronType=Art	7	det	_	_
-7	System	System	NOUN	NN	Case=Dat|Gender=Neut|Number=Sing	4	nmod	_	SpaceAfter=No
-8	?	?	PUNCT	$.	_	1	punct	_	_
+# text = ``Wollt ihr den Bruch mit dem System?
+1	``	``	PUNCT	$(	_	2	punct	_	FixTigerDep=Yes|SpaceAfter=No
+2	Wollt	wollen	VERB	VMFIN	Mood=Ind|Number=Plur|Person=2|Tense=Pres|VerbForm=Fin	0	root	_	_
+3	ihr	ihr	PRON	PPER	Case=Nom|Number=Plur|Person=2|PronType=Prs	2	nsubj	_	_
+4	den	der	DET	ART	Case=Acc|Definite=Def|Gender=Masc|Number=Sing|PronType=Art	5	det	_	_
+5	Bruch	Bruch	NOUN	NN	Case=Acc|Gender=Masc|Number=Sing	2	obj	_	_
+6	mit	mit	ADP	APPR	_	8	case	_	_
+7	dem	der	DET	ART	Case=Dat|Definite=Def|Gender=Neut|Number=Sing|PronType=Art	8	det	_	_
+8	System	System	NOUN	NN	Case=Dat|Gender=Neut|Number=Sing	5	nmod	_	SpaceAfter=No
+9	?	?	PUNCT	$.	_	2	punct	_	_
 
 # sent_id = test-s576
-# text = Yard schwieg sich über deren Nationalität am Montag aus.
-1	Yard	Yard	PROPN	NE	Case=Nom|Number=Sing	2	nsubj	_	_
-2	schwieg	schweigen	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	0	root	_	_
-3	sich	er|es|sie	PRON	PRF	Case=Acc|Number=Sing|Person=3|PronType=Prs|Reflex=Yes	2	obj	_	_
-4	über	über	ADP	APPR	_	6	case	_	_
-5	deren	der	PRON	PDS	Case=Gen|Number=Plur|PronType=Dem	6	det	_	_
-6	Nationalität	Nationalität	NOUN	NN	Case=Acc|Gender=Fem|Number=Sing	2	obl	_	_
-7-8	am	_	_	_	_	_	_	_	_
-7	an	an	ADP	APPR	_	9	case	_	_
-8	dem	der	DET	ART	Case=Dat|Definite=Def|Gender=Masc|Number=Sing|PronType=Art	9	det	_	_
-9	Montag	Montag	PROPN	NN	Case=Dat|Gender=Masc|Number=Sing	2	obl	_	_
-10	aus	aus	ADP	PTKVZ	_	2	compound:prt	_	SpaceAfter=No
-11	.	.	PUNCT	$.	_	2	punct	_	_
+# text = Scotland Yard schwieg sich über deren Nationalität am Montag aus.
+1	Scotland	Scotland	PROPN	NE	_	2	dep	_	FixTigerDep=Yes
+2	Yard	Yard	PROPN	NE	Case=Nom|Number=Sing	3	nsubj	_	_
+3	schwieg	schweigen	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	0	root	_	_
+4	sich	er|es|sie	PRON	PRF	Case=Acc|Number=Sing|Person=3|PronType=Prs|Reflex=Yes	3	obj	_	_
+5	über	über	ADP	APPR	_	7	case	_	_
+6	deren	der	PRON	PDS	Case=Gen|Number=Plur|PronType=Dem	7	det	_	_
+7	Nationalität	Nationalität	NOUN	NN	Case=Acc|Gender=Fem|Number=Sing	3	obl	_	_
+8-9	am	_	_	_	_	_	_	_	_
+8	an	an	ADP	APPR	_	10	case	_	_
+9	dem	der	DET	ART	Case=Dat|Definite=Def|Gender=Masc|Number=Sing|PronType=Art	10	det	_	_
+10	Montag	Montag	PROPN	NN	Case=Dat|Gender=Masc|Number=Sing	3	obl	_	_
+11	aus	aus	ADP	PTKVZ	_	3	compound:prt	_	SpaceAfter=No
+12	.	.	PUNCT	$.	_	3	punct	_	_
 
 # sent_id = test-s577
-# text = Ziel der künftigen Verfassung und des politischen Systems Eritreas sei soziale Gerechtigkeit.
-1	Ziel	Ziel	NOUN	NN	Case=Nom|Gender=Neut|Number=Sing	12	nsubj	_	_
-2	der	der	DET	ART	Case=Gen|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	4	det	_	_
-3	künftigen	künftig	ADJ	ADJA	Case=Gen|Gender=Fem|Number=Sing	4	amod	_	_
-4	Verfassung	Verfassung	NOUN	NN	Case=Gen|Gender=Fem|Number=Sing	1	nmod	_	_
-5	und	und	CCONJ	KON	_	8	cc	_	_
-6	des	der	DET	ART	Case=Gen|Definite=Def|Gender=Neut|Number=Sing|PronType=Art	8	det	_	_
-7	politischen	politisch	ADJ	ADJA	Case=Gen|Gender=Neut|Number=Sing	8	amod	_	_
-8	Systems	System	NOUN	NN	Case=Gen|Gender=Neut|Number=Sing	4	conj	_	_
-9	Eritreas	Eritrea	PROPN	NE	Case=Gen|Gender=Neut|Number=Sing	8	nmod	_	_
-10	sei	sein	AUX	VAFIN	Mood=Sub|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	12	cop	_	_
-11	soziale	sozial	ADJ	ADJA	Case=Nom|Gender=Fem|Number=Sing	12	amod	_	_
-12	Gerechtigkeit	Gerechtigkeit	NOUN	NN	Case=Nom|Gender=Fem|Number=Sing	0	root	_	SpaceAfter=No
-13	.	.	PUNCT	$.	_	12	punct	_	_
+# text = Wesentliches Ziel der künftigen Verfassung und des politischen Systems Eritreas sei soziale Gerechtigkeit.
+1	Wesentliches	wesentlich	ADJ	ADJA	Case=Nom|Gender=Neut|Number=Sing	2	dep	_	FixTigerDep=Yes
+2	Ziel	Ziel	NOUN	NN	Case=Nom|Gender=Neut|Number=Sing	13	nsubj	_	_
+3	der	der	DET	ART	Case=Gen|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	5	det	_	_
+4	künftigen	künftig	ADJ	ADJA	Case=Gen|Gender=Fem|Number=Sing	5	amod	_	_
+5	Verfassung	Verfassung	NOUN	NN	Case=Gen|Gender=Fem|Number=Sing	2	nmod	_	_
+6	und	und	CCONJ	KON	_	9	cc	_	_
+7	des	der	DET	ART	Case=Gen|Definite=Def|Gender=Neut|Number=Sing|PronType=Art	9	det	_	_
+8	politischen	politisch	ADJ	ADJA	Case=Gen|Gender=Neut|Number=Sing	9	amod	_	_
+9	Systems	System	NOUN	NN	Case=Gen|Gender=Neut|Number=Sing	5	conj	_	_
+10	Eritreas	Eritrea	PROPN	NE	Case=Gen|Gender=Neut|Number=Sing	9	nmod	_	_
+11	sei	sein	AUX	VAFIN	Mood=Sub|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	13	cop	_	_
+12	soziale	sozial	ADJ	ADJA	Case=Nom|Gender=Fem|Number=Sing	13	amod	_	_
+13	Gerechtigkeit	Gerechtigkeit	NOUN	NN	Case=Nom|Gender=Fem|Number=Sing	0	root	_	SpaceAfter=No
+14	.	.	PUNCT	$.	_	13	punct	_	_
 
 # sent_id = test-s578
 # text = Zorn des Zyprioten galt einer geheimen Landkarte, die er der türkisch -- zypriotischen Presse hatte zustekken lassen, um sich darüber öffentlich erregen zu können.
@@ -11413,60 +11642,62 @@
 27	.	.	PUNCT	$.	_	4	punct	_	_
 
 # sent_id = test-s579
-# text = Zukunft des Jägers 90 scheint unmittelbar vor dem für Montag geplanten Besuch von Verteidigungsminister Volker Rühe in London weiter offen.
-1	Zukunft	Zukunft	NOUN	NN	Case=Nom|Gender=Fem|Number=Sing	5	nsubj	_	_
-2	des	der	DET	ART	Case=Gen|Definite=Def|Gender=Masc|Number=Sing|PronType=Art	3	det	_	_
-3	Jägers	Jäger	PROPN	NN	Case=Gen|Gender=Masc|Number=Sing	1	nmod	_	_
-4	90	90	PROPN	CARD	NumType=Card	3	flat	_	_
-5	scheint	scheinen	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	0	root	_	_
-6	unmittelbar	unmittelbar	ADV	ADJD	_	12	advmod	_	_
-7	vor	vor	ADP	APPR	_	12	case	_	_
-8	dem	der	DET	ART	Case=Dat|Definite=Def|Gender=Masc|Number=Sing|PronType=Art	12	det	_	_
-9	für	für	ADP	APPR	_	10	case	_	_
-10	Montag	Montag	PROPN	NN	Case=Acc|Gender=Masc|Number=Sing	11	nmod	_	_
-11	geplanten	geplant	ADJ	ADJA	Case=Dat|Gender=Masc|Number=Sing	12	amod	_	_
-12	Besuch	Besuch	NOUN	NN	Case=Dat|Gender=Masc|Number=Sing	5	obl	_	_
-13	von	von	ADP	APPR	_	14	case	_	_
-14	Verteidigungsminister	Verteidigungsminister	NOUN	NN	Case=Dat|Gender=Masc|Number=Sing	12	nmod	_	_
-15	Volker	Volker	PROPN	NE	Case=Nom|Gender=Masc|Number=Sing	14	appos	_	_
-16	Rühe	Rühe	PROPN	NE	Case=Nom|Gender=Masc|Number=Sing	15	flat	_	_
-17	in	in	ADP	APPR	_	18	case	_	_
-18	London	London	PROPN	NE	Case=Dat|Gender=Neut|Number=Sing	12	nmod	_	_
-19	weiter	weiter	ADV	ADV	_	5	advmod	_	_
-20	offen	offen	ADJ	ADJD	_	5	xcomp	_	SpaceAfter=No
-21	.	.	PUNCT	$.	_	5	punct	_	_
+# text = Die Zukunft des Jägers 90 scheint unmittelbar vor dem für Montag geplanten Besuch von Verteidigungsminister Volker Rühe in London weiter offen.
+1	Die	der	DET	ART	Case=Nom|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	2	dep	_	FixTigerDep=Yes
+2	Zukunft	Zukunft	NOUN	NN	Case=Nom|Gender=Fem|Number=Sing	6	nsubj	_	_
+3	des	der	DET	ART	Case=Gen|Definite=Def|Gender=Masc|Number=Sing|PronType=Art	4	det	_	_
+4	Jägers	Jäger	PROPN	NN	Case=Gen|Gender=Masc|Number=Sing	2	nmod	_	_
+5	90	90	PROPN	CARD	NumType=Card	4	flat	_	_
+6	scheint	scheinen	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	0	root	_	_
+7	unmittelbar	unmittelbar	ADV	ADJD	_	13	advmod	_	_
+8	vor	vor	ADP	APPR	_	13	case	_	_
+9	dem	der	DET	ART	Case=Dat|Definite=Def|Gender=Masc|Number=Sing|PronType=Art	13	det	_	_
+10	für	für	ADP	APPR	_	11	case	_	_
+11	Montag	Montag	PROPN	NN	Case=Acc|Gender=Masc|Number=Sing	12	nmod	_	_
+12	geplanten	geplant	ADJ	ADJA	Case=Dat|Gender=Masc|Number=Sing	13	amod	_	_
+13	Besuch	Besuch	NOUN	NN	Case=Dat|Gender=Masc|Number=Sing	6	obl	_	_
+14	von	von	ADP	APPR	_	15	case	_	_
+15	Verteidigungsminister	Verteidigungsminister	NOUN	NN	Case=Dat|Gender=Masc|Number=Sing	13	nmod	_	_
+16	Volker	Volker	PROPN	NE	Case=Nom|Gender=Masc|Number=Sing	15	appos	_	_
+17	Rühe	Rühe	PROPN	NE	Case=Nom|Gender=Masc|Number=Sing	16	flat	_	_
+18	in	in	ADP	APPR	_	19	case	_	_
+19	London	London	PROPN	NE	Case=Dat|Gender=Neut|Number=Sing	13	nmod	_	_
+20	weiter	weiter	ADV	ADV	_	6	advmod	_	_
+21	offen	offen	ADJ	ADJD	_	6	xcomp	_	SpaceAfter=No
+22	.	.	PUNCT	$.	_	6	punct	_	_
 
 # sent_id = test-s580
-# text = Zum ersten Mal in der Geschichte einer deutschen Großbank können nicht nur bestimmte Mitarbeitergruppen, sondern alle Arbeitnehmer Optionen erwerben'', lobt sich das Institut.
-1-2	Zum	_	_	_	_	_	_	_	_
-1	Zu	zu	ADP	APPR	_	4	case	_	_
-2	dem	der	DET	ART	Case=Dat|Definite=Def|Gender=Neut|Number=Sing|PronType=Art	4	det	_	_
-3	ersten	erster	ADJ	ADJA	Case=Dat|Gender=Neut|Number=Sing	4	amod	_	_
-4	Mal	Mal	NOUN	NN	Case=Dat|Gender=Neut|Number=Sing	21	obl	_	_
-5	in	in	ADP	APPR	_	7	case	_	_
-6	der	der	DET	ART	Case=Dat|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	7	det	_	_
-7	Geschichte	Geschichte	NOUN	NN	Case=Dat|Gender=Fem|Number=Sing	4	nmod	_	_
-8	einer	ein	DET	ART	Case=Gen|Definite=Ind|Gender=Fem|Number=Sing|PronType=Art	10	det	_	_
-9	deutschen	deutsch	ADJ	ADJA	Case=Gen|Gender=Fem|Number=Sing	10	amod	_	_
-10	Großbank	Großbank	NOUN	NN	Case=Gen|Gender=Fem|Number=Sing	7	nmod	_	_
-11	können	können	AUX	VMFIN	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	21	aux	_	_
-12	nicht	nicht	PART	PTKNEG	Polarity=Neg	13	advmod	_	_
-13	nur	nur	ADV	ADV	_	15	cc	_	_
-14	bestimmte	bestimmt	ADJ	ADJA	Case=Nom|Gender=Fem|Number=Plur	15	amod	_	_
-15	Mitarbeitergruppen	Mitarbeitergruppe	NOUN	NN	Case=Nom|Gender=Fem|Number=Plur	21	nsubj	_	SpaceAfter=No
-16	,	,	PUNCT	$,	_	19	punct	_	_
-17	sondern	sondern	CCONJ	KON	_	19	cc	_	_
-18	alle	alle	PRON	PIAT	Case=Nom|Definite=Ind|Gender=Masc|Number=Plur|PronType=Ind	19	det	_	_
-19	Arbeitnehmer	Arbeitnehmer	NOUN	NN	Case=Nom|Gender=Masc|Number=Plur	15	conj	_	_
-20	Optionen	Option	NOUN	NN	Case=Acc|Gender=Fem|Number=Plur	21	obj	_	_
-21	erwerben	erwerben	VERB	VVINF	VerbForm=Inf	24	ccomp	_	SpaceAfter=No
-22	''	''	PUNCT	$(	_	24	punct	_	SpaceAfter=No
-23	,	,	PUNCT	$,	_	24	punct	_	_
-24	lobt	loben	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	0	root	_	_
-25	sich	er|es|sie	PRON	PRF	Case=Acc|Number=Sing|Person=3|PronType=Prs|Reflex=Yes	24	obj	_	_
-26	das	der	DET	ART	Case=Nom|Definite=Def|Gender=Neut|Number=Sing|PronType=Art	27	det	_	_
-27	Institut	Institut	NOUN	NN	Case=Nom|Gender=Neut|Number=Sing	24	nsubj	_	SpaceAfter=No
-28	.	.	PUNCT	$.	_	24	punct	_	_
+# text = ``Zum ersten Mal in der Geschichte einer deutschen Großbank können nicht nur bestimmte Mitarbeitergruppen, sondern alle Arbeitnehmer Optionen erwerben'', lobt sich das Institut.
+1	``	``	PUNCT	$(	_	2	punct	_	FixTigerDep=Yes|SpaceAfter=No
+2-3	Zum	_	_	_	_	_	_	_	_
+2	Zu	zu	ADP	APPR	_	5	case	_	_
+3	dem	der	DET	ART	Case=Dat|Definite=Def|Gender=Neut|Number=Sing|PronType=Art	5	det	_	_
+4	ersten	erster	ADJ	ADJA	Case=Dat|Gender=Neut|Number=Sing	5	amod	_	_
+5	Mal	Mal	NOUN	NN	Case=Dat|Gender=Neut|Number=Sing	22	obl	_	_
+6	in	in	ADP	APPR	_	8	case	_	_
+7	der	der	DET	ART	Case=Dat|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	8	det	_	_
+8	Geschichte	Geschichte	NOUN	NN	Case=Dat|Gender=Fem|Number=Sing	5	nmod	_	_
+9	einer	ein	DET	ART	Case=Gen|Definite=Ind|Gender=Fem|Number=Sing|PronType=Art	11	det	_	_
+10	deutschen	deutsch	ADJ	ADJA	Case=Gen|Gender=Fem|Number=Sing	11	amod	_	_
+11	Großbank	Großbank	NOUN	NN	Case=Gen|Gender=Fem|Number=Sing	8	nmod	_	_
+12	können	können	AUX	VMFIN	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	22	aux	_	_
+13	nicht	nicht	PART	PTKNEG	Polarity=Neg	14	advmod	_	_
+14	nur	nur	ADV	ADV	_	16	cc	_	_
+15	bestimmte	bestimmt	ADJ	ADJA	Case=Nom|Gender=Fem|Number=Plur	16	amod	_	_
+16	Mitarbeitergruppen	Mitarbeitergruppe	NOUN	NN	Case=Nom|Gender=Fem|Number=Plur	22	nsubj	_	SpaceAfter=No
+17	,	,	PUNCT	$,	_	20	punct	_	_
+18	sondern	sondern	CCONJ	KON	_	20	cc	_	_
+19	alle	alle	PRON	PIAT	Case=Nom|Definite=Ind|Gender=Masc|Number=Plur|PronType=Ind	20	det	_	_
+20	Arbeitnehmer	Arbeitnehmer	NOUN	NN	Case=Nom|Gender=Masc|Number=Plur	16	conj	_	_
+21	Optionen	Option	NOUN	NN	Case=Acc|Gender=Fem|Number=Plur	22	obj	_	_
+22	erwerben	erwerben	VERB	VVINF	VerbForm=Inf	25	ccomp	_	SpaceAfter=No
+23	''	''	PUNCT	$(	_	25	punct	_	SpaceAfter=No
+24	,	,	PUNCT	$,	_	25	punct	_	_
+25	lobt	loben	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	0	root	_	_
+26	sich	er|es|sie	PRON	PRF	Case=Acc|Number=Sing|Person=3|PronType=Prs|Reflex=Yes	25	obj	_	_
+27	das	der	DET	ART	Case=Nom|Definite=Def|Gender=Neut|Number=Sing|PronType=Art	28	det	_	_
+28	Institut	Institut	NOUN	NN	Case=Nom|Gender=Neut|Number=Sing	25	nsubj	_	SpaceAfter=No
+29	.	.	PUNCT	$.	_	25	punct	_	_
 
 # sent_id = test-s581
 # text = In dem Gespräch am Dienstag nachmittag verzichteten die Innenpolitiker der Koalition deswegen erneut darauf, einen Beschluß über die erleichterte Einbürgerung zu formulieren.
@@ -11516,7 +11747,7 @@
 15	Bündnis	Bündnis	PROPN	NN	Case=Dat|Gender=Neut|Number=Sing	13	nmod	_	_
 16	90	90	PROPN	CARD	NumType=Card	15	flat	_	_
 17	/	/	PUNCT	$(	_	18	punct	_	_
-18	Grünen	Grüne	PROPN	NN	Case=Dat|Number=Plur	15	conj	_	_
+18	Grünen	grüne	PROPN	NN	Case=Dat|Number=Plur	15	conj	_	_
 19	vorgesehen	vorsehen	VERB	VVPP	VerbForm=Part	0	root	_	SpaceAfter=No
 20	,	,	PUNCT	$,	_	19	punct	_	_
 21	in	in	ADP	APPR	_	22	case	_	_
@@ -12052,17 +12283,18 @@
 27	.	.	PUNCT	$.	_	10	punct	_	_
 
 # sent_id = test-s605
-# text = Mann war nicht wählbar und landete in der Psychiatrie.
-1	Mann	Mann	PROPN	NN	Case=Nom|Gender=Masc|Number=Sing	4	nsubj:pass	_	_
-2	war	sein	AUX	VAFIN	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	4	cop	_	_
-3	nicht	nicht	PART	PTKNEG	Polarity=Neg	4	advmod	_	_
-4	wählbar	wählbar	ADJ	ADJD	_	0	root	_	_
-5	und	und	CCONJ	KON	_	6	cc	_	_
-6	landete	landen	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	4	conj	_	_
-7	in	in	ADP	APPR	_	9	case	_	_
-8	der	der	DET	ART	Case=Dat|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	9	det	_	_
-9	Psychiatrie	Psychiatrie	NOUN	NN	Case=Dat|Gender=Fem|Number=Sing	6	obl	_	SpaceAfter=No
-10	.	.	PUNCT	$.	_	4	punct	_	_
+# text = Der Mann war nicht wählbar und landete in der Psychiatrie.
+1	Der	der	DET	ART	Case=Nom|Definite=Def|Gender=Masc|Number=Sing|PronType=Art	2	dep	_	FixTigerDep=Yes
+2	Mann	Mann	PROPN	NN	Case=Nom|Gender=Masc|Number=Sing	5	nsubj:pass	_	_
+3	war	sein	AUX	VAFIN	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	5	cop	_	_
+4	nicht	nicht	PART	PTKNEG	Polarity=Neg	5	advmod	_	_
+5	wählbar	wählbar	ADJ	ADJD	_	0	root	_	_
+6	und	und	CCONJ	KON	_	7	cc	_	_
+7	landete	landen	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	5	conj	_	_
+8	in	in	ADP	APPR	_	10	case	_	_
+9	der	der	DET	ART	Case=Dat|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	10	det	_	_
+10	Psychiatrie	Psychiatrie	NOUN	NN	Case=Dat|Gender=Fem|Number=Sing	7	obl	_	SpaceAfter=No
+11	.	.	PUNCT	$.	_	5	punct	_	_
 
 # sent_id = test-s606
 # text = Die GAP ist viel zu teuer.
@@ -12084,32 +12316,33 @@
 6	.	.	PUNCT	$.	_	5	punct	_	_
 
 # sent_id = test-s608
-# text = Rühe forderte, die Strukturreform der Nato sofort einzuleiten, um wie geplant 1997 mit den Reformstaaten Osteuropas über ihren Beitritt verhandeln zu können.
-1	Rühe	Rühe	PROPN	NE	Case=Nom|Gender=Masc|Number=Sing	2	nsubj	_	_
-2	forderte	fordern	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	0	root	_	SpaceAfter=No
-3	,	,	PUNCT	$,	_	2	punct	_	_
-4	die	der	DET	ART	Case=Acc|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	5	det	_	_
-5	Strukturreform	Strukturreform	NOUN	NN	Case=Acc|Gender=Fem|Number=Sing	9	obj	_	_
-6	der	der	DET	ART	Case=Gen|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	7	det	_	_
-7	Nato	Nato	PROPN	NE	Case=Gen|Gender=Fem|Number=Sing	5	nmod	_	_
-8	sofort	sofort	ADV	ADV	_	9	advmod	_	_
-9	einzuleiten	einleiten	VERB	VVIZU	VerbForm=Inf	2	xcomp	_	SpaceAfter=No
-10	,	,	PUNCT	$,	_	2	punct	_	_
-11	um	um	ADP	KOUI	_	22	mark	_	_
-12	wie	wie	CCONJ	KOKOM	_	13	case	_	_
-13	geplant	planen	ADV	VVPP	VerbForm=Part	22	advmod	_	_
-14	1997	1997	NUM	CARD	NumType=Card	22	obl	_	_
-15	mit	mit	ADP	APPR	_	17	case	_	_
-16	den	der	DET	ART	Case=Dat|Definite=Def|Gender=Masc|Number=Plur|PronType=Art	17	det	_	_
-17	Reformstaaten	Reformstaat	NOUN	NN	Case=Dat|Gender=Masc|Number=Plur	22	obl	_	_
-18	Osteuropas	Osteuropa	NOUN	NE	Case=Gen|Gender=Neut|Number=Sing	17	nmod	_	_
-19	über	über	ADP	APPR	_	21	case	_	_
-20	ihren	ihr	PRON	PPOSAT	Case=Acc|Gender=Masc|Number=Sing|Poss=Yes	21	det:poss	_	_
-21	Beitritt	Beitritt	NOUN	NN	Case=Acc|Gender=Masc|Number=Sing	22	obl	_	_
-22	verhandeln	verhandeln	VERB	VVINF	VerbForm=Inf	9	advcl	_	_
-23	zu	zu	PART	PTKZU	_	24	mark	_	_
-24	können	können	AUX	VMINF	VerbForm=Inf	22	aux	_	SpaceAfter=No
-25	.	.	PUNCT	$.	_	2	punct	_	_
+# text = Verteidigungsminister Rühe forderte, die Strukturreform der Nato sofort einzuleiten, um wie geplant 1997 mit den Reformstaaten Osteuropas über ihren Beitritt verhandeln zu können.
+1	Verteidigungsminister	Verteidigungsminister	NOUN	NN	Case=Nom|Gender=Masc|Number=Sing	2	dep	_	FixTigerDep=Yes
+2	Rühe	Rühe	PROPN	NE	Case=Nom|Gender=Masc|Number=Sing	3	nsubj	_	_
+3	forderte	fordern	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	0	root	_	SpaceAfter=No
+4	,	,	PUNCT	$,	_	3	punct	_	_
+5	die	der	DET	ART	Case=Acc|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	6	det	_	_
+6	Strukturreform	Strukturreform	NOUN	NN	Case=Acc|Gender=Fem|Number=Sing	10	obj	_	_
+7	der	der	DET	ART	Case=Gen|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	8	det	_	_
+8	Nato	Nato	PROPN	NE	Case=Gen|Gender=Fem|Number=Sing	6	nmod	_	_
+9	sofort	sofort	ADV	ADV	_	10	advmod	_	_
+10	einzuleiten	einleiten	VERB	VVIZU	VerbForm=Inf	3	xcomp	_	SpaceAfter=No
+11	,	,	PUNCT	$,	_	3	punct	_	_
+12	um	um	ADP	KOUI	_	23	mark	_	_
+13	wie	wie	CCONJ	KOKOM	_	14	case	_	_
+14	geplant	planen	ADV	VVPP	VerbForm=Part	23	advmod	_	_
+15	1997	1997	NUM	CARD	NumType=Card	23	obl	_	_
+16	mit	mit	ADP	APPR	_	18	case	_	_
+17	den	der	DET	ART	Case=Dat|Definite=Def|Gender=Masc|Number=Plur|PronType=Art	18	det	_	_
+18	Reformstaaten	Reformstaat	NOUN	NN	Case=Dat|Gender=Masc|Number=Plur	23	obl	_	_
+19	Osteuropas	Osteuropa	NOUN	NE	Case=Gen|Gender=Neut|Number=Sing	18	nmod	_	_
+20	über	über	ADP	APPR	_	22	case	_	_
+21	ihren	ihr	PRON	PPOSAT	Case=Acc|Gender=Masc|Number=Sing|Poss=Yes	22	det:poss	_	_
+22	Beitritt	Beitritt	NOUN	NN	Case=Acc|Gender=Masc|Number=Sing	23	obl	_	_
+23	verhandeln	verhandeln	VERB	VVINF	VerbForm=Inf	10	advcl	_	_
+24	zu	zu	PART	PTKZU	_	25	mark	_	_
+25	können	können	AUX	VMINF	VerbForm=Inf	23	aux	_	SpaceAfter=No
+26	.	.	PUNCT	$.	_	3	punct	_	_
 
 # sent_id = test-s609
 # text = Eine Verwaltung der ökonomischen Krise ist nicht ihre Lösung.
@@ -12152,39 +12385,41 @@
 12	.	.	PUNCT	$.	_	3	punct	_	_
 
 # sent_id = test-s612
-# text = Japan ist dort erst erschienen, nachdem Kohl persönlich in Tokio darum gebeten hatte.
-1	Japan	Japan	PROPN	NE	Case=Nom|Gender=Neut|Number=Sing	5	nsubj	_	_
-2	ist	sein	AUX	VAFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	5	aux	_	_
-3	dort	dort	ADV	ADV	_	5	advmod	_	_
-4	erst	erst	ADV	ADV	_	5	advmod	_	_
-5	erschienen	erscheinen	VERB	VVPP	VerbForm=Part	0	root	_	SpaceAfter=No
-6	,	,	PUNCT	$,	_	5	punct	_	_
-7	nachdem	nachdem	SCONJ	KOUS	_	13	mark	_	_
-8	Kohl	Kohl	PROPN	NE	Case=Nom|Number=Sing	13	nsubj	_	_
-9	persönlich	persönlich	ADV	ADJD	_	13	advmod	_	_
-10	in	in	ADP	APPR	_	11	case	_	_
-11	Tokio	Tokio	PROPN	NE	Case=Dat|Gender=Neut|Number=Sing	13	obl	_	_
-12	darum	darum	ADV	PAV	_	13	advmod	_	_
-13	gebeten	bitten	VERB	VVPP	VerbForm=Part	5	advcl	_	_
-14	hatte	haben	AUX	VAFIN	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	13	aux	_	SpaceAfter=No
-15	.	.	PUNCT	$.	_	5	punct	_	_
+# text = Auch Japan ist dort erst erschienen, nachdem Kohl persönlich in Tokio darum gebeten hatte.
+1	Auch	auch	ADV	ADV	_	2	dep	_	FixTigerDep=Yes
+2	Japan	Japan	PROPN	NE	Case=Nom|Gender=Neut|Number=Sing	6	nsubj	_	_
+3	ist	sein	AUX	VAFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	6	aux	_	_
+4	dort	dort	ADV	ADV	_	6	advmod	_	_
+5	erst	erst	ADV	ADV	_	6	advmod	_	_
+6	erschienen	erscheinen	VERB	VVPP	VerbForm=Part	0	root	_	SpaceAfter=No
+7	,	,	PUNCT	$,	_	6	punct	_	_
+8	nachdem	nachdem	SCONJ	KOUS	_	14	mark	_	_
+9	Kohl	Kohl	PROPN	NE	Case=Nom|Number=Sing	14	nsubj	_	_
+10	persönlich	persönlich	ADV	ADJD	_	14	advmod	_	_
+11	in	in	ADP	APPR	_	12	case	_	_
+12	Tokio	Tokio	PROPN	NE	Case=Dat|Gender=Neut|Number=Sing	14	obl	_	_
+13	darum	darum	ADV	PAV	_	14	advmod	_	_
+14	gebeten	bitten	VERB	VVPP	VerbForm=Part	6	advcl	_	_
+15	hatte	haben	AUX	VAFIN	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	14	aux	_	SpaceAfter=No
+16	.	.	PUNCT	$.	_	6	punct	_	_
 
 # sent_id = test-s613
-# text = Detektive und kostspielige Elektronik kann sich der Supermarkt an der Ecke nicht leisten.
-1	Detektive	Detektiv	NOUN	NN	Case=Acc|Gender=Masc|Number=Plur	13	obj	_	_
-2	und	und	CCONJ	KON	_	4	cc	_	_
-3	kostspielige	kostspielig	ADJ	ADJA	Case=Acc|Gender=Fem|Number=Sing	4	amod	_	_
-4	Elektronik	Elektronik	NOUN	NN	Case=Acc|Gender=Fem|Number=Sing	1	conj	_	_
-5	kann	können	AUX	VMFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	13	aux	_	_
-6	sich	er|es|sie	PRON	PRF	Case=Dat|Number=Sing|Person=3|PronType=Prs|Reflex=Yes	13	iobj	_	_
-7	der	der	DET	ART	Case=Nom|Definite=Def|Gender=Masc|Number=Sing|PronType=Art	8	det	_	_
-8	Supermarkt	Supermarkt	NOUN	NN	Case=Nom|Gender=Masc|Number=Sing	13	nsubj	_	_
-9	an	an	ADP	APPR	_	11	case	_	_
-10	der	der	DET	ART	Case=Dat|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	11	det	_	_
-11	Ecke	Ecke	NOUN	NN	Case=Dat|Gender=Fem|Number=Sing	8	nmod	_	_
-12	nicht	nicht	PART	PTKNEG	Polarity=Neg	13	advmod	_	_
-13	leisten	leisten	VERB	VVINF	VerbForm=Inf	0	root	_	SpaceAfter=No
-14	.	.	PUNCT	$.	_	13	punct	_	_
+# text = Teure Detektive und kostspielige Elektronik kann sich der Supermarkt an der Ecke nicht leisten.
+1	Teure	teuer	ADJ	ADJA	Case=Acc|Gender=Masc|Number=Plur	2	dep	_	FixTigerDep=Yes
+2	Detektive	Detektiv	NOUN	NN	Case=Acc|Gender=Masc|Number=Plur	14	obj	_	_
+3	und	und	CCONJ	KON	_	5	cc	_	_
+4	kostspielige	kostspielig	ADJ	ADJA	Case=Acc|Gender=Fem|Number=Sing	5	amod	_	_
+5	Elektronik	Elektronik	NOUN	NN	Case=Acc|Gender=Fem|Number=Sing	2	conj	_	_
+6	kann	können	AUX	VMFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	14	aux	_	_
+7	sich	er|es|sie	PRON	PRF	Case=Dat|Number=Sing|Person=3|PronType=Prs|Reflex=Yes	14	iobj	_	_
+8	der	der	DET	ART	Case=Nom|Definite=Def|Gender=Masc|Number=Sing|PronType=Art	9	det	_	_
+9	Supermarkt	Supermarkt	NOUN	NN	Case=Nom|Gender=Masc|Number=Sing	14	nsubj	_	_
+10	an	an	ADP	APPR	_	12	case	_	_
+11	der	der	DET	ART	Case=Dat|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	12	det	_	_
+12	Ecke	Ecke	NOUN	NN	Case=Dat|Gender=Fem|Number=Sing	9	nmod	_	_
+13	nicht	nicht	PART	PTKNEG	Polarity=Neg	14	advmod	_	_
+14	leisten	leisten	VERB	VVINF	VerbForm=Inf	0	root	_	SpaceAfter=No
+15	.	.	PUNCT	$.	_	14	punct	_	_
 
 # sent_id = test-s614
 # text = Hat das denn zur Folge, daß die Jugendlichen sich Orientierungen suchen außerhalb der bislang traditionellen Vorbilder aus Familie und Schule?
@@ -12214,77 +12449,81 @@
 23	?	?	PUNCT	$.	_	1	punct	_	_
 
 # sent_id = test-s615
-# text = Wir in der Wirtschaft lernen von eurer Erniedrigung und von euren Skandalen, daß wir noch mehr die Öffentlichkeit meiden müssen.
-1	Wir	wir	PRON	PPER	Case=Nom|Number=Plur|Person=1|PronType=Prs	5	nsubj	_	_
-2	in	in	ADP	APPR	_	4	case	_	_
-3	der	der	DET	ART	Case=Dat|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	4	det	_	_
-4	Wirtschaft	Wirtschaft	NOUN	NN	Case=Dat|Gender=Fem|Number=Sing	1	nmod	_	_
-5	lernen	lernen	VERB	VVFIN	Mood=Ind|Number=Plur|Person=1|Tense=Pres|VerbForm=Fin	0	root	_	_
-6	von	von	ADP	APPR	_	8	case	_	_
-7	eurer	euer	PRON	PPOSAT	Case=Dat|Gender=Fem|Number=Sing|Poss=Yes	8	det:poss	_	_
-8	Erniedrigung	Erniedrigung	NOUN	NN	Case=Dat|Gender=Fem|Number=Sing	5	obl	_	_
-9	und	und	CCONJ	KON	_	12	cc	_	_
-10	von	von	ADP	APPR	_	12	case	_	_
-11	euren	euer	PRON	PPOSAT	Case=Dat|Gender=Masc|Number=Plur|Poss=Yes	12	det:poss	_	_
-12	Skandalen	Skandal	NOUN	NN	Case=Dat|Gender=Masc|Number=Plur	8	conj	_	SpaceAfter=No
-13	,	,	PUNCT	$,	_	5	punct	_	_
-14	daß	daß	SCONJ	KOUS	_	20	mark	_	_
-15	wir	wir	PRON	PPER	Case=Nom|Number=Plur|Person=1|PronType=Prs	20	nsubj	_	_
-16	noch	noch	ADV	ADV	_	17	advmod	_	_
-17	mehr	mehr	ADV	ADV	_	20	advmod	_	_
-18	die	der	DET	ART	Case=Acc|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	19	det	_	_
-19	Öffentlichkeit	Öffentlichkeit	NOUN	NN	Case=Acc|Gender=Fem|Number=Sing	20	obj	_	_
-20	meiden	meiden	VERB	VVINF	VerbForm=Inf	5	ccomp	_	_
-21	müssen	müssen	AUX	VMFIN	Mood=Ind|Number=Plur|Person=1|Tense=Pres|VerbForm=Fin	20	aux	_	SpaceAfter=No
-22	.	.	PUNCT	$.	_	5	punct	_	_
+# text = ``Wir in der Wirtschaft lernen von eurer Erniedrigung und von euren Skandalen, daß wir noch mehr die Öffentlichkeit meiden müssen.
+1	``	``	PUNCT	$(	_	2	punct	_	FixTigerDep=Yes|SpaceAfter=No
+2	Wir	wir	PRON	PPER	Case=Nom|Number=Plur|Person=1|PronType=Prs	6	nsubj	_	_
+3	in	in	ADP	APPR	_	5	case	_	_
+4	der	der	DET	ART	Case=Dat|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	5	det	_	_
+5	Wirtschaft	Wirtschaft	NOUN	NN	Case=Dat|Gender=Fem|Number=Sing	2	nmod	_	_
+6	lernen	lernen	VERB	VVFIN	Mood=Ind|Number=Plur|Person=1|Tense=Pres|VerbForm=Fin	0	root	_	_
+7	von	von	ADP	APPR	_	9	case	_	_
+8	eurer	euer	PRON	PPOSAT	Case=Dat|Gender=Fem|Number=Sing|Poss=Yes	9	det:poss	_	_
+9	Erniedrigung	Erniedrigung	NOUN	NN	Case=Dat|Gender=Fem|Number=Sing	6	obl	_	_
+10	und	und	CCONJ	KON	_	13	cc	_	_
+11	von	von	ADP	APPR	_	13	case	_	_
+12	euren	euer	PRON	PPOSAT	Case=Dat|Gender=Masc|Number=Plur|Poss=Yes	13	det:poss	_	_
+13	Skandalen	Skandal	NOUN	NN	Case=Dat|Gender=Masc|Number=Plur	9	conj	_	SpaceAfter=No
+14	,	,	PUNCT	$,	_	6	punct	_	_
+15	daß	daß	SCONJ	KOUS	_	21	mark	_	_
+16	wir	wir	PRON	PPER	Case=Nom|Number=Plur|Person=1|PronType=Prs	21	nsubj	_	_
+17	noch	noch	ADV	ADV	_	18	advmod	_	_
+18	mehr	mehr	ADV	ADV	_	21	advmod	_	_
+19	die	der	DET	ART	Case=Acc|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	20	det	_	_
+20	Öffentlichkeit	Öffentlichkeit	NOUN	NN	Case=Acc|Gender=Fem|Number=Sing	21	obj	_	_
+21	meiden	meiden	VERB	VVINF	VerbForm=Inf	6	ccomp	_	_
+22	müssen	müssen	AUX	VMFIN	Mood=Ind|Number=Plur|Person=1|Tense=Pres|VerbForm=Fin	21	aux	_	SpaceAfter=No
+23	.	.	PUNCT	$.	_	6	punct	_	_
 
 # sent_id = test-s616
-# text = Diese Art von humanitärer Hilfe wird hier nicht gebraucht.
-1	Diese	dies	PRON	PDAT	Case=Nom|Gender=Fem|Number=Sing|PronType=Dem	2	det	_	_
-2	Art	Art	NOUN	NN	Case=Nom|Gender=Fem|Number=Sing	9	nsubj:pass	_	_
-3	von	von	ADP	APPR	_	5	case	_	_
-4	humanitärer	humanitär	ADJ	ADJA	Case=Dat|Gender=Fem|Number=Sing	5	amod	_	_
-5	Hilfe	Hilfe	NOUN	NN	Case=Dat|Gender=Fem|Number=Sing	2	nmod	_	_
-6	wird	werden	AUX	VAFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin|Voice=Pass	9	aux:pass	_	_
-7	hier	hier	ADV	ADV	_	9	advmod	_	_
-8	nicht	nicht	PART	PTKNEG	Polarity=Neg	9	advmod	_	_
-9	gebraucht	brauchen	VERB	VVPP	VerbForm=Part	0	root	_	SpaceAfter=No
-10	.	.	PUNCT	$.	_	9	punct	_	_
+# text = ``Diese Art von humanitärer Hilfe wird hier nicht gebraucht.
+1	``	``	PUNCT	$(	_	2	punct	_	FixTigerDep=Yes|SpaceAfter=No
+2	Diese	dies	PRON	PDAT	Case=Nom|Gender=Fem|Number=Sing|PronType=Dem	3	det	_	_
+3	Art	Art	NOUN	NN	Case=Nom|Gender=Fem|Number=Sing	10	nsubj:pass	_	_
+4	von	von	ADP	APPR	_	6	case	_	_
+5	humanitärer	humanitär	ADJ	ADJA	Case=Dat|Gender=Fem|Number=Sing	6	amod	_	_
+6	Hilfe	Hilfe	NOUN	NN	Case=Dat|Gender=Fem|Number=Sing	3	nmod	_	_
+7	wird	werden	AUX	VAFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin|Voice=Pass	10	aux:pass	_	_
+8	hier	hier	ADV	ADV	_	10	advmod	_	_
+9	nicht	nicht	PART	PTKNEG	Polarity=Neg	10	advmod	_	_
+10	gebraucht	brauchen	VERB	VVPP	VerbForm=Part	0	root	_	SpaceAfter=No
+11	.	.	PUNCT	$.	_	10	punct	_	_
 
 # sent_id = test-s617
-# text = Dies ist der bestmögliche Kompromiß'', sagte Gratschow am Samstag in Moskau.
-1	Dies	dies	PRON	PDS	Case=Nom|Gender=Neut|Number=Sing|PronType=Dem	5	nsubj	_	_
-2	ist	sein	AUX	VAFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	5	cop	_	_
-3	der	der	DET	ART	Case=Nom|Definite=Def|Gender=Masc|Number=Sing|PronType=Art	5	det	_	_
-4	bestmögliche	bestmöglich	ADJ	ADJA	Case=Nom|Gender=Masc|Number=Sing	5	amod	_	_
-5	Kompromiß	Kompromiß	NOUN	NN	Case=Nom|Gender=Masc|Number=Sing	8	ccomp	_	SpaceAfter=No
-6	''	''	PUNCT	$(	_	8	punct	_	SpaceAfter=No
-7	,	,	PUNCT	$,	_	8	punct	_	_
-8	sagte	sagen	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	0	root	_	_
-9	Gratschow	Gratschow	PROPN	NE	Case=Nom|Number=Sing	8	nsubj	_	_
-10-11	am	_	_	_	_	_	_	_	_
-10	an	an	ADP	APPR	_	12	case	_	_
-11	dem	der	DET	ART	Case=Dat|Definite=Def|Gender=Masc|Number=Sing|PronType=Art	12	det	_	_
-12	Samstag	Samstag	PROPN	NN	Case=Dat|Gender=Masc|Number=Sing	8	obl	_	_
-13	in	in	ADP	APPR	_	14	case	_	_
-14	Moskau	Moskau	PROPN	NE	Case=Dat|Gender=Neut|Number=Sing	8	obl	_	SpaceAfter=No
-15	.	.	PUNCT	$.	_	8	punct	_	_
+# text = ``Dies ist der bestmögliche Kompromiß'', sagte Gratschow am Samstag in Moskau.
+1	``	``	PUNCT	$(	_	2	punct	_	FixTigerDep=Yes|SpaceAfter=No
+2	Dies	dies	PRON	PDS	Case=Nom|Gender=Neut|Number=Sing|PronType=Dem	6	nsubj	_	_
+3	ist	sein	AUX	VAFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	6	cop	_	_
+4	der	der	DET	ART	Case=Nom|Definite=Def|Gender=Masc|Number=Sing|PronType=Art	6	det	_	_
+5	bestmögliche	bestmöglich	ADJ	ADJA	Case=Nom|Gender=Masc|Number=Sing	6	amod	_	_
+6	Kompromiß	Kompromiß	NOUN	NN	Case=Nom|Gender=Masc|Number=Sing	9	ccomp	_	SpaceAfter=No
+7	''	''	PUNCT	$(	_	9	punct	_	SpaceAfter=No
+8	,	,	PUNCT	$,	_	9	punct	_	_
+9	sagte	sagen	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	0	root	_	_
+10	Gratschow	Gratschow	PROPN	NE	Case=Nom|Number=Sing	9	nsubj	_	_
+11-12	am	_	_	_	_	_	_	_	_
+11	an	an	ADP	APPR	_	13	case	_	_
+12	dem	der	DET	ART	Case=Dat|Definite=Def|Gender=Masc|Number=Sing|PronType=Art	13	det	_	_
+13	Samstag	Samstag	PROPN	NN	Case=Dat|Gender=Masc|Number=Sing	9	obl	_	_
+14	in	in	ADP	APPR	_	15	case	_	_
+15	Moskau	Moskau	PROPN	NE	Case=Dat|Gender=Neut|Number=Sing	9	obl	_	SpaceAfter=No
+16	.	.	PUNCT	$.	_	9	punct	_	_
 
 # sent_id = test-s618
-# text = Das Kartellamt ist grundsätzlich reaktiv'', argumentiert SPD-Experte Börnsen.
-1	Das	der	DET	ART	Case=Nom|Definite=Def|Gender=Neut|Number=Sing|PronType=Art	2	det	_	_
-2	Kartellamt	Kartellamt	NOUN	NN	Case=Nom|Gender=Neut|Number=Sing	5	nsubj	_	_
-3	ist	sein	AUX	VAFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	5	cop	_	_
-4	grundsätzlich	grundsätzlich	ADV	ADJD	_	5	advmod	_	_
-5	reaktiv	reaktiv	ADJ	ADJD	_	8	ccomp	_	SpaceAfter=No
-6	''	''	PUNCT	$(	_	8	punct	_	SpaceAfter=No
-7	,	,	PUNCT	$,	_	8	punct	_	_
-8	argumentiert	argumentieren	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	0	root	_	_
-9	SPD	SPD	PROPN	NN	Case=Nom|Gender=Masc|Number=Sing	11	compound	_	SpaceAfter=No
-10	-	-	PUNCT	$(	_	9	punct	_	SpaceAfter=No
-11	Experte	Experte	NOUN	NN	Case=Nom|Gender=Masc|Number=Sing	8	nsubj	_	_
-12	Börnsen	Börnsen	PROPN	NE	Case=Nom|Gender=Masc|Number=Sing	9	appos	_	SpaceAfter=No
-13	.	.	PUNCT	$.	_	8	punct	_	_
+# text = ``Das Kartellamt ist grundsätzlich reaktiv'', argumentiert SPD-Experte Börnsen.
+1	``	``	PUNCT	$(	_	2	punct	_	FixTigerDep=Yes|SpaceAfter=No
+2	Das	der	DET	ART	Case=Nom|Definite=Def|Gender=Neut|Number=Sing|PronType=Art	3	det	_	_
+3	Kartellamt	Kartellamt	NOUN	NN	Case=Nom|Gender=Neut|Number=Sing	6	nsubj	_	_
+4	ist	sein	AUX	VAFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	6	cop	_	_
+5	grundsätzlich	grundsätzlich	ADV	ADJD	_	6	advmod	_	_
+6	reaktiv	reaktiv	ADJ	ADJD	_	9	ccomp	_	SpaceAfter=No
+7	''	''	PUNCT	$(	_	9	punct	_	SpaceAfter=No
+8	,	,	PUNCT	$,	_	9	punct	_	_
+9	argumentiert	argumentieren	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	0	root	_	_
+10	SPD	SPD	PROPN	NN	Case=Nom|Gender=Masc|Number=Sing	12	compound	_	SpaceAfter=No
+11	-	-	PUNCT	$(	_	10	punct	_	SpaceAfter=No
+12	Experte	Experte	NOUN	NN	Case=Nom|Gender=Masc|Number=Sing	9	nsubj	_	_
+13	Börnsen	Börnsen	PROPN	NE	Case=Nom|Gender=Masc|Number=Sing	10	appos	_	SpaceAfter=No
+14	.	.	PUNCT	$.	_	9	punct	_	_
 
 # sent_id = test-s619
 # text = Der Attentäter Yigal Amir betonte, er habe allein gehandelt.
@@ -12301,28 +12540,29 @@
 11	.	.	PUNCT	$.	_	5	punct	_	_
 
 # sent_id = test-s620
-# text = Die haben noch nicht unsere Neurose, sich immer streng unter Kontrolle haben zu müssen'', befindet der Lachspezialist.
-1	Die	der	PRON	PDS	Case=Nom|Number=Plur|PronType=Dem	2	nsubj	_	_
-2	haben	haben	VERB	VAFIN	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	18	ccomp	_	_
-3	noch	noch	ADV	ADV	_	4	advmod	_	_
-4	nicht	nicht	PART	PTKNEG	Polarity=Neg	2	advmod	_	_
-5	unsere	unser	PRON	PPOSAT	Case=Acc|Gender=Fem|Number=Sing|Poss=Yes	6	det:poss	_	_
-6	Neurose	Neurose	NOUN	NN	Case=Acc|Gender=Fem|Number=Sing	2	obj	_	SpaceAfter=No
-7	,	,	PUNCT	$,	_	18	punct	_	_
-8	sich	er|es|sie	PRON	PRF	Case=Acc|Number=Sing|Person=3|PronType=Prs|Reflex=Yes	13	obj	_	_
-9	immer	immer	ADV	ADV	_	13	advmod	_	_
-10	streng	streng	ADV	ADJD	_	13	advmod	_	_
-11	unter	unter	ADP	APPR	_	12	case	_	_
-12	Kontrolle	Kontrolle	NOUN	NN	Case=Dat|Gender=Fem|Number=Sing	13	obl	_	_
-13	haben	haben	VERB	VAINF	VerbForm=Inf	6	xcomp	_	_
-14	zu	zu	PART	PTKZU	_	15	mark	_	_
-15	müssen	müssen	AUX	VMINF	VerbForm=Inf	13	aux	_	SpaceAfter=No
-16	''	''	PUNCT	$(	_	18	punct	_	SpaceAfter=No
-17	,	,	PUNCT	$,	_	18	punct	_	_
-18	befindet	befinden	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	0	root	_	_
-19	der	der	DET	ART	Case=Nom|Definite=Def|Gender=Masc|Number=Sing|PronType=Art	20	det	_	_
-20	Lachspezialist	Lachspezialist	NOUN	NN	Case=Nom|Gender=Masc|Number=Sing	18	nsubj	_	SpaceAfter=No
-21	.	.	PUNCT	$.	_	18	punct	_	_
+# text = ``Die haben noch nicht unsere Neurose, sich immer streng unter Kontrolle haben zu müssen'', befindet der Lachspezialist.
+1	``	``	PUNCT	$(	_	2	punct	_	FixTigerDep=Yes|SpaceAfter=No
+2	Die	der	PRON	PDS	Case=Nom|Number=Plur|PronType=Dem	3	nsubj	_	_
+3	haben	haben	VERB	VAFIN	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	19	ccomp	_	_
+4	noch	noch	ADV	ADV	_	5	advmod	_	_
+5	nicht	nicht	PART	PTKNEG	Polarity=Neg	3	advmod	_	_
+6	unsere	unser	PRON	PPOSAT	Case=Acc|Gender=Fem|Number=Sing|Poss=Yes	7	det:poss	_	_
+7	Neurose	Neurose	NOUN	NN	Case=Acc|Gender=Fem|Number=Sing	3	obj	_	SpaceAfter=No
+8	,	,	PUNCT	$,	_	19	punct	_	_
+9	sich	er|es|sie	PRON	PRF	Case=Acc|Number=Sing|Person=3|PronType=Prs|Reflex=Yes	14	obj	_	_
+10	immer	immer	ADV	ADV	_	14	advmod	_	_
+11	streng	streng	ADV	ADJD	_	14	advmod	_	_
+12	unter	unter	ADP	APPR	_	13	case	_	_
+13	Kontrolle	Kontrolle	NOUN	NN	Case=Dat|Gender=Fem|Number=Sing	14	obl	_	_
+14	haben	haben	VERB	VAINF	VerbForm=Inf	7	xcomp	_	_
+15	zu	zu	PART	PTKZU	_	16	mark	_	_
+16	müssen	müssen	AUX	VMINF	VerbForm=Inf	14	aux	_	SpaceAfter=No
+17	''	''	PUNCT	$(	_	19	punct	_	SpaceAfter=No
+18	,	,	PUNCT	$,	_	19	punct	_	_
+19	befindet	befinden	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	0	root	_	_
+20	der	der	DET	ART	Case=Nom|Definite=Def|Gender=Masc|Number=Sing|PronType=Art	21	det	_	_
+21	Lachspezialist	Lachspezialist	NOUN	NN	Case=Nom|Gender=Masc|Number=Sing	19	nsubj	_	SpaceAfter=No
+22	.	.	PUNCT	$.	_	19	punct	_	_
 
 # sent_id = test-s621
 # text = Zwei Themen, die Perot immer wieder anspricht, Rezession und Bürokratie, machen ihnen besonders zu schaffen.
@@ -12850,7 +13090,7 @@
 12	so	so	ADV	ADV	_	25	advmod	_	_
 13	wurde	werden	AUX	VAFIN	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin|Voice=Pass	25	aux:pass	_	_
 14	Violeta	Violeta	PROPN	NE	Case=Nom|Gender=Fem|Number=Sing	17	nmod	_	_
-15	Romeros	Romeros	PROPN	NE	Case=Gen|Gender=Fem|Number=Sing	14	flat	_	_
+15	Romeros	Romero	PROPN	NE	Case=Gen|Gender=Fem|Number=Sing	14	flat	_	_
 16	hartnäckige	hartnäckig	ADJ	ADJA	Case=Nom|Gender=Fem|Number=Sing	17	amod	_	_
 17	Ablehnung	Ablehnung	NOUN	NN	Case=Nom|Gender=Fem|Number=Sing	25	nsubj:pass	_	_
 18	letztlich	letztlich	ADV	ADV	_	25	advmod	_	_
@@ -12890,7 +13130,7 @@
 # text = Würden die Deutschen den 8. Mai 1945 nicht als Kapitulation sondern als Tag der Befreiung begreifen, wäre diese Erkenntnis Allgemeingut.
 1	Würden	werden	AUX	VAFIN	Mood=Sub|Number=Plur|Person=3|Tense=Past|VerbForm=Fin	16	aux	_	_
 2	die	der	DET	ART	Case=Nom|Definite=Def|Number=Plur|PronType=Art	3	det	_	_
-3	Deutschen	Deutsche	PROPN	NN	Case=Nom|Number=Plur	16	nsubj	_	_
+3	Deutschen	deutsche	PROPN	NN	Case=Nom|Number=Plur	16	nsubj	_	_
 4	den	der	DET	ART	Case=Acc|Definite=Def|Gender=Masc|Number=Sing|PronType=Art	6	det	_	_
 5	8.	@ord@	NUM	ADJA	Case=Acc|Gender=Masc|Number=Sing	7	amod	_	_
 6	Mai	Mai	PROPN	NN	Case=Acc|Gender=Masc|Number=Sing	16	obj	_	_
@@ -13179,7 +13419,7 @@
 17	für	für	ADP	APPR	_	19	case	_	_
 18	den	der	DET	ART	Case=Acc|Definite=Def|Gender=Masc|Number=Sing|PronType=Art	19	det	_	_
 19	Sportartikelhersteller	Sportartikelhersteller	NOUN	NN	Case=Acc|Gender=Masc|Number=Sing	16	nmod	_	_
-20	adidas	Adidas	PROPN	NE	Case=Nom|Number=Sing	19	appos	_	_
+20	adidas	adidas	PROPN	NE	Case=Nom|Number=Sing	19	appos	_	_
 21	in	in	ADP	APPR	_	22	case	_	_
 22	Herzogenaurach	Herzogenaurach	PROPN	NE	Case=Dat|Gender=Neut|Number=Sing	19	nmod	_	_
 23	verfallen	verfallen	VERB	VVINF	VerbForm=Inf	0	root	_	_
@@ -13336,7 +13576,7 @@
 # sent_id = test-s663
 # text = Chris Patten, der als Parteivorsitzender maßgeblich am Wahlsieg der britischen ``Tories'' im April dieses Jahres beteiligt war, gilt als erfahrener Politiker.
 1	Chris	Chris	PROPN	NE	Case=Nom|Gender=Masc|Number=Sing	24	nsubj	_	_
-2	Patten	Patte	PROPN	NE	Case=Nom|Gender=Masc|Number=Sing	1	flat	_	SpaceAfter=No
+2	Patten	Patten	PROPN	NE	Case=Nom|Gender=Masc|Number=Sing	1	flat	_	SpaceAfter=No
 3	,	,	PUNCT	$,	_	24	punct	_	_
 4	der	der	PRON	PRELS	Case=Nom|Gender=Masc|Number=Sing|PronType=Rel	21	nsubj	_	_
 5	als	als	ADP	APPR	_	6	case	_	_
@@ -13378,7 +13618,7 @@
 8	,	,	PUNCT	$,	_	6	punct	_	_
 9	man	man	PRON	PIS	Case=Nom|Definite=Ind|Number=Sing|PronType=Ind	15	nsubj	_	_
 10	werde	werden	AUX	VAFIN	Mood=Sub|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	15	aux	_	_
-11	Jelzins	Jelzin	PROPN	NE	Case=Gen|Number=Sing	12	nmod	_	_
+11	Jelzins	Jelzins	PROPN	NE	Case=Gen|Number=Sing	12	nmod	_	_
 12	Aussage	Aussage	NOUN	NN	Case=Acc|Gender=Fem|Number=Sing	15	obj	_	_
 13	``	``	PUNCT	$(	_	15	punct	_	SpaceAfter=No
 14	vorsichtig	vorsichtig	ADV	ADJD	_	15	advmod	_	_
@@ -13546,8 +13786,8 @@
 
 # sent_id = test-s671
 # text = RIO DE JANEIRO, 5. Juli (dpa).
-1	RIO	RIO	PROPN	NE	_	0	root	_	_
-2	DE	DE	PROPN	NE	_	1	flat	_	_
+1	RIO	Rio	PROPN	NE	_	0	root	_	_
+2	DE	de	PROPN	NE	_	1	flat	_	_
 3	JANEIRO	Janeiro	PROPN	NE	Case=Nom|Gender=Neut|Number=Sing	1	flat	_	SpaceAfter=No
 4	,	,	PUNCT	$,	_	1	punct	_	_
 5	5.	5.	NUM	ADJA	Case=Nom|Gender=Masc|Number=Sing	6	amod	_	_
@@ -13842,7 +14082,7 @@
 11	sagte	sagen	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	0	root	_	_
 12	Landesvorsitzender	Landesvorsitzender	NOUN	NN	Case=Nom|Gender=Masc|Number=Sing	11	nsubj	_	_
 13	Steffen	Steffen	PROPN	NE	Case=Nom|Gender=Masc|Number=Sing	12	appos	_	_
-14	Reiche	Reich|Reiche	PROPN	NE	Case=Nom|Gender=Masc|Number=Sing	13	flat	_	_
+14	Reiche	Reiche	PROPN	NE	Case=Nom|Gender=Masc|Number=Sing	13	flat	_	_
 15-16	am	_	_	_	_	_	_	_	_
 15	an	an	ADP	APPR	_	17	case	_	_
 16	dem	der	DET	ART	Case=Dat|Definite=Def|Gender=Masc|Number=Sing|PronType=Art	17	det	_	_
@@ -14159,7 +14399,7 @@
 22	teils	teils	ADV	ADV	_	25	advmod	_	_
 23	von	von	ADP	APPR	_	25	case	_	_
 24	türkischen	türkisch	ADJ	ADJA	Case=Dat|Gender=Masc|Number=Plur	25	amod	_	_
-25	Zyprioten	Zypriote	PROPN	NN	Case=Dat|Gender=Masc|Number=Plur	33	nmod	_	SpaceAfter=No
+25	Zyprioten	Zypriot	PROPN	NN	Case=Dat|Gender=Masc|Number=Plur	33	nmod	_	SpaceAfter=No
 26	,	,	PUNCT	$,	_	33	punct	_	_
 27	teils	teils	ADV	ADV	_	32	advmod	_	_
 28	von	von	ADP	APPR	_	32	case	_	_
@@ -14664,13 +14904,13 @@
 5	6.	6.	NUM	ADJA	Case=Nom|Gender=Masc|Number=Sing	6	amod	_	_
 6	Juli	Juli	PROPN	NN	Case=Nom|Gender=Masc|Number=Sing	1	appos	_	_
 7	(	(	PUNCT	$(	_	8	punct	_	SpaceAfter=No
-8	AP	AP	PROPN	NE	Case=Nom|Number=Sing	1	appos	_	_
+8	AP	ap	PROPN	NE	Case=Nom|Number=Sing	1	appos	_	_
 9	/	/	PUNCT	$(	_	10	punct	_	_
 10	dpa	dpa	PROPN	NE	Case=Nom|Gender=Fem|Number=Sing	8	conj	_	_
 11	/	/	PUNCT	$(	_	12	punct	_	_
 12	Reuter	Reuter	PROPN	NE	Case=Nom|Number=Sing	8	conj	_	_
 13	/	/	PUNCT	$(	_	14	punct	_	_
-14	AFP	AFP	PROPN	NE	Case=Nom|Number=Sing	8	conj	_	SpaceAfter=No
+14	AFP	afp	PROPN	NE	Case=Nom|Number=Sing	8	conj	_	SpaceAfter=No
 15	)	)	PUNCT	$(	_	8	punct	_	SpaceAfter=No
 16	.	.	PUNCT	$.	_	1	punct	_	_
 
@@ -14740,7 +14980,7 @@
 
 # sent_id = test-s731
 # text = BRÜSSEL, 6. Juli (dpa).
-1	BRÜSSEL	BRÜSSEL	PROPN	NE	Case=Nom|Gender=Neut|Number=Sing	0	root	_	SpaceAfter=No
+1	BRÜSSEL	Brüssel	PROPN	NE	Case=Nom|Gender=Neut|Number=Sing	0	root	_	SpaceAfter=No
 2	,	,	PUNCT	$,	_	1	punct	_	_
 3	6.	6.	NUM	ADJA	Case=Nom|Gender=Masc|Number=Sing	4	amod	_	_
 4	Juli	Juli	PROPN	NN	Case=Nom|Gender=Masc|Number=Sing	1	appos	_	_
@@ -14991,7 +15231,7 @@
 4	mehr	mehr	ADV	ADV	_	2	advmod	_	_
 5	an	an	ADP	APPR	_	7	case	_	_
 6	die	der	DET	ART	Case=Acc|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	7	det	_	_
-7	Linke	Linke	PROPN	NN	Case=Acc|Gender=Fem|Number=Sing	2	obl	_	SpaceAfter=No
+7	Linke	linke	PROPN	NN	Case=Acc|Gender=Fem|Number=Sing	2	obl	_	SpaceAfter=No
 8	.	.	PUNCT	$.	_	2	punct	_	_
 
 # sent_id = test-s742
@@ -16340,7 +16580,7 @@
 4	nach	nach	ADP	APPR	_	6	case	_	_
 5	den	der	DET	ART	Case=Dat|Definite=Def|Gender=Neut|Number=Plur|PronType=Art	6	det	_	_
 6	Worten	Wort	NOUN	NN	Case=Dat|Gender=Neut|Number=Plur	18	obl	_	_
-7	Bazins	Bazins	PROPN	NE	Case=Gen|Number=Sing	6	nmod	_	_
+7	Bazins	Bazin	PROPN	NE	Case=Gen|Number=Sing	6	nmod	_	_
 8	in	in	ADP	APPR	_	10	case	_	_
 9	acht	acht	NUM	CARD	NumType=Card	10	nummod	_	_
 10	Monaten	Monat	NOUN	NN	Case=Dat|Gender=Masc|Number=Plur	18	obl	_	_
@@ -16533,8 +16773,8 @@
 
 # sent_id = test-s820
 # text = DEN HAAG, 5. November (dpa).
-1	DEN	d	PROPN	NE	_	0	root	_	_
-2	HAAG	HAAG	PROPN	NE	Case=Nom|Gender=Neut|Number=Sing	1	flat	_	SpaceAfter=No
+1	DEN	Den	PROPN	NE	_	0	root	_	_
+2	HAAG	Haag	PROPN	NE	Case=Nom|Gender=Neut|Number=Sing	1	flat	_	SpaceAfter=No
 3	,	,	PUNCT	$,	_	1	punct	_	_
 4	5.	5.	NUM	ADJA	Case=Acc|Gender=Masc|Number=Sing	5	amod	_	_
 5	November	November	PROPN	NN	Case=Acc|Gender=Masc|Number=Sing	1	appos	_	_
@@ -17518,7 +17758,7 @@
 1	Die	der	DET	ART	Case=Nom|Definite=Def|Gender=Fem|Number=Sing|PronType=Art	2	det	_	_
 2	Polizei	Polizei	NOUN	NN	Case=Nom|Gender=Fem|Number=Sing	3	nsubj	_	_
 3	bezweifelt	bezweifeln	VERB	VVFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	0	root	_	_
-4	Amirs	Amirs	PROPN	NE	Case=Gen|Number=Sing	5	nmod	_	_
+4	Amirs	Amir	PROPN	NE	Case=Gen|Number=Sing	5	nmod	_	_
 5	Mitgliedschaft	Mitgliedschaft	NOUN	NN	Case=Acc|Gender=Fem|Number=Sing	3	obj	_	_
 6	in	in	ADP	APPR	_	8	case	_	_
 7	irgendeiner	irgendein	DET	PIAT	Case=Dat|Definite=Ind|Gender=Fem|Number=Sing|PronType=Ind	8	det	_	_
@@ -17769,7 +18009,7 @@
 14	eine	ein	DET	ART	Case=Acc|Definite=Ind|Gender=Fem|Number=Sing|PronType=Art	16	det	_	_
 15	zweite	zweiter	ADJ	ADJA	Case=Acc|Gender=Fem|Number=Sing	16	amod	_	_
 16	Amtszeit	Amtszeit	NOUN	NN	Case=Acc|Gender=Fem|Number=Sing	6	obl	_	_
-17	Reischs	Reischs	PROPN	NE	Case=Gen|Number=Sing	16	nmod	_	_
+17	Reischs	Reisch	PROPN	NE	Case=Gen|Number=Sing	16	nmod	_	_
 18	aus	aus	ADP	PTKVZ	_	6	compound:prt	_	SpaceAfter=No
 19	.	.	PUNCT	$.	_	6	punct	_	_
 
@@ -18215,7 +18455,7 @@
 
 # sent_id = test-s913
 # text = VAVUNIYA, 6. November (rtr).
-1	VAVUNIYA	VAVUNIYA	PROPN	NE	Case=Nom|Gender=Neut|Number=Sing	0	root	_	SpaceAfter=No
+1	VAVUNIYA	Vavuniya	PROPN	NE	Case=Nom|Gender=Neut|Number=Sing	0	root	_	SpaceAfter=No
 2	,	,	PUNCT	$,	_	1	punct	_	_
 3	6.	6.	NUM	ADJA	Case=Nom|Gender=Masc|Number=Sing	4	amod	_	_
 4	November	November	PROPN	NN	Case=Nom|Gender=Masc|Number=Sing	1	appos	_	_
@@ -18658,7 +18898,7 @@
 31	Antonioni	Antonioni	PROPN	NE	_	28	conj	_	_
 32	inszenierten	inszeniert	ADJ	ADJA	Case=Gen|Gender=Masc|Number=Sing	33	amod	_	_
 33	Films	Film	NOUN	NN	Case=Gen|Gender=Masc|Number=Sing	26	nmod	_	_
-34	Jenseits	Jenseits	PROPN	APPR	_	33	appos	_	_
+34	Jenseits	jenseits	PROPN	APPR	_	33	appos	_	_
 35	der	der	DET	ART	Case=Gen|Definite=Def|Gender=Fem|Number=Plur|PronType=Art	34	compound	_	_
 36	Wolken	Wolke	PROPN	NN	Case=Gen|Gender=Fem|Number=Plur	35	flat	_	_
 37	--	--	PUNCT	$(	_	33	punct	_	_
@@ -18731,8 +18971,8 @@
 51	und	und	CCONJ	KON	_	50	conj	_	_
 52	durch	durch	ADP	ADV	_	51	case	_	_
 53	filmische	filmisch	ADJ	ADJA	Case=Nom|Gender=Fem|Number=Sing	50	fixed	_	_
-54	Musil	Musil	NOUN	NN	Case=Acc|Gender=Fem|Number=Sing	56	compound	_	SpaceAfter=No
-55	-	-	PUNCT	$(	_	56	punct	_	SpaceAfter=No
+54	Musil	Musil	NOUN	NN	Case=Acc|Gender=Fem|Number=Sing	56	compound	_	_
+55	-	-	PUNCT	$(	_	56	punct	_	_
 56	Paraphrase	Paraphrase	NOUN	NN	Case=Acc|Gender=Fem|Number=Sing	18	appos	_	SpaceAfter=No
 57	,	,	PUNCT	$,	_	56	punct	_	_
 58	lyrisch	lyrisch	ADJ	ADJD	_	18	appos	_	SpaceAfter=No
@@ -19016,7 +19256,7 @@
 5	gemessen	messen	ADV	VVPP	VerbForm=Part	12	advmod	_	SpaceAfter=No
 6	,	,	PUNCT	$,	_	12	punct	_	_
 7	ist	sein	AUX	VAFIN	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	12	cop	_	_
-8	Mortiers	Mortiers	PROPN	NE	Case=Gen|Number=Sing	9	nmod	_	_
+8	Mortiers	Mortier	PROPN	NE	Case=Gen|Number=Sing	9	nmod	_	_
 9	Verdienst	Verdienst	NOUN	NN	Case=Nom|Gender=Masc|Number=Sing	12	nsubj	_	_
 10	ohnedies	ohnedies	ADV	ADV	_	12	advmod	_	_
 11	eine	ein	DET	ART	Case=Nom|Definite=Ind|Gender=Fem|Number=Sing|PronType=Art	12	det	_	_


### PR DESCRIPTION
Missing/incorrect tokens at the beginning of Tiger sentences have been added to the corpus. New tokens have been attached to the following word in the sentence with the relation `dep` except for punctuation, which has been attached as `punct`. Since these sentences need to be reannotated, the tokens are marked with the comment `FixTigerDep=Yes`.